### PR TITLE
README: point to both read-only doc and google docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,13 @@ reports from them, and provides a web interface.
 Documentation
 =============
 
-Documentation lives on Google Docs. You can find an index to all the available
-documents here:
+Documentation can be read at:
+
+  https://beancount.github.io/docs/
+
+Documentation authoring happens on Google Docs, where you can contribute by
+requesting acces or commenting on individual documents. An index of all source
+documents is available here:
 
   http://furius.ca/beancount/doc/index
 

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Documentation can be read at:
   https://beancount.github.io/docs/
 
 Documentation authoring happens on Google Docs, where you can contribute by
-requesting acces or commenting on individual documents. An index of all source
+requesting access or commenting on individual documents. An index of all source
 documents is available here:
 
   http://furius.ca/beancount/doc/index


### PR DESCRIPTION
Rationale: most users will need first to find the read-only version of the doc
and will only then considering contributing (via Google Docs). Also, it is
kinda hard at present to find the entry link to the documentation without a
link from here.