### PR TITLE
Add optional locale to parse numbers.

### DIFF
--- a/beancount/core/number.py
+++ b/beancount/core/number.py
@@ -12,6 +12,7 @@ About Decimal usage:
 __copyright__ = "Copyright (C) 2015-2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
+from babel.numbers import parse_decimal
 import types
 import warnings
 import re
@@ -72,7 +73,7 @@ NUMBER_RE = r"[+-]?\s*[0-9,]*(?:\.[0-9]*)?"
 _CLEAN_NUMBER_RE = re.compile('[, ]')
 
 # pylint: disable=invalid-name
-def D(strord=None):
+def D(strord=None, locale=None):
     """Convert a string into a Decimal object.
 
     This is used in parsing amounts from files in the importers. This is the
@@ -84,6 +85,7 @@ def D(strord=None):
 
     Args:
       strord: A string or Decimal instance.
+      locale: The optional locale to use when parsing strings.
     Returns:
       A Decimal instance.
     """
@@ -92,6 +94,8 @@ def D(strord=None):
         if strord is None or strord == '':
             return Decimal()
         elif isinstance(strord, str):
+            if locale:
+                return parse_decimal(strord, locale=locale)
             return Decimal(_CLEAN_NUMBER_RE.sub('', strord))
         elif isinstance(strord, Decimal):
             return strord

--- a/beancount/core/number.py
+++ b/beancount/core/number.py
@@ -12,7 +12,6 @@ About Decimal usage:
 __copyright__ = "Copyright (C) 2015-2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
-from babel.numbers import parse_decimal
 import types
 import warnings
 import re
@@ -56,6 +55,8 @@ if not is_fast_decimal(decimal):
 
 
 Decimal = decimal.Decimal
+
+from babel.numbers import parse_decimal
 
 # Constants.
 ZERO = Decimal()

--- a/beancount/core/number_test.py
+++ b/beancount/core/number_test.py
@@ -38,6 +38,13 @@ class TestToDecimal(unittest.TestCase):
         self.assertEqual(Decimal(), D(''))
         self.assertEqual(Decimal(), D(None))
 
+    def test_localized_D(self):
+        dec = Decimal('1000.345')
+        self.assertEqual(dec, D('1’000.345', locale='de_CH'))
+        self.assertEqual(dec, D('1.000,345', locale='de_DE'))
+        self.assertEqual(dec, D('1,000.345', locale='en_US'))
+        self.assertEqual(dec, D('1\u202f000.345', locale='fr_CH'))
+
     def test_round_to(self):
         self.assertEqual(D('135.12'), number.round_to(D('135.12345'), D('0.01')))
         self.assertEqual(D('135.12'), number.round_to(D('135.12987'), D('0.01')))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 python-dateutil>=2.6.0
+babel>=2.8.0
 bottle>=0.12
 ply>=3.4
 lxml>=3.0

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,10 @@ else:
             # against it.
             'chardet',
 
+            # This library is needed to provide locale support for the
+            # number parsing.
+            'babel',
+
             # This library is used to download and convert the documentation
             # programmatically and to upload lists of holdings to a Google
             # Spreadsheet for live intra-day monitoring.


### PR DESCRIPTION
Useful when parsing localized CSV files with different number grouping
and decimal points.  Can be adjusted by manually importing `babel`:

    from babel import Locale
    Locale("de_CH").number_symbols["group"] = "'"  # For ASCII imports, default is UTF-8 quote

in importers.

Also works better than setting `LC_NUMERIC` via the `locale` module (see
warnings there).