### PR TITLE
Fix lint error

### DIFF
--- a/beancount/prices/sources/iex.py
+++ b/beancount/prices/sources/iex.py
@@ -33,7 +33,7 @@ def fetch_quote(ticker):
     results = response.json()
     if len(results) != 1:
         raise IEXError("Invalid number of responses from IEX: {}".format(
-            response.status_code, response.text))
+            response.text))
     result = results[0]
 
     price = D(result['price']).quantize(D('0.01'))


### PR DESCRIPTION
```
beancount/prices/sources/iex.py:35: [E1305(too-many-format-args), fetch_quote] Too many arguments for format string
```