### PR TITLE
Catch ValueError exception in fix_payees

### DIFF
--- a/beancount/plugins/fix_payees.py
+++ b/beancount/plugins/fix_payees.py
@@ -71,7 +71,7 @@ def fix_payees(entries, options_map, config):
     if config.strip():
         try:
             expr = ast.literal_eval(config)
-        except SyntaxError:
+        except (SyntaxError, ValueError):
             meta = data.new_metadata(options_map['filename'], 0)
             errors.append(FixPayeesError(meta,
                                          "Syntax error in config: {}".format(config),


### PR DESCRIPTION
Catch the ValueError exception in the fix_payees plugin since
ast.literal_eval can also throw that exception, e.g.:

>>> ast.literal_eval("[() ()]")
...
ValueError: malformed node or string: <_ast.Call object at 0x7f56ad7bfcf8>