### PR TITLE
Parser rework

### DIFF
--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -66,12 +66,9 @@
 
 
 /* First part of user prologue.  */
-#line 11 "beancount/parser/grammar.y"
+#line 49 "beancount/parser/grammar.y"
 
 
-#include <stdio.h>
-#include <assert.h>
-#include "parser.h"
 #include "grammar.h"
 #include "lexer.h"
 
@@ -82,19 +79,19 @@ extern YY_DECL;
  * in the handler. Always run the code to clean the references provided by the
  * reduced rule. {05bb0fb60e86}
  */
-#define BUILD(clean, target, method_name, format, ...)                          \
+#define BUILD(clean, target, method_name, format, ...)                  \
     target = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);    \
-    clean;                                                                      \
-    if (target == NULL) {                                                       \
-        build_grammar_error_from_exception(scanner, parser, builder);           \
-        YYERROR;                                                                \
+    clean;                                                              \
+    if (target == NULL) {                                               \
+        build_grammar_error_from_exception(builder, yyloc);             \
+        YYERROR;                                                        \
     }
 
-#define FILENAME ((Parser*)parser)->filename
-#define LINENO ((yyloc).first_line + ((Parser*)parser)->line)
+#define FILENAME (yyloc).file_name
+#define LINENO (yyloc).first_line
 
 /* Build a grammar error from the exception context. */
-void build_grammar_error_from_exception(yyscan_t scanner, PyObject* parser, PyObject* builder)
+void build_grammar_error_from_exception(PyObject* builder, YYLTYPE yyloc)
 {
     PyObject* traceback = NULL;
     PyObject* value = NULL;
@@ -113,8 +110,7 @@ void build_grammar_error_from_exception(yyscan_t scanner, PyObject* parser, PyOb
 
         /* Build and accumulate a new error object. {27d1d459c5cd} */
         rv = PyObject_CallMethod(builder, "build_grammar_error", "OiOOO",
-                                 ((Parser*)parser)->filename,
-                                 yyget_lineno(scanner) + ((Parser*)parser)->line,
+                                 yyloc.file_name, yyloc.first_line,
                                  value, type, traceback);
     } else {
         PyErr_SetString(PyExc_RuntimeError, "No exception");
@@ -127,7 +123,7 @@ void build_grammar_error_from_exception(yyscan_t scanner, PyObject* parser, PyOb
 }
 
 /* Error-handling function. {ca6aab8b9748} */
-void yyerror(YYLTYPE *locp, yyscan_t scanner, PyObject* parser, PyObject* builder, char const* message)
+void yyerror(YYLTYPE *locp, yyscan_t scanner, PyObject* builder, char const* message)
 {
     PyObject* rv = NULL;
 
@@ -137,8 +133,7 @@ void yyerror(YYLTYPE *locp, yyscan_t scanner, PyObject* parser, PyObject* builde
 
     /* Register a syntax error with the builder. */
     rv = PyObject_CallMethod(builder, "build_grammar_error", "Ois",
-                             ((Parser*)parser)->filename,
-                             yyget_lineno(scanner) + ((Parser*)parser)->line,
+                             locp[0].file_name, locp[0].first_line,
                              message);
 
     Py_XDECREF(rv);
@@ -157,7 +152,7 @@ const char* getTokenName(int token);
 #define DECREF6(x1, x2, x3, x4, x5, x6)    DECREF5(x1, x2, x3, x4, x5); Py_DECREF(x6);
 
 
-#line 161 "beancount/parser/grammar.c"
+#line 156 "beancount/parser/grammar.c"
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus
@@ -190,6 +185,45 @@ const char* getTokenName(int token);
 #if YYDEBUG
 extern int yydebug;
 #endif
+/* "%code requires" blocks.  */
+#line 12 "beancount/parser/grammar.y"
+
+
+#include <stdio.h>
+#include <assert.h>
+#include "parser.h"
+
+/* Extend default location type with file name information. */
+typedef struct YYLTYPE {
+    int first_line;
+    int first_column;
+    int last_line;
+    int last_column;
+    PyObject* file_name;
+} YYLTYPE;
+
+#define YYLTYPE_IS_DECLARED 1
+
+/* Extend defult location action to copy file name over. */
+#define YYLLOC_DEFAULT(current, rhs, N)                                 \
+    do {                                                                \
+        if (N) {                                                        \
+            (current).first_line   = YYRHSLOC(rhs, 1).first_line;       \
+            (current).first_column = YYRHSLOC(rhs, 1).first_column;     \
+            (current).last_line    = YYRHSLOC(rhs, N).last_line;        \
+            (current).last_column  = YYRHSLOC(rhs, N).last_column;      \
+            (current).file_name    = YYRHSLOC(rhs, N).file_name;        \
+        } else {                                                        \
+            (current).first_line   = (current).last_line =              \
+                YYRHSLOC(rhs, 0).last_line;                             \
+            (current).first_column = (current).last_column =            \
+                YYRHSLOC(rhs, 0).last_column;                           \
+            (current).file_name    = YYRHSLOC(rhs, 0).file_name;        \
+        }                                                               \
+    } while (0)
+
+
+#line 227 "beancount/parser/grammar.c"
 
 /* Token type.  */
 #ifndef YYTOKENTYPE
@@ -257,7 +291,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 117 "beancount/parser/grammar.y"
+#line 149 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -267,7 +301,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 271 "beancount/parser/grammar.c"
+#line 305 "beancount/parser/grammar.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -291,7 +325,7 @@ struct YYLTYPE
 
 
 
-int yyparse (yyscan_t scanner, PyObject* parser, PyObject* builder);
+int yyparse (yyscan_t scanner, PyObject* builder);
 
 #endif /* !YY_YY_BEANCOUNT_PARSER_GRAMMAR_H_INCLUDED  */
 
@@ -593,20 +627,20 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   251,   251,   254,   258,   262,   266,   271,   272,   276,
-     277,   278,   279,   285,   289,   294,   299,   304,   309,   314,
-     318,   323,   328,   333,   340,   348,   353,   359,   365,   369,
-     373,   377,   379,   384,   389,   394,   399,   405,   411,   416,
-     417,   418,   419,   420,   421,   422,   423,   424,   428,   434,
-     439,   443,   448,   453,   459,   464,   470,   475,   480,   486,
-     492,   498,   507,   513,   520,   524,   530,   536,   542,   548,
-     554,   560,   568,   575,   580,   585,   590,   595,   600,   605,
-     612,   618,   623,   628,   634,   639,   644,   650,   654,   658,
-     662,   669,   675,   681,   687,   693,   695,   702,   707,   712,
-     717,   722,   727,   737,   742,   748,   755,   756,   757,   758,
-     759,   760,   761,   762,   763,   764,   765,   766,   771,   777,
-     783,   788,   794,   795,   796,   797,   798,   799,   800,   801,
-     804,   808,   813,   831,   838
+       0,   283,   283,   286,   290,   294,   298,   303,   304,   308,
+     309,   310,   311,   317,   321,   326,   331,   336,   341,   346,
+     350,   355,   360,   365,   372,   380,   385,   391,   397,   401,
+     405,   409,   411,   416,   421,   426,   431,   437,   443,   448,
+     449,   450,   451,   452,   453,   454,   455,   456,   460,   466,
+     471,   475,   480,   485,   491,   496,   502,   507,   512,   518,
+     524,   530,   539,   545,   552,   556,   562,   568,   574,   580,
+     586,   592,   600,   607,   612,   617,   622,   627,   632,   637,
+     644,   650,   655,   660,   666,   671,   676,   682,   686,   690,
+     694,   701,   707,   713,   719,   725,   727,   734,   739,   744,
+     749,   754,   759,   769,   774,   780,   787,   788,   789,   790,
+     791,   792,   793,   794,   795,   796,   797,   798,   803,   809,
+     815,   820,   826,   827,   828,   829,   830,   831,   832,   833,
+     836,   840,   845,   863,   870
 };
 #endif
 
@@ -901,7 +935,7 @@ static const yytype_uint8 yyr2[] =
       }                                                           \
     else                                                          \
       {                                                           \
-        yyerror (&yylloc, scanner, parser, builder, YY_("syntax error: cannot back up")); \
+        yyerror (&yylloc, scanner, builder, YY_("syntax error: cannot back up")); \
         YYERROR;                                                  \
       }                                                           \
   while (0)
@@ -1003,7 +1037,7 @@ do {                                                                      \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value, Location, scanner, parser, builder); \
+                  Type, Value, Location, scanner, builder); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -1014,13 +1048,12 @@ do {                                                                      \
 `-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner, PyObject* parser, PyObject* builder)
+yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner, PyObject* builder)
 {
   FILE *yyoutput = yyo;
   YYUSE (yyoutput);
   YYUSE (yylocationp);
   YYUSE (scanner);
-  YYUSE (parser);
   YYUSE (builder);
   if (!yyvaluep)
     return;
@@ -1039,14 +1072,14 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YY
 `---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner, PyObject* parser, PyObject* builder)
+yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner, PyObject* builder)
 {
   YYFPRINTF (yyo, "%s %s (",
              yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
   YY_LOCATION_PRINT (yyo, *yylocationp);
   YYFPRINTF (yyo, ": ");
-  yy_symbol_value_print (yyo, yytype, yyvaluep, yylocationp, scanner, parser, builder);
+  yy_symbol_value_print (yyo, yytype, yyvaluep, yylocationp, scanner, builder);
   YYFPRINTF (yyo, ")");
 }
 
@@ -1079,7 +1112,7 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, yyscan_t scanner, PyObject* parser, PyObject* builder)
+yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, yyscan_t scanner, PyObject* builder)
 {
   unsigned long yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -1093,7 +1126,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule
       yy_symbol_print (stderr,
                        yystos[yyssp[yyi + 1 - yynrhs]],
                        &yyvsp[(yyi + 1) - (yynrhs)]
-                       , &(yylsp[(yyi + 1) - (yynrhs)])                       , scanner, parser, builder);
+                       , &(yylsp[(yyi + 1) - (yynrhs)])                       , scanner, builder);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -1101,7 +1134,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule
 # define YY_REDUCE_PRINT(Rule)          \
 do {                                    \
   if (yydebug)                          \
-    yy_reduce_print (yyssp, yyvsp, yylsp, Rule, scanner, parser, builder); \
+    yy_reduce_print (yyssp, yyvsp, yylsp, Rule, scanner, builder); \
 } while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
@@ -1364,12 +1397,11 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, yyscan_t scanner, PyObject* parser, PyObject* builder)
+yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, yyscan_t scanner, PyObject* builder)
 {
   YYUSE (yyvaluep);
   YYUSE (yylocationp);
   YYUSE (scanner);
-  YYUSE (parser);
   YYUSE (builder);
   if (!yymsg)
     yymsg = "Deleting";
@@ -1388,7 +1420,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
 `----------*/
 
 int
-yyparse (yyscan_t scanner, PyObject* parser, PyObject* builder)
+yyparse (yyscan_t scanner, PyObject* builder)
 {
 /* The lookahead symbol.  */
 int yychar;
@@ -1586,7 +1618,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = yylex (&yylval, &yylloc, scanner, parser, builder);
+      yychar = yylex (&yylval, &yylloc, scanner, builder);
     }
 
   if (yychar <= YYEOF)
@@ -1667,136 +1699,136 @@ yyreduce:
   switch (yyn)
     {
   case 3:
-#line 255 "beancount/parser/grammar.y"
+#line 287 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1675 "beancount/parser/grammar.c"
-    break;
-
-  case 4:
-#line 259 "beancount/parser/grammar.y"
-    {
-        (yyval.character) = (yyvsp[0].character);
-    }
-#line 1683 "beancount/parser/grammar.c"
-    break;
-
-  case 5:
-#line 263 "beancount/parser/grammar.y"
-    {
-        (yyval.character) = '*';
-    }
-#line 1691 "beancount/parser/grammar.c"
-    break;
-
-  case 6:
-#line 267 "beancount/parser/grammar.y"
-    {
-        (yyval.character) = '#';
-    }
-#line 1699 "beancount/parser/grammar.c"
-    break;
-
-  case 13:
-#line 286 "beancount/parser/grammar.y"
-    {
-                (yyval.pyobj) = (yyvsp[0].pyobj);
-            }
 #line 1707 "beancount/parser/grammar.c"
     break;
 
+  case 4:
+#line 291 "beancount/parser/grammar.y"
+    {
+        (yyval.character) = (yyvsp[0].character);
+    }
+#line 1715 "beancount/parser/grammar.c"
+    break;
+
+  case 5:
+#line 295 "beancount/parser/grammar.y"
+    {
+        (yyval.character) = '*';
+    }
+#line 1723 "beancount/parser/grammar.c"
+    break;
+
+  case 6:
+#line 299 "beancount/parser/grammar.y"
+    {
+        (yyval.character) = '#';
+    }
+#line 1731 "beancount/parser/grammar.c"
+    break;
+
+  case 13:
+#line 318 "beancount/parser/grammar.y"
+    {
+                (yyval.pyobj) = (yyvsp[0].pyobj);
+            }
+#line 1739 "beancount/parser/grammar.c"
+    break;
+
   case 14:
-#line 290 "beancount/parser/grammar.y"
+#line 322 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Add((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1716 "beancount/parser/grammar.c"
+#line 1748 "beancount/parser/grammar.c"
     break;
 
   case 15:
-#line 295 "beancount/parser/grammar.y"
+#line 327 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Subtract((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1725 "beancount/parser/grammar.c"
+#line 1757 "beancount/parser/grammar.c"
     break;
 
   case 16:
-#line 300 "beancount/parser/grammar.y"
+#line 332 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Multiply((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1734 "beancount/parser/grammar.c"
+#line 1766 "beancount/parser/grammar.c"
     break;
 
   case 17:
-#line 305 "beancount/parser/grammar.y"
+#line 337 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_TrueDivide((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1743 "beancount/parser/grammar.c"
+#line 1775 "beancount/parser/grammar.c"
     break;
 
   case 18:
-#line 310 "beancount/parser/grammar.y"
+#line 342 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Negative((yyvsp[0].pyobj));
                 DECREF1((yyvsp[0].pyobj));
             }
-#line 1752 "beancount/parser/grammar.c"
+#line 1784 "beancount/parser/grammar.c"
     break;
 
   case 19:
-#line 315 "beancount/parser/grammar.y"
+#line 347 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1760 "beancount/parser/grammar.c"
+#line 1792 "beancount/parser/grammar.c"
     break;
 
   case 20:
-#line 319 "beancount/parser/grammar.y"
+#line 351 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1768 "beancount/parser/grammar.c"
+#line 1800 "beancount/parser/grammar.c"
     break;
 
   case 21:
-#line 324 "beancount/parser/grammar.y"
+#line 356 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 1777 "beancount/parser/grammar.c"
+#line 1809 "beancount/parser/grammar.c"
     break;
 
   case 22:
-#line 329 "beancount/parser/grammar.y"
+#line 361 "beancount/parser/grammar.y"
     {
                 BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
             }
-#line 1786 "beancount/parser/grammar.c"
+#line 1818 "beancount/parser/grammar.c"
     break;
 
   case 23:
-#line 334 "beancount/parser/grammar.y"
+#line 366 "beancount/parser/grammar.y"
     {
                 BUILD(,
                        (yyval.pyobj), "pipe_deprecated_error", "Oi", FILENAME, LINENO);
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1796 "beancount/parser/grammar.c"
+#line 1828 "beancount/parser/grammar.c"
     break;
 
   case 24:
-#line 341 "beancount/parser/grammar.y"
+#line 373 "beancount/parser/grammar.y"
     {
                /* Note: We're passing a bogus value here in order to avoid
                 * having to declare a second macro just for this one special
@@ -1804,247 +1836,247 @@ yyreduce:
                BUILD(,
                       (yyval.pyobj), "tag_link_new", "O", Py_None);
            }
-#line 1808 "beancount/parser/grammar.c"
+#line 1840 "beancount/parser/grammar.c"
     break;
 
   case 25:
-#line 349 "beancount/parser/grammar.y"
+#line 381 "beancount/parser/grammar.y"
     {
                BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1817 "beancount/parser/grammar.c"
+#line 1849 "beancount/parser/grammar.c"
     break;
 
   case 26:
-#line 354 "beancount/parser/grammar.y"
+#line 386 "beancount/parser/grammar.y"
     {
                BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1826 "beancount/parser/grammar.c"
+#line 1858 "beancount/parser/grammar.c"
     break;
 
   case 27:
-#line 360 "beancount/parser/grammar.y"
+#line 392 "beancount/parser/grammar.y"
     {
                 BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "transaction", "OiObOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1835 "beancount/parser/grammar.c"
-    break;
-
-  case 28:
-#line 366 "beancount/parser/grammar.y"
-    {
-            (yyval.character) = '\0';
-        }
-#line 1843 "beancount/parser/grammar.c"
-    break;
-
-  case 29:
-#line 370 "beancount/parser/grammar.y"
-    {
-            (yyval.character) = '*';
-        }
-#line 1851 "beancount/parser/grammar.c"
-    break;
-
-  case 30:
-#line 374 "beancount/parser/grammar.y"
-    {
-            (yyval.character) = '#';
-        }
-#line 1859 "beancount/parser/grammar.c"
-    break;
-
-  case 32:
-#line 380 "beancount/parser/grammar.y"
-    {
-                     (yyval.pyobj) = (yyvsp[0].pyobj);
-                 }
 #line 1867 "beancount/parser/grammar.c"
     break;
 
+  case 28:
+#line 398 "beancount/parser/grammar.y"
+    {
+            (yyval.character) = '\0';
+        }
+#line 1875 "beancount/parser/grammar.c"
+    break;
+
+  case 29:
+#line 402 "beancount/parser/grammar.y"
+    {
+            (yyval.character) = '*';
+        }
+#line 1883 "beancount/parser/grammar.c"
+    break;
+
+  case 30:
+#line 406 "beancount/parser/grammar.y"
+    {
+            (yyval.character) = '#';
+        }
+#line 1891 "beancount/parser/grammar.c"
+    break;
+
+  case 32:
+#line 412 "beancount/parser/grammar.y"
+    {
+                     (yyval.pyobj) = (yyvsp[0].pyobj);
+                 }
+#line 1899 "beancount/parser/grammar.c"
+    break;
+
   case 33:
-#line 385 "beancount/parser/grammar.y"
+#line 417 "beancount/parser/grammar.y"
     {
             BUILD(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
         }
-#line 1876 "beancount/parser/grammar.c"
+#line 1908 "beancount/parser/grammar.c"
     break;
 
   case 34:
-#line 390 "beancount/parser/grammar.y"
+#line 422 "beancount/parser/grammar.y"
     {
             BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
         }
-#line 1885 "beancount/parser/grammar.c"
+#line 1917 "beancount/parser/grammar.c"
     break;
 
   case 35:
-#line 395 "beancount/parser/grammar.y"
+#line 427 "beancount/parser/grammar.y"
     {
             BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
         }
-#line 1894 "beancount/parser/grammar.c"
+#line 1926 "beancount/parser/grammar.c"
     break;
 
   case 36:
-#line 400 "beancount/parser/grammar.y"
+#line 432 "beancount/parser/grammar.y"
     {
             BUILD(DECREF1((yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-1].pyobj), missing, Py_None, Py_None, Py_False, (yyvsp[-2].character));
         }
-#line 1903 "beancount/parser/grammar.c"
+#line 1935 "beancount/parser/grammar.c"
     break;
 
   case 37:
-#line 406 "beancount/parser/grammar.y"
+#line 438 "beancount/parser/grammar.y"
     {
               BUILD(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
           }
-#line 1912 "beancount/parser/grammar.c"
+#line 1944 "beancount/parser/grammar.c"
     break;
 
   case 38:
-#line 412 "beancount/parser/grammar.y"
+#line 444 "beancount/parser/grammar.y"
     {
                    (yyval.pyobj) = (yyvsp[-1].pyobj);
                }
-#line 1920 "beancount/parser/grammar.c"
+#line 1952 "beancount/parser/grammar.c"
     break;
 
   case 47:
-#line 425 "beancount/parser/grammar.y"
+#line 457 "beancount/parser/grammar.y"
     {
                     (yyval.pyobj) = (yyvsp[0].pyobj);
                 }
-#line 1928 "beancount/parser/grammar.c"
+#line 1960 "beancount/parser/grammar.c"
     break;
 
   case 48:
-#line 429 "beancount/parser/grammar.y"
+#line 461 "beancount/parser/grammar.y"
     {
                     Py_INCREF(Py_None);
                     (yyval.pyobj) = Py_None;
                 }
-#line 1937 "beancount/parser/grammar.c"
+#line 1969 "beancount/parser/grammar.c"
     break;
 
   case 49:
-#line 435 "beancount/parser/grammar.y"
+#line 467 "beancount/parser/grammar.y"
     {
                        Py_INCREF(Py_None);
                        (yyval.pyobj) = Py_None;
                    }
-#line 1946 "beancount/parser/grammar.c"
+#line 1978 "beancount/parser/grammar.c"
     break;
 
   case 50:
-#line 440 "beancount/parser/grammar.y"
+#line 472 "beancount/parser/grammar.y"
     {
                        (yyval.pyobj) = (yyvsp[-3].pyobj);
                    }
-#line 1954 "beancount/parser/grammar.c"
+#line 1986 "beancount/parser/grammar.c"
     break;
 
   case 51:
-#line 444 "beancount/parser/grammar.y"
+#line 476 "beancount/parser/grammar.y"
     {
                        BUILD(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
                    }
-#line 1963 "beancount/parser/grammar.c"
+#line 1995 "beancount/parser/grammar.c"
     break;
 
   case 52:
-#line 449 "beancount/parser/grammar.y"
+#line 481 "beancount/parser/grammar.y"
     {
                        BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 1972 "beancount/parser/grammar.c"
+#line 2004 "beancount/parser/grammar.c"
     break;
 
   case 53:
-#line 454 "beancount/parser/grammar.y"
+#line 486 "beancount/parser/grammar.y"
     {
                        BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 1981 "beancount/parser/grammar.c"
+#line 2013 "beancount/parser/grammar.c"
     break;
 
   case 54:
-#line 460 "beancount/parser/grammar.y"
+#line 492 "beancount/parser/grammar.y"
     {
                    Py_INCREF(Py_None);
                    (yyval.pyobj) = Py_None;
                }
-#line 1990 "beancount/parser/grammar.c"
+#line 2022 "beancount/parser/grammar.c"
     break;
 
   case 55:
-#line 465 "beancount/parser/grammar.y"
+#line 497 "beancount/parser/grammar.y"
     {
                    BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                }
-#line 1999 "beancount/parser/grammar.c"
+#line 2031 "beancount/parser/grammar.c"
     break;
 
   case 56:
-#line 471 "beancount/parser/grammar.y"
+#line 503 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
               }
-#line 2008 "beancount/parser/grammar.c"
+#line 2040 "beancount/parser/grammar.c"
     break;
 
   case 57:
-#line 476 "beancount/parser/grammar.y"
+#line 508 "beancount/parser/grammar.y"
     {
                   BUILD(DECREF1((yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
               }
-#line 2017 "beancount/parser/grammar.c"
+#line 2049 "beancount/parser/grammar.c"
     break;
 
   case 58:
-#line 481 "beancount/parser/grammar.y"
+#line 513 "beancount/parser/grammar.y"
     {
                   BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
               }
-#line 2026 "beancount/parser/grammar.c"
+#line 2058 "beancount/parser/grammar.c"
     break;
 
   case 59:
-#line 487 "beancount/parser/grammar.y"
+#line 519 "beancount/parser/grammar.y"
     {
              BUILD(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
          }
-#line 2035 "beancount/parser/grammar.c"
+#line 2067 "beancount/parser/grammar.c"
     break;
 
   case 60:
-#line 493 "beancount/parser/grammar.y"
+#line 525 "beancount/parser/grammar.y"
     {
            BUILD(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
        }
-#line 2044 "beancount/parser/grammar.c"
+#line 2076 "beancount/parser/grammar.c"
     break;
 
   case 61:
-#line 499 "beancount/parser/grammar.y"
+#line 531 "beancount/parser/grammar.y"
     {
              /* Note: key_value is a tuple, Py_BuildValue() won't wrap it up
               * within a tuple, so expand in the method (it receives two
@@ -2052,92 +2084,92 @@ yyreduce:
              BUILD(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
          }
-#line 2056 "beancount/parser/grammar.c"
+#line 2088 "beancount/parser/grammar.c"
     break;
 
   case 62:
-#line 508 "beancount/parser/grammar.y"
+#line 540 "beancount/parser/grammar.y"
     {
             BUILD(DECREF1((yyvsp[-2].pyobj)),
                    (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
         }
-#line 2065 "beancount/parser/grammar.c"
+#line 2097 "beancount/parser/grammar.c"
     break;
 
   case 63:
-#line 514 "beancount/parser/grammar.y"
+#line 546 "beancount/parser/grammar.y"
     {
          BUILD(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                 (yyval.pyobj), "open", "OiOOOOO", FILENAME, LINENO, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          ;
      }
-#line 2075 "beancount/parser/grammar.c"
+#line 2107 "beancount/parser/grammar.c"
     break;
 
   case 64:
-#line 521 "beancount/parser/grammar.y"
+#line 553 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2083 "beancount/parser/grammar.c"
+#line 2115 "beancount/parser/grammar.c"
     break;
 
   case 65:
-#line 525 "beancount/parser/grammar.y"
+#line 557 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2092 "beancount/parser/grammar.c"
+#line 2124 "beancount/parser/grammar.c"
     break;
 
   case 66:
-#line 531 "beancount/parser/grammar.y"
+#line 563 "beancount/parser/grammar.y"
     {
           BUILD(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "close", "OiOOO", FILENAME, LINENO, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2101 "beancount/parser/grammar.c"
+#line 2133 "beancount/parser/grammar.c"
     break;
 
   case 67:
-#line 537 "beancount/parser/grammar.y"
+#line 569 "beancount/parser/grammar.y"
     {
               BUILD(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "commodity", "OiOOO", FILENAME, LINENO, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
           }
-#line 2110 "beancount/parser/grammar.c"
+#line 2142 "beancount/parser/grammar.c"
     break;
 
   case 68:
-#line 543 "beancount/parser/grammar.y"
+#line 575 "beancount/parser/grammar.y"
     {
         BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "pad", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
     }
-#line 2119 "beancount/parser/grammar.c"
+#line 2151 "beancount/parser/grammar.c"
     break;
 
   case 69:
-#line 549 "beancount/parser/grammar.y"
+#line 581 "beancount/parser/grammar.y"
     {
             BUILD(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
                    (yyval.pyobj), "balance", "OiOOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
         }
-#line 2128 "beancount/parser/grammar.c"
+#line 2160 "beancount/parser/grammar.c"
     break;
 
   case 70:
-#line 555 "beancount/parser/grammar.y"
+#line 587 "beancount/parser/grammar.y"
     {
            BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
        }
-#line 2137 "beancount/parser/grammar.c"
+#line 2169 "beancount/parser/grammar.c"
     break;
 
   case 71:
-#line 561 "beancount/parser/grammar.y"
+#line 593 "beancount/parser/grammar.y"
     {
                      BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
@@ -2145,269 +2177,269 @@ yyreduce:
                      Py_INCREF(Py_None);
                      ;
                  }
-#line 2149 "beancount/parser/grammar.c"
+#line 2181 "beancount/parser/grammar.c"
     break;
 
   case 72:
-#line 569 "beancount/parser/grammar.y"
+#line 601 "beancount/parser/grammar.y"
     {
                      BUILD(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = (yyvsp[-1].pyobj);
                  }
-#line 2159 "beancount/parser/grammar.c"
+#line 2191 "beancount/parser/grammar.c"
     break;
 
   case 73:
-#line 576 "beancount/parser/grammar.y"
+#line 608 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing);
                  (yyval.pyobj) = missing;
              }
-#line 2168 "beancount/parser/grammar.c"
+#line 2200 "beancount/parser/grammar.c"
     break;
 
   case 74:
-#line 581 "beancount/parser/grammar.y"
+#line 613 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2176 "beancount/parser/grammar.c"
+#line 2208 "beancount/parser/grammar.c"
     break;
 
   case 75:
-#line 586 "beancount/parser/grammar.y"
+#line 618 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing);
                  (yyval.pyobj) = missing;
              }
-#line 2185 "beancount/parser/grammar.c"
+#line 2217 "beancount/parser/grammar.c"
     break;
 
   case 76:
-#line 591 "beancount/parser/grammar.y"
+#line 623 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2193 "beancount/parser/grammar.c"
+#line 2225 "beancount/parser/grammar.c"
     break;
 
   case 77:
-#line 596 "beancount/parser/grammar.y"
+#line 628 "beancount/parser/grammar.y"
     {
                     BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2202 "beancount/parser/grammar.c"
+#line 2234 "beancount/parser/grammar.c"
     break;
 
   case 78:
-#line 601 "beancount/parser/grammar.y"
+#line 633 "beancount/parser/grammar.y"
     {
                     BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2211 "beancount/parser/grammar.c"
+#line 2243 "beancount/parser/grammar.c"
     break;
 
   case 79:
-#line 606 "beancount/parser/grammar.y"
+#line 638 "beancount/parser/grammar.y"
     {
                     BUILD(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                     ;
                 }
-#line 2221 "beancount/parser/grammar.c"
+#line 2253 "beancount/parser/grammar.c"
     break;
 
   case 80:
-#line 613 "beancount/parser/grammar.y"
+#line 645 "beancount/parser/grammar.y"
     {
                       BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                  }
-#line 2230 "beancount/parser/grammar.c"
+#line 2262 "beancount/parser/grammar.c"
     break;
 
   case 81:
-#line 619 "beancount/parser/grammar.y"
+#line 651 "beancount/parser/grammar.y"
     {
               BUILD(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
           }
-#line 2239 "beancount/parser/grammar.c"
+#line 2271 "beancount/parser/grammar.c"
     break;
 
   case 82:
-#line 624 "beancount/parser/grammar.y"
+#line 656 "beancount/parser/grammar.y"
     {
               BUILD(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
           }
-#line 2248 "beancount/parser/grammar.c"
+#line 2280 "beancount/parser/grammar.c"
     break;
 
   case 83:
-#line 629 "beancount/parser/grammar.y"
+#line 661 "beancount/parser/grammar.y"
     {
               Py_INCREF(Py_None);
               (yyval.pyobj) = Py_None;
           }
-#line 2257 "beancount/parser/grammar.c"
+#line 2289 "beancount/parser/grammar.c"
     break;
 
   case 84:
-#line 635 "beancount/parser/grammar.y"
+#line 667 "beancount/parser/grammar.y"
     {
                    /* We indicate that there was a cost if there */
                    (yyval.pyobj) = PyList_New(0);
                }
-#line 2266 "beancount/parser/grammar.c"
+#line 2298 "beancount/parser/grammar.c"
     break;
 
   case 85:
-#line 640 "beancount/parser/grammar.y"
+#line 672 "beancount/parser/grammar.y"
     {
                    BUILD(DECREF1((yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
                }
-#line 2275 "beancount/parser/grammar.c"
+#line 2307 "beancount/parser/grammar.c"
     break;
 
   case 86:
-#line 645 "beancount/parser/grammar.y"
+#line 677 "beancount/parser/grammar.y"
     {
                    BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                }
-#line 2284 "beancount/parser/grammar.c"
+#line 2316 "beancount/parser/grammar.c"
     break;
 
   case 87:
-#line 651 "beancount/parser/grammar.y"
+#line 683 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2292 "beancount/parser/grammar.c"
+#line 2324 "beancount/parser/grammar.c"
     break;
 
   case 88:
-#line 655 "beancount/parser/grammar.y"
+#line 687 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2300 "beancount/parser/grammar.c"
+#line 2332 "beancount/parser/grammar.c"
     break;
 
   case 89:
-#line 659 "beancount/parser/grammar.y"
+#line 691 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2308 "beancount/parser/grammar.c"
+#line 2340 "beancount/parser/grammar.c"
     break;
 
   case 90:
-#line 663 "beancount/parser/grammar.y"
+#line 695 "beancount/parser/grammar.y"
     {
               BUILD(,
                      (yyval.pyobj), "cost_merge", "O", Py_None);
           }
-#line 2317 "beancount/parser/grammar.c"
+#line 2349 "beancount/parser/grammar.c"
     break;
 
   case 91:
-#line 670 "beancount/parser/grammar.y"
+#line 702 "beancount/parser/grammar.y"
     {
           BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "price", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2326 "beancount/parser/grammar.c"
+#line 2358 "beancount/parser/grammar.c"
     break;
 
   case 92:
-#line 676 "beancount/parser/grammar.y"
+#line 708 "beancount/parser/grammar.y"
     {
           BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "event", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2335 "beancount/parser/grammar.c"
+#line 2367 "beancount/parser/grammar.c"
     break;
 
   case 93:
-#line 682 "beancount/parser/grammar.y"
+#line 714 "beancount/parser/grammar.y"
     {
              BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "query", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2344 "beancount/parser/grammar.c"
+#line 2376 "beancount/parser/grammar.c"
     break;
 
   case 94:
-#line 688 "beancount/parser/grammar.y"
+#line 720 "beancount/parser/grammar.y"
     {
           BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "note", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2353 "beancount/parser/grammar.c"
+#line 2385 "beancount/parser/grammar.c"
     break;
 
   case 96:
-#line 696 "beancount/parser/grammar.y"
+#line 728 "beancount/parser/grammar.y"
     {
              BUILD(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "document", "OiOOOOO", FILENAME, LINENO, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2362 "beancount/parser/grammar.c"
+#line 2394 "beancount/parser/grammar.c"
     break;
 
   case 97:
-#line 703 "beancount/parser/grammar.y"
+#line 735 "beancount/parser/grammar.y"
     {
                  BUILD(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2371 "beancount/parser/grammar.c"
+#line 2403 "beancount/parser/grammar.c"
     break;
 
   case 98:
-#line 708 "beancount/parser/grammar.y"
+#line 740 "beancount/parser/grammar.y"
     {
                  BUILD(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2380 "beancount/parser/grammar.c"
+#line 2412 "beancount/parser/grammar.c"
     break;
 
   case 99:
-#line 713 "beancount/parser/grammar.y"
+#line 745 "beancount/parser/grammar.y"
     {
                  BUILD(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2389 "beancount/parser/grammar.c"
+#line 2421 "beancount/parser/grammar.c"
     break;
 
   case 100:
-#line 718 "beancount/parser/grammar.y"
+#line 750 "beancount/parser/grammar.y"
     {
                  BUILD(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2398 "beancount/parser/grammar.c"
+#line 2430 "beancount/parser/grammar.c"
     break;
 
   case 101:
-#line 723 "beancount/parser/grammar.y"
+#line 755 "beancount/parser/grammar.y"
     {
                  BUILD(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2407 "beancount/parser/grammar.c"
+#line 2439 "beancount/parser/grammar.c"
     break;
 
   case 102:
-#line 728 "beancount/parser/grammar.y"
+#line 760 "beancount/parser/grammar.y"
     {
                  /* Obtain beancount.core.account.TYPE */
                  PyObject* module = PyImport_ImportModule("beancount.core.account");
@@ -2416,99 +2448,99 @@ yyreduce:
                  BUILD(DECREF2((yyvsp[0].pyobj), dtype),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
              }
-#line 2420 "beancount/parser/grammar.c"
+#line 2452 "beancount/parser/grammar.c"
     break;
 
   case 103:
-#line 738 "beancount/parser/grammar.y"
+#line 770 "beancount/parser/grammar.y"
     {
                       Py_INCREF(Py_None);
                       (yyval.pyobj) = Py_None;
                   }
-#line 2429 "beancount/parser/grammar.c"
+#line 2461 "beancount/parser/grammar.c"
     break;
 
   case 104:
-#line 743 "beancount/parser/grammar.y"
+#line 775 "beancount/parser/grammar.y"
     {
                       BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                   }
-#line 2438 "beancount/parser/grammar.c"
+#line 2470 "beancount/parser/grammar.c"
     break;
 
   case 105:
-#line 749 "beancount/parser/grammar.y"
+#line 781 "beancount/parser/grammar.y"
     {
            BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "custom", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
        }
-#line 2447 "beancount/parser/grammar.c"
+#line 2479 "beancount/parser/grammar.c"
     break;
 
   case 117:
-#line 767 "beancount/parser/grammar.y"
+#line 799 "beancount/parser/grammar.y"
     {
           (yyval.pyobj) = (yyvsp[0].pyobj);
       }
-#line 2455 "beancount/parser/grammar.c"
+#line 2487 "beancount/parser/grammar.c"
     break;
 
   case 118:
-#line 772 "beancount/parser/grammar.y"
+#line 804 "beancount/parser/grammar.y"
     {
            BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "option", "OiOO", FILENAME, LINENO, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2464 "beancount/parser/grammar.c"
+#line 2496 "beancount/parser/grammar.c"
     break;
 
   case 119:
-#line 778 "beancount/parser/grammar.y"
+#line 810 "beancount/parser/grammar.y"
     {
            BUILD(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "include", "OiO", FILENAME, LINENO, (yyvsp[-1].pyobj));
        }
-#line 2473 "beancount/parser/grammar.c"
+#line 2505 "beancount/parser/grammar.c"
     break;
 
   case 120:
-#line 784 "beancount/parser/grammar.y"
+#line 816 "beancount/parser/grammar.y"
     {
            BUILD(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "OiOO", FILENAME, LINENO, (yyvsp[-1].pyobj), Py_None);
        }
-#line 2482 "beancount/parser/grammar.c"
+#line 2514 "beancount/parser/grammar.c"
     break;
 
   case 121:
-#line 789 "beancount/parser/grammar.y"
+#line 821 "beancount/parser/grammar.y"
     {
            BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "OiOO", FILENAME, LINENO, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2491 "beancount/parser/grammar.c"
+#line 2523 "beancount/parser/grammar.c"
     break;
 
   case 130:
-#line 805 "beancount/parser/grammar.y"
+#line 837 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2499 "beancount/parser/grammar.c"
+#line 2531 "beancount/parser/grammar.c"
     break;
 
   case 131:
-#line 809 "beancount/parser/grammar.y"
+#line 841 "beancount/parser/grammar.y"
     {
                  BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
              }
-#line 2508 "beancount/parser/grammar.c"
+#line 2540 "beancount/parser/grammar.c"
     break;
 
   case 132:
-#line 814 "beancount/parser/grammar.y"
+#line 846 "beancount/parser/grammar.y"
     {
                  /*
                   * Ignore the error and continue reducing ({3d95e55b654e}).
@@ -2526,20 +2558,20 @@ yyreduce:
                   */
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2530 "beancount/parser/grammar.c"
+#line 2562 "beancount/parser/grammar.c"
     break;
 
   case 133:
-#line 832 "beancount/parser/grammar.y"
+#line 864 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
              }
-#line 2539 "beancount/parser/grammar.c"
+#line 2571 "beancount/parser/grammar.c"
     break;
 
   case 134:
-#line 839 "beancount/parser/grammar.y"
+#line 871 "beancount/parser/grammar.y"
     {
          /* If a Python exception has been raised and not handled, abort. In
           * case of unrecoverable error, the lexer raises a Python exception and
@@ -2551,11 +2583,11 @@ yyreduce:
          BUILD(DECREF1((yyvsp[0].pyobj)),
                 (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2555 "beancount/parser/grammar.c"
+#line 2587 "beancount/parser/grammar.c"
     break;
 
 
-#line 2559 "beancount/parser/grammar.c"
+#line 2591 "beancount/parser/grammar.c"
 
       default: break;
     }
@@ -2606,7 +2638,7 @@ yyerrlab:
     {
       ++yynerrs;
 #if ! YYERROR_VERBOSE
-      yyerror (&yylloc, scanner, parser, builder, YY_("syntax error"));
+      yyerror (&yylloc, scanner, builder, YY_("syntax error"));
 #else
 # define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
                                         yyssp, yytoken)
@@ -2633,7 +2665,7 @@ yyerrlab:
                 yymsgp = yymsg;
               }
           }
-        yyerror (&yylloc, scanner, parser, builder, yymsgp);
+        yyerror (&yylloc, scanner, builder, yymsgp);
         if (yysyntax_error_status == 2)
           goto yyexhaustedlab;
       }
@@ -2657,7 +2689,7 @@ yyerrlab:
       else
         {
           yydestruct ("Error: discarding",
-                      yytoken, &yylval, &yylloc, scanner, parser, builder);
+                      yytoken, &yylval, &yylloc, scanner, builder);
           yychar = YYEMPTY;
         }
     }
@@ -2711,7 +2743,7 @@ yyerrlab1:
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, yylsp, scanner, parser, builder);
+                  yystos[yystate], yyvsp, yylsp, scanner, builder);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -2755,7 +2787,7 @@ yyabortlab:
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
 yyexhaustedlab:
-  yyerror (&yylloc, scanner, parser, builder, YY_("memory exhausted"));
+  yyerror (&yylloc, scanner, builder, YY_("memory exhausted"));
   yyresult = 2;
   /* Fall through.  */
 #endif
@@ -2771,7 +2803,7 @@ yyreturn:
          user semantic actions for why this is necessary.  */
       yytoken = YYTRANSLATE (yychar);
       yydestruct ("Cleanup: discarding lookahead",
-                  yytoken, &yylval, &yylloc, scanner, parser, builder);
+                  yytoken, &yylval, &yylloc, scanner, builder);
     }
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
@@ -2780,7 +2812,7 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp, yylsp, scanner, parser, builder);
+                  yystos[*yyssp], yyvsp, yylsp, scanner, builder);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -2793,7 +2825,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 854 "beancount/parser/grammar.y"
+#line 886 "beancount/parser/grammar.y"
 
 
 /* A function that will convert a token name to a string, used in debugging. */

--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -79,16 +79,15 @@ extern YY_DECL;
  * in the handler. Always run the code to clean the references provided by the
  * reduced rule. {05bb0fb60e86}
  */
-#define BUILD(clean, target, method_name, format, ...)                  \
-    target = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);    \
+#define CALL(clean, target, method_name, format, ...)                   \
+    target = PyObject_CallMethod(builder, method_name, "Oi" format,     \
+                                 (yyloc).file_name, (yyloc).first_line, \
+                                 ## __VA_ARGS__);                       \
     clean;                                                              \
     if (target == NULL) {                                               \
         build_grammar_error_from_exception(builder, yyloc);             \
         YYERROR;                                                        \
     }
-
-#define FILENAME (yyloc).file_name
-#define LINENO (yyloc).first_line
 
 /* Build a grammar error from the exception context. */
 void build_grammar_error_from_exception(PyObject* builder, YYLTYPE yyloc)
@@ -152,7 +151,7 @@ const char* getTokenName(int token);
 #define DECREF6(x1, x2, x3, x4, x5, x6)    DECREF5(x1, x2, x3, x4, x5); Py_DECREF(x6);
 
 
-#line 156 "beancount/parser/grammar.c"
+#line 155 "beancount/parser/grammar.c"
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus
@@ -223,7 +222,7 @@ typedef struct YYLTYPE {
     } while (0)
 
 
-#line 227 "beancount/parser/grammar.c"
+#line 226 "beancount/parser/grammar.c"
 
 /* Token type.  */
 #ifndef YYTOKENTYPE
@@ -291,7 +290,7 @@ typedef struct YYLTYPE {
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 149 "beancount/parser/grammar.y"
+#line 148 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -301,7 +300,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 305 "beancount/parser/grammar.c"
+#line 304 "beancount/parser/grammar.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -627,20 +626,20 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   283,   283,   286,   290,   294,   298,   303,   304,   308,
-     309,   310,   311,   317,   321,   326,   331,   336,   341,   346,
-     350,   355,   360,   365,   372,   380,   385,   391,   397,   401,
-     405,   409,   411,   416,   421,   426,   431,   437,   443,   448,
-     449,   450,   451,   452,   453,   454,   455,   456,   460,   466,
-     471,   475,   480,   485,   491,   496,   502,   507,   512,   518,
-     524,   530,   539,   545,   552,   556,   562,   568,   574,   580,
-     586,   592,   600,   607,   612,   617,   622,   627,   632,   637,
-     644,   650,   655,   660,   666,   671,   676,   682,   686,   690,
-     694,   701,   707,   713,   719,   725,   727,   734,   739,   744,
-     749,   754,   759,   769,   774,   780,   787,   788,   789,   790,
-     791,   792,   793,   794,   795,   796,   797,   798,   803,   809,
-     815,   820,   826,   827,   828,   829,   830,   831,   832,   833,
-     836,   840,   845,   863,   870
+       0,   282,   282,   285,   289,   293,   297,   302,   303,   307,
+     308,   309,   310,   316,   320,   325,   330,   335,   340,   345,
+     349,   354,   359,   364,   371,   379,   384,   390,   396,   400,
+     404,   408,   410,   415,   420,   425,   430,   436,   442,   447,
+     448,   449,   450,   451,   452,   453,   454,   455,   459,   465,
+     470,   474,   479,   484,   490,   495,   501,   506,   511,   517,
+     523,   529,   538,   544,   551,   555,   561,   567,   573,   579,
+     585,   591,   599,   606,   611,   616,   621,   626,   631,   636,
+     643,   649,   654,   659,   665,   670,   675,   681,   685,   689,
+     693,   700,   706,   712,   718,   724,   726,   733,   738,   743,
+     748,   753,   758,   768,   773,   779,   786,   787,   788,   789,
+     790,   791,   792,   793,   794,   795,   796,   797,   802,   808,
+     814,   819,   825,   826,   827,   828,   829,   830,   831,   832,
+     835,   839,   844,   862,   869
 };
 #endif
 
@@ -1699,848 +1698,848 @@ yyreduce:
   switch (yyn)
     {
   case 3:
-#line 287 "beancount/parser/grammar.y"
+#line 286 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1707 "beancount/parser/grammar.c"
+#line 1706 "beancount/parser/grammar.c"
     break;
 
   case 4:
-#line 291 "beancount/parser/grammar.y"
+#line 290 "beancount/parser/grammar.y"
     {
         (yyval.character) = (yyvsp[0].character);
     }
-#line 1715 "beancount/parser/grammar.c"
+#line 1714 "beancount/parser/grammar.c"
     break;
 
   case 5:
-#line 295 "beancount/parser/grammar.y"
+#line 294 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1723 "beancount/parser/grammar.c"
+#line 1722 "beancount/parser/grammar.c"
     break;
 
   case 6:
-#line 299 "beancount/parser/grammar.y"
+#line 298 "beancount/parser/grammar.y"
     {
         (yyval.character) = '#';
     }
-#line 1731 "beancount/parser/grammar.c"
+#line 1730 "beancount/parser/grammar.c"
     break;
 
   case 13:
-#line 318 "beancount/parser/grammar.y"
+#line 317 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1739 "beancount/parser/grammar.c"
+#line 1738 "beancount/parser/grammar.c"
     break;
 
   case 14:
-#line 322 "beancount/parser/grammar.y"
+#line 321 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Add((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1748 "beancount/parser/grammar.c"
+#line 1747 "beancount/parser/grammar.c"
     break;
 
   case 15:
-#line 327 "beancount/parser/grammar.y"
+#line 326 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Subtract((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1757 "beancount/parser/grammar.c"
+#line 1756 "beancount/parser/grammar.c"
     break;
 
   case 16:
-#line 332 "beancount/parser/grammar.y"
+#line 331 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Multiply((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1766 "beancount/parser/grammar.c"
+#line 1765 "beancount/parser/grammar.c"
     break;
 
   case 17:
-#line 337 "beancount/parser/grammar.y"
+#line 336 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_TrueDivide((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1775 "beancount/parser/grammar.c"
+#line 1774 "beancount/parser/grammar.c"
     break;
 
   case 18:
-#line 342 "beancount/parser/grammar.y"
+#line 341 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Negative((yyvsp[0].pyobj));
                 DECREF1((yyvsp[0].pyobj));
             }
-#line 1784 "beancount/parser/grammar.c"
+#line 1783 "beancount/parser/grammar.c"
     break;
 
   case 19:
-#line 347 "beancount/parser/grammar.y"
+#line 346 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1792 "beancount/parser/grammar.c"
+#line 1791 "beancount/parser/grammar.c"
     break;
 
   case 20:
-#line 351 "beancount/parser/grammar.y"
+#line 350 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1800 "beancount/parser/grammar.c"
+#line 1799 "beancount/parser/grammar.c"
     break;
 
   case 21:
-#line 356 "beancount/parser/grammar.y"
+#line 355 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 1809 "beancount/parser/grammar.c"
+#line 1808 "beancount/parser/grammar.c"
     break;
 
   case 22:
-#line 361 "beancount/parser/grammar.y"
+#line 360 "beancount/parser/grammar.y"
     {
-                BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                       (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+                CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                     (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
             }
-#line 1818 "beancount/parser/grammar.c"
+#line 1817 "beancount/parser/grammar.c"
     break;
 
   case 23:
-#line 366 "beancount/parser/grammar.y"
+#line 365 "beancount/parser/grammar.y"
     {
-                BUILD(,
-                       (yyval.pyobj), "pipe_deprecated_error", "Oi", FILENAME, LINENO);
+                CALL(,
+                     (yyval.pyobj), "pipe_deprecated_error", "");
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1828 "beancount/parser/grammar.c"
+#line 1827 "beancount/parser/grammar.c"
     break;
 
   case 24:
-#line 373 "beancount/parser/grammar.y"
+#line 372 "beancount/parser/grammar.y"
     {
                /* Note: We're passing a bogus value here in order to avoid
                 * having to declare a second macro just for this one special
                 * case. */
-               BUILD(,
-                      (yyval.pyobj), "tag_link_new", "O", Py_None);
+               CALL(,
+                    (yyval.pyobj), "tag_link_new", "O", Py_None);
            }
-#line 1840 "beancount/parser/grammar.c"
+#line 1839 "beancount/parser/grammar.c"
     break;
 
   case 25:
-#line 381 "beancount/parser/grammar.y"
+#line 380 "beancount/parser/grammar.y"
     {
-               BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                      (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+               CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                    (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1849 "beancount/parser/grammar.c"
+#line 1848 "beancount/parser/grammar.c"
     break;
 
   case 26:
-#line 386 "beancount/parser/grammar.y"
+#line 385 "beancount/parser/grammar.y"
     {
-               BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                      (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+               CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                    (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1858 "beancount/parser/grammar.c"
+#line 1857 "beancount/parser/grammar.c"
     break;
 
   case 27:
-#line 392 "beancount/parser/grammar.y"
+#line 391 "beancount/parser/grammar.y"
     {
-                BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                       (yyval.pyobj), "transaction", "OiObOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                     (yyval.pyobj), "transaction", "ObOOO", (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1867 "beancount/parser/grammar.c"
+#line 1866 "beancount/parser/grammar.c"
     break;
 
   case 28:
-#line 398 "beancount/parser/grammar.y"
+#line 397 "beancount/parser/grammar.y"
     {
             (yyval.character) = '\0';
         }
-#line 1875 "beancount/parser/grammar.c"
+#line 1874 "beancount/parser/grammar.c"
     break;
 
   case 29:
-#line 402 "beancount/parser/grammar.y"
+#line 401 "beancount/parser/grammar.y"
     {
             (yyval.character) = '*';
         }
-#line 1883 "beancount/parser/grammar.c"
+#line 1882 "beancount/parser/grammar.c"
     break;
 
   case 30:
-#line 406 "beancount/parser/grammar.y"
+#line 405 "beancount/parser/grammar.y"
     {
             (yyval.character) = '#';
         }
-#line 1891 "beancount/parser/grammar.c"
+#line 1890 "beancount/parser/grammar.c"
     break;
 
   case 32:
-#line 412 "beancount/parser/grammar.y"
+#line 411 "beancount/parser/grammar.y"
     {
                      (yyval.pyobj) = (yyvsp[0].pyobj);
                  }
-#line 1899 "beancount/parser/grammar.c"
+#line 1898 "beancount/parser/grammar.c"
     break;
 
   case 33:
-#line 417 "beancount/parser/grammar.y"
+#line 416 "beancount/parser/grammar.y"
     {
-            BUILD(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
-                   (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
+            CALL(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
+                 (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
         }
-#line 1908 "beancount/parser/grammar.c"
+#line 1907 "beancount/parser/grammar.c"
     break;
 
   case 34:
-#line 422 "beancount/parser/grammar.y"
+#line 421 "beancount/parser/grammar.y"
     {
-            BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
-                   (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
+            CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
+                 (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
         }
-#line 1917 "beancount/parser/grammar.c"
+#line 1916 "beancount/parser/grammar.c"
     break;
 
   case 35:
-#line 427 "beancount/parser/grammar.y"
+#line 426 "beancount/parser/grammar.y"
     {
-            BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
-                   (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
+            CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
+                 (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
         }
-#line 1926 "beancount/parser/grammar.c"
+#line 1925 "beancount/parser/grammar.c"
     break;
 
   case 36:
-#line 432 "beancount/parser/grammar.y"
+#line 431 "beancount/parser/grammar.y"
     {
-            BUILD(DECREF1((yyvsp[-1].pyobj)),
-                   (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-1].pyobj), missing, Py_None, Py_None, Py_False, (yyvsp[-2].character));
+            CALL(DECREF1((yyvsp[-1].pyobj)),
+                 (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-1].pyobj), missing, Py_None, Py_None, Py_False, (yyvsp[-2].character));
         }
-#line 1935 "beancount/parser/grammar.c"
+#line 1934 "beancount/parser/grammar.c"
     break;
 
   case 37:
-#line 438 "beancount/parser/grammar.y"
+#line 437 "beancount/parser/grammar.y"
     {
-              BUILD(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
-                     (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
+              CALL(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
+                   (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
           }
-#line 1944 "beancount/parser/grammar.c"
+#line 1943 "beancount/parser/grammar.c"
     break;
 
   case 38:
-#line 444 "beancount/parser/grammar.y"
+#line 443 "beancount/parser/grammar.y"
     {
                    (yyval.pyobj) = (yyvsp[-1].pyobj);
                }
-#line 1952 "beancount/parser/grammar.c"
+#line 1951 "beancount/parser/grammar.c"
     break;
 
   case 47:
-#line 457 "beancount/parser/grammar.y"
+#line 456 "beancount/parser/grammar.y"
     {
                     (yyval.pyobj) = (yyvsp[0].pyobj);
                 }
-#line 1960 "beancount/parser/grammar.c"
+#line 1959 "beancount/parser/grammar.c"
     break;
 
   case 48:
-#line 461 "beancount/parser/grammar.y"
+#line 460 "beancount/parser/grammar.y"
     {
                     Py_INCREF(Py_None);
                     (yyval.pyobj) = Py_None;
                 }
-#line 1969 "beancount/parser/grammar.c"
+#line 1968 "beancount/parser/grammar.c"
     break;
 
   case 49:
-#line 467 "beancount/parser/grammar.y"
+#line 466 "beancount/parser/grammar.y"
     {
                        Py_INCREF(Py_None);
                        (yyval.pyobj) = Py_None;
                    }
-#line 1978 "beancount/parser/grammar.c"
+#line 1977 "beancount/parser/grammar.c"
     break;
 
   case 50:
-#line 472 "beancount/parser/grammar.y"
+#line 471 "beancount/parser/grammar.y"
     {
                        (yyval.pyobj) = (yyvsp[-3].pyobj);
                    }
-#line 1986 "beancount/parser/grammar.c"
+#line 1985 "beancount/parser/grammar.c"
     break;
 
   case 51:
-#line 476 "beancount/parser/grammar.y"
+#line 475 "beancount/parser/grammar.y"
     {
-                       BUILD(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
-                              (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
+                       CALL(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
+                            (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
                    }
-#line 1995 "beancount/parser/grammar.c"
+#line 1994 "beancount/parser/grammar.c"
     break;
 
   case 52:
-#line 481 "beancount/parser/grammar.y"
+#line 480 "beancount/parser/grammar.y"
     {
-                       BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                              (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+                       CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                            (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2004 "beancount/parser/grammar.c"
+#line 2003 "beancount/parser/grammar.c"
     break;
 
   case 53:
-#line 486 "beancount/parser/grammar.y"
+#line 485 "beancount/parser/grammar.y"
     {
-                       BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                              (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+                       CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                            (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2013 "beancount/parser/grammar.c"
+#line 2012 "beancount/parser/grammar.c"
     break;
 
   case 54:
-#line 492 "beancount/parser/grammar.y"
+#line 491 "beancount/parser/grammar.y"
     {
                    Py_INCREF(Py_None);
                    (yyval.pyobj) = Py_None;
                }
-#line 2022 "beancount/parser/grammar.c"
+#line 2021 "beancount/parser/grammar.c"
     break;
 
   case 55:
-#line 497 "beancount/parser/grammar.y"
+#line 496 "beancount/parser/grammar.y"
     {
-                   BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                          (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+                   CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                }
-#line 2031 "beancount/parser/grammar.c"
+#line 2030 "beancount/parser/grammar.c"
     break;
 
   case 56:
-#line 503 "beancount/parser/grammar.y"
+#line 502 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
               }
-#line 2040 "beancount/parser/grammar.c"
+#line 2039 "beancount/parser/grammar.c"
     break;
 
   case 57:
-#line 508 "beancount/parser/grammar.y"
+#line 507 "beancount/parser/grammar.y"
     {
-                  BUILD(DECREF1((yyvsp[0].pyobj)),
-                         (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
+                  CALL(DECREF1((yyvsp[0].pyobj)),
+                       (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
               }
-#line 2049 "beancount/parser/grammar.c"
+#line 2048 "beancount/parser/grammar.c"
     break;
 
   case 58:
-#line 513 "beancount/parser/grammar.y"
+#line 512 "beancount/parser/grammar.y"
     {
-                  BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                  CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                       (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
               }
-#line 2058 "beancount/parser/grammar.c"
+#line 2057 "beancount/parser/grammar.c"
     break;
 
   case 59:
-#line 519 "beancount/parser/grammar.y"
+#line 518 "beancount/parser/grammar.y"
     {
-             BUILD(DECREF1((yyvsp[-1].pyobj)),
-                    (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
+             CALL(DECREF1((yyvsp[-1].pyobj)),
+                  (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
          }
-#line 2067 "beancount/parser/grammar.c"
+#line 2066 "beancount/parser/grammar.c"
     break;
 
   case 60:
-#line 525 "beancount/parser/grammar.y"
+#line 524 "beancount/parser/grammar.y"
     {
-           BUILD(DECREF1((yyvsp[-1].pyobj)),
-                  (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
+           CALL(DECREF1((yyvsp[-1].pyobj)),
+                (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
        }
-#line 2076 "beancount/parser/grammar.c"
+#line 2075 "beancount/parser/grammar.c"
     break;
 
   case 61:
-#line 531 "beancount/parser/grammar.y"
+#line 530 "beancount/parser/grammar.y"
     {
              /* Note: key_value is a tuple, Py_BuildValue() won't wrap it up
               * within a tuple, so expand in the method (it receives two
               * objects). See https://docs.python.org/3.4/c-api/arg.html. */
-             BUILD(DECREF1((yyvsp[-1].pyobj)),
-                    (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
+             CALL(DECREF1((yyvsp[-1].pyobj)),
+                  (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
          }
-#line 2088 "beancount/parser/grammar.c"
+#line 2087 "beancount/parser/grammar.c"
     break;
 
   case 62:
-#line 540 "beancount/parser/grammar.y"
+#line 539 "beancount/parser/grammar.y"
     {
-            BUILD(DECREF1((yyvsp[-2].pyobj)),
-                   (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
+            CALL(DECREF1((yyvsp[-2].pyobj)),
+                 (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
         }
-#line 2097 "beancount/parser/grammar.c"
+#line 2096 "beancount/parser/grammar.c"
     break;
 
   case 63:
-#line 546 "beancount/parser/grammar.y"
+#line 545 "beancount/parser/grammar.y"
     {
-         BUILD(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                (yyval.pyobj), "open", "OiOOOOO", FILENAME, LINENO, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+         CALL(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+              (yyval.pyobj), "open", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          ;
      }
-#line 2107 "beancount/parser/grammar.c"
+#line 2106 "beancount/parser/grammar.c"
     break;
 
   case 64:
-#line 553 "beancount/parser/grammar.y"
+#line 552 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2115 "beancount/parser/grammar.c"
+#line 2114 "beancount/parser/grammar.c"
     break;
 
   case 65:
-#line 557 "beancount/parser/grammar.y"
+#line 556 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2124 "beancount/parser/grammar.c"
+#line 2123 "beancount/parser/grammar.c"
     break;
 
   case 66:
-#line 563 "beancount/parser/grammar.y"
+#line 562 "beancount/parser/grammar.y"
     {
-          BUILD(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                 (yyval.pyobj), "close", "OiOOO", FILENAME, LINENO, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+          CALL(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+               (yyval.pyobj), "close", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2133 "beancount/parser/grammar.c"
+#line 2132 "beancount/parser/grammar.c"
     break;
 
   case 67:
-#line 569 "beancount/parser/grammar.y"
+#line 568 "beancount/parser/grammar.y"
     {
-              BUILD(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                     (yyval.pyobj), "commodity", "OiOOO", FILENAME, LINENO, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+              CALL(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                   (yyval.pyobj), "commodity", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
           }
-#line 2142 "beancount/parser/grammar.c"
+#line 2141 "beancount/parser/grammar.c"
     break;
 
   case 68:
-#line 575 "beancount/parser/grammar.y"
+#line 574 "beancount/parser/grammar.y"
     {
-        BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-               (yyval.pyobj), "pad", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+        CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+             (yyval.pyobj), "pad", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
     }
-#line 2151 "beancount/parser/grammar.c"
+#line 2150 "beancount/parser/grammar.c"
     break;
 
   case 69:
-#line 581 "beancount/parser/grammar.y"
+#line 580 "beancount/parser/grammar.y"
     {
-            BUILD(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
-                   (yyval.pyobj), "balance", "OiOOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
+            CALL(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
+                 (yyval.pyobj), "balance", "OOOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
         }
-#line 2160 "beancount/parser/grammar.c"
+#line 2159 "beancount/parser/grammar.c"
     break;
 
   case 70:
-#line 587 "beancount/parser/grammar.y"
+#line 586 "beancount/parser/grammar.y"
     {
-           BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                  (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+           CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
        }
-#line 2169 "beancount/parser/grammar.c"
+#line 2168 "beancount/parser/grammar.c"
     break;
 
   case 71:
-#line 593 "beancount/parser/grammar.y"
+#line 592 "beancount/parser/grammar.y"
     {
-                     BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                            (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+                     CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                          (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = Py_None;
                      Py_INCREF(Py_None);
                      ;
                  }
-#line 2181 "beancount/parser/grammar.c"
+#line 2180 "beancount/parser/grammar.c"
     break;
 
   case 72:
-#line 601 "beancount/parser/grammar.y"
+#line 600 "beancount/parser/grammar.y"
     {
-                     BUILD(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
-                            (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
+                     CALL(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
+                          (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = (yyvsp[-1].pyobj);
                  }
-#line 2191 "beancount/parser/grammar.c"
+#line 2190 "beancount/parser/grammar.c"
     break;
 
   case 73:
-#line 608 "beancount/parser/grammar.y"
+#line 607 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing);
                  (yyval.pyobj) = missing;
              }
-#line 2200 "beancount/parser/grammar.c"
+#line 2199 "beancount/parser/grammar.c"
     break;
 
   case 74:
-#line 613 "beancount/parser/grammar.y"
+#line 612 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2208 "beancount/parser/grammar.c"
+#line 2207 "beancount/parser/grammar.c"
     break;
 
   case 75:
-#line 618 "beancount/parser/grammar.y"
+#line 617 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing);
                  (yyval.pyobj) = missing;
              }
-#line 2217 "beancount/parser/grammar.c"
+#line 2216 "beancount/parser/grammar.c"
     break;
 
   case 76:
-#line 623 "beancount/parser/grammar.y"
+#line 622 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2225 "beancount/parser/grammar.c"
+#line 2224 "beancount/parser/grammar.c"
     break;
 
   case 77:
-#line 628 "beancount/parser/grammar.y"
+#line 627 "beancount/parser/grammar.y"
     {
-                    BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                           (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
+                    CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                         (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2234 "beancount/parser/grammar.c"
+#line 2233 "beancount/parser/grammar.c"
     break;
 
   case 78:
-#line 633 "beancount/parser/grammar.y"
+#line 632 "beancount/parser/grammar.y"
     {
-                    BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                           (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
+                    CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                         (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2243 "beancount/parser/grammar.c"
+#line 2242 "beancount/parser/grammar.c"
     break;
 
   case 79:
-#line 638 "beancount/parser/grammar.y"
+#line 637 "beancount/parser/grammar.y"
     {
-                    BUILD(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                           (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+                    CALL(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                         (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                     ;
                 }
-#line 2253 "beancount/parser/grammar.c"
+#line 2252 "beancount/parser/grammar.c"
     break;
 
   case 80:
-#line 645 "beancount/parser/grammar.y"
+#line 644 "beancount/parser/grammar.y"
     {
-                      BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                             (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+                      CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                           (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                  }
-#line 2262 "beancount/parser/grammar.c"
+#line 2261 "beancount/parser/grammar.c"
     break;
 
   case 81:
-#line 651 "beancount/parser/grammar.y"
+#line 650 "beancount/parser/grammar.y"
     {
-              BUILD(DECREF1((yyvsp[-1].pyobj)),
-                     (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
+              CALL(DECREF1((yyvsp[-1].pyobj)),
+                   (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
           }
-#line 2271 "beancount/parser/grammar.c"
+#line 2270 "beancount/parser/grammar.c"
     break;
 
   case 82:
-#line 656 "beancount/parser/grammar.y"
+#line 655 "beancount/parser/grammar.y"
     {
-              BUILD(DECREF1((yyvsp[-1].pyobj)),
-                     (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
+              CALL(DECREF1((yyvsp[-1].pyobj)),
+                   (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
           }
-#line 2280 "beancount/parser/grammar.c"
+#line 2279 "beancount/parser/grammar.c"
     break;
 
   case 83:
-#line 661 "beancount/parser/grammar.y"
+#line 660 "beancount/parser/grammar.y"
     {
               Py_INCREF(Py_None);
               (yyval.pyobj) = Py_None;
           }
-#line 2289 "beancount/parser/grammar.c"
+#line 2288 "beancount/parser/grammar.c"
     break;
 
   case 84:
-#line 667 "beancount/parser/grammar.y"
+#line 666 "beancount/parser/grammar.y"
     {
                    /* We indicate that there was a cost if there */
                    (yyval.pyobj) = PyList_New(0);
                }
-#line 2298 "beancount/parser/grammar.c"
+#line 2297 "beancount/parser/grammar.c"
     break;
 
   case 85:
-#line 672 "beancount/parser/grammar.y"
+#line 671 "beancount/parser/grammar.y"
     {
-                   BUILD(DECREF1((yyvsp[0].pyobj)),
-                          (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
+                   CALL(DECREF1((yyvsp[0].pyobj)),
+                        (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
                }
-#line 2307 "beancount/parser/grammar.c"
+#line 2306 "beancount/parser/grammar.c"
     break;
 
   case 86:
-#line 677 "beancount/parser/grammar.y"
+#line 676 "beancount/parser/grammar.y"
     {
-                   BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                          (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                   CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                }
-#line 2316 "beancount/parser/grammar.c"
+#line 2315 "beancount/parser/grammar.c"
     break;
 
   case 87:
-#line 683 "beancount/parser/grammar.y"
+#line 682 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2324 "beancount/parser/grammar.c"
+#line 2323 "beancount/parser/grammar.c"
     break;
 
   case 88:
-#line 687 "beancount/parser/grammar.y"
+#line 686 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2332 "beancount/parser/grammar.c"
+#line 2331 "beancount/parser/grammar.c"
     break;
 
   case 89:
-#line 691 "beancount/parser/grammar.y"
+#line 690 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2340 "beancount/parser/grammar.c"
+#line 2339 "beancount/parser/grammar.c"
     break;
 
   case 90:
-#line 695 "beancount/parser/grammar.y"
+#line 694 "beancount/parser/grammar.y"
     {
-              BUILD(,
-                     (yyval.pyobj), "cost_merge", "O", Py_None);
+              CALL(,
+                   (yyval.pyobj), "cost_merge", "O", Py_None);
           }
-#line 2349 "beancount/parser/grammar.c"
+#line 2348 "beancount/parser/grammar.c"
     break;
 
   case 91:
-#line 702 "beancount/parser/grammar.y"
+#line 701 "beancount/parser/grammar.y"
     {
-          BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                 (yyval.pyobj), "price", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+          CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+               (yyval.pyobj), "price", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2358 "beancount/parser/grammar.c"
+#line 2357 "beancount/parser/grammar.c"
     break;
 
   case 92:
-#line 708 "beancount/parser/grammar.y"
+#line 707 "beancount/parser/grammar.y"
     {
-          BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                 (yyval.pyobj), "event", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+          CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+               (yyval.pyobj), "event", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2367 "beancount/parser/grammar.c"
+#line 2366 "beancount/parser/grammar.c"
     break;
 
   case 93:
-#line 714 "beancount/parser/grammar.y"
+#line 713 "beancount/parser/grammar.y"
     {
-             BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                    (yyval.pyobj), "query", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+             CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                  (yyval.pyobj), "query", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2376 "beancount/parser/grammar.c"
+#line 2375 "beancount/parser/grammar.c"
     break;
 
   case 94:
-#line 720 "beancount/parser/grammar.y"
+#line 719 "beancount/parser/grammar.y"
     {
-          BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                 (yyval.pyobj), "note", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+          CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+               (yyval.pyobj), "note", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2385 "beancount/parser/grammar.c"
+#line 2384 "beancount/parser/grammar.c"
     break;
 
   case 96:
-#line 728 "beancount/parser/grammar.y"
+#line 727 "beancount/parser/grammar.y"
     {
-             BUILD(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                    (yyval.pyobj), "document", "OiOOOOO", FILENAME, LINENO, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+             CALL(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                  (yyval.pyobj), "document", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2394 "beancount/parser/grammar.c"
+#line 2393 "beancount/parser/grammar.c"
     break;
 
   case 97:
-#line 735 "beancount/parser/grammar.y"
+#line 734 "beancount/parser/grammar.y"
     {
-                 BUILD(DECREF1((yyvsp[0].pyobj)),
-                        (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
+                 CALL(DECREF1((yyvsp[0].pyobj)),
+                      (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2403 "beancount/parser/grammar.c"
+#line 2402 "beancount/parser/grammar.c"
     break;
 
   case 98:
-#line 740 "beancount/parser/grammar.y"
+#line 739 "beancount/parser/grammar.y"
     {
-                 BUILD(DECREF1((yyvsp[0].pyobj)),
-                        (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
+                 CALL(DECREF1((yyvsp[0].pyobj)),
+                      (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2412 "beancount/parser/grammar.c"
+#line 2411 "beancount/parser/grammar.c"
     break;
 
   case 99:
-#line 745 "beancount/parser/grammar.y"
+#line 744 "beancount/parser/grammar.y"
     {
-                 BUILD(DECREF1((yyvsp[0].pyobj)),
-                        (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
+                 CALL(DECREF1((yyvsp[0].pyobj)),
+                      (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2421 "beancount/parser/grammar.c"
+#line 2420 "beancount/parser/grammar.c"
     break;
 
   case 100:
-#line 750 "beancount/parser/grammar.y"
+#line 749 "beancount/parser/grammar.y"
     {
-                 BUILD(DECREF1((yyvsp[0].pyobj)),
-                        (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
+                 CALL(DECREF1((yyvsp[0].pyobj)),
+                      (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2430 "beancount/parser/grammar.c"
+#line 2429 "beancount/parser/grammar.c"
     break;
 
   case 101:
-#line 755 "beancount/parser/grammar.y"
+#line 754 "beancount/parser/grammar.y"
     {
-                 BUILD(DECREF1((yyvsp[0].pyobj)),
-                        (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
+                 CALL(DECREF1((yyvsp[0].pyobj)),
+                      (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2439 "beancount/parser/grammar.c"
+#line 2438 "beancount/parser/grammar.c"
     break;
 
   case 102:
-#line 760 "beancount/parser/grammar.y"
+#line 759 "beancount/parser/grammar.y"
     {
                  /* Obtain beancount.core.account.TYPE */
                  PyObject* module = PyImport_ImportModule("beancount.core.account");
                  PyObject* dtype = PyObject_GetAttrString(module, "TYPE");
                  Py_DECREF(module);
-                 BUILD(DECREF2((yyvsp[0].pyobj), dtype),
-                        (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
+                 CALL(DECREF2((yyvsp[0].pyobj), dtype),
+                      (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
              }
-#line 2452 "beancount/parser/grammar.c"
+#line 2451 "beancount/parser/grammar.c"
     break;
 
   case 103:
-#line 770 "beancount/parser/grammar.y"
+#line 769 "beancount/parser/grammar.y"
     {
                       Py_INCREF(Py_None);
                       (yyval.pyobj) = Py_None;
                   }
-#line 2461 "beancount/parser/grammar.c"
+#line 2460 "beancount/parser/grammar.c"
     break;
 
   case 104:
-#line 775 "beancount/parser/grammar.y"
+#line 774 "beancount/parser/grammar.y"
     {
-                      BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                             (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+                      CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                   }
-#line 2470 "beancount/parser/grammar.c"
+#line 2469 "beancount/parser/grammar.c"
     break;
 
   case 105:
-#line 781 "beancount/parser/grammar.y"
+#line 780 "beancount/parser/grammar.y"
     {
-           BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                  (yyval.pyobj), "custom", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+           CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                (yyval.pyobj), "custom", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
        }
-#line 2479 "beancount/parser/grammar.c"
+#line 2478 "beancount/parser/grammar.c"
     break;
 
   case 117:
-#line 799 "beancount/parser/grammar.y"
+#line 798 "beancount/parser/grammar.y"
     {
           (yyval.pyobj) = (yyvsp[0].pyobj);
       }
-#line 2487 "beancount/parser/grammar.c"
+#line 2486 "beancount/parser/grammar.c"
     break;
 
   case 118:
-#line 804 "beancount/parser/grammar.y"
+#line 803 "beancount/parser/grammar.y"
     {
-           BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
-                  (yyval.pyobj), "option", "OiOO", FILENAME, LINENO, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
+           CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
+                (yyval.pyobj), "option", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2496 "beancount/parser/grammar.c"
+#line 2495 "beancount/parser/grammar.c"
     break;
 
   case 119:
-#line 810 "beancount/parser/grammar.y"
+#line 809 "beancount/parser/grammar.y"
     {
-           BUILD(DECREF1((yyvsp[-1].pyobj)),
-                  (yyval.pyobj), "include", "OiO", FILENAME, LINENO, (yyvsp[-1].pyobj));
+           CALL(DECREF1((yyvsp[-1].pyobj)),
+                (yyval.pyobj), "include", "O", (yyvsp[-1].pyobj));
        }
-#line 2505 "beancount/parser/grammar.c"
+#line 2504 "beancount/parser/grammar.c"
     break;
 
   case 120:
-#line 816 "beancount/parser/grammar.y"
+#line 815 "beancount/parser/grammar.y"
     {
-           BUILD(DECREF1((yyvsp[-1].pyobj)),
-                  (yyval.pyobj), "plugin", "OiOO", FILENAME, LINENO, (yyvsp[-1].pyobj), Py_None);
+           CALL(DECREF1((yyvsp[-1].pyobj)),
+                (yyval.pyobj), "plugin", "OO", (yyvsp[-1].pyobj), Py_None);
        }
-#line 2514 "beancount/parser/grammar.c"
+#line 2513 "beancount/parser/grammar.c"
     break;
 
   case 121:
-#line 821 "beancount/parser/grammar.y"
+#line 820 "beancount/parser/grammar.y"
     {
-           BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
-                  (yyval.pyobj), "plugin", "OiOO", FILENAME, LINENO, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
+           CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
+                (yyval.pyobj), "plugin", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2523 "beancount/parser/grammar.c"
+#line 2522 "beancount/parser/grammar.c"
     break;
 
   case 130:
-#line 837 "beancount/parser/grammar.y"
+#line 836 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2531 "beancount/parser/grammar.c"
+#line 2530 "beancount/parser/grammar.c"
     break;
 
   case 131:
-#line 841 "beancount/parser/grammar.y"
+#line 840 "beancount/parser/grammar.y"
     {
-                 BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
-                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
+                 CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                      (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
              }
-#line 2540 "beancount/parser/grammar.c"
+#line 2539 "beancount/parser/grammar.c"
     break;
 
   case 132:
-#line 846 "beancount/parser/grammar.y"
+#line 845 "beancount/parser/grammar.y"
     {
                  /*
                   * Ignore the error and continue reducing ({3d95e55b654e}).
@@ -2558,20 +2557,20 @@ yyreduce:
                   */
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2562 "beancount/parser/grammar.c"
+#line 2561 "beancount/parser/grammar.c"
     break;
 
   case 133:
-#line 864 "beancount/parser/grammar.y"
+#line 863 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
              }
-#line 2571 "beancount/parser/grammar.c"
+#line 2570 "beancount/parser/grammar.c"
     break;
 
   case 134:
-#line 871 "beancount/parser/grammar.y"
+#line 870 "beancount/parser/grammar.y"
     {
          /* If a Python exception has been raised and not handled, abort. In
           * case of unrecoverable error, the lexer raises a Python exception and
@@ -2580,14 +2579,14 @@ yyreduce:
          if (PyErr_Occurred()) {
              YYABORT;
          }
-         BUILD(DECREF1((yyvsp[0].pyobj)),
-                (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
+         CALL(DECREF1((yyvsp[0].pyobj)),
+              (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2587 "beancount/parser/grammar.c"
+#line 2586 "beancount/parser/grammar.c"
     break;
 
 
-#line 2591 "beancount/parser/grammar.c"
+#line 2590 "beancount/parser/grammar.c"
 
       default: break;
     }
@@ -2825,7 +2824,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 886 "beancount/parser/grammar.y"
+#line 885 "beancount/parser/grammar.y"
 
 
 /* A function that will convert a token name to a string, used in debugging. */

--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -2548,14 +2548,21 @@ yyreduce:
   case 134:
 #line 846 "beancount/parser/grammar.y"
     {
+         /* If a Python exception has been raised and not handled, abort. In
+          * case of unrecoverable error, the lexer raises a Python exception and
+          * the yylex() function returns -1, whcih is translated by Bison into
+          * an EOF token, handled here. */
+         if (PyErr_Occurred()) {
+             YYABORT;
+         }
          BUILDY(DECREF1((yyvsp[0].pyobj)),
                 (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2555 "beancount/parser/grammar.c"
+#line 2562 "beancount/parser/grammar.c"
     break;
 
 
-#line 2559 "beancount/parser/grammar.c"
+#line 2566 "beancount/parser/grammar.c"
 
       default: break;
     }
@@ -2793,7 +2800,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 854 "beancount/parser/grammar.y"
+#line 861 "beancount/parser/grammar.y"
 
 
 /* A function that will convert a token name to a string, used in debugging. */

--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -69,6 +69,7 @@
 #line 52 "beancount/parser/grammar.y"
 
 
+#include "macros.h"
 #include "grammar.h"
 #include "lexer.h"
 
@@ -79,11 +80,11 @@ extern YY_DECL;
  * in the handler. Always run the code to clean the references provided by the
  * reduced rule. {05bb0fb60e86}
  */
-#define CALL(clean, target, method_name, format, ...)                   \
+#define CALL(CLEAN, target, method_name, format, ...)                   \
     target = PyObject_CallMethod(builder, method_name, "Oi" format,     \
                                  (yyloc).file_name, (yyloc).first_line, \
                                  ## __VA_ARGS__);                       \
-    clean;                                                              \
+    CLEAN;                                                              \
     if (target == NULL) {                                               \
         build_grammar_error_from_exception(builder, yyloc);             \
         YYERROR;                                                        \
@@ -138,16 +139,10 @@ void yyerror(YYLTYPE *locp, yyscan_t scanner, PyObject* builder, char const* mes
     Py_XDECREF(rv);
 }
 
-/* Macros to clean up memory for temporaries in rule reductions. */
-#define DECREF1(x1)                        Py_DECREF(x1);
-#define DECREF2(x1, x2)                    DECREF1(x1); Py_DECREF(x2);
-#define DECREF3(x1, x2, x3)                DECREF2(x1, x2); Py_DECREF(x3);
-#define DECREF4(x1, x2, x3, x4)            DECREF3(x1, x2, x3); Py_DECREF(x4);
-#define DECREF5(x1, x2, x3, x4, x5)        DECREF4(x1, x2, x3, x4); Py_DECREF(x5);
-#define DECREF6(x1, x2, x3, x4, x5, x6)    DECREF5(x1, x2, x3, x4, x5); Py_DECREF(x6);
+#define DECREF(...) _CC_FUNC(Py_DECREF, __VA_ARGS__)
 
 
-#line 151 "beancount/parser/grammar.c"
+#line 146 "beancount/parser/grammar.c"
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus
@@ -221,7 +216,7 @@ typedef struct YYLTYPE {
 const char* token_to_string(int token);
 
 
-#line 225 "beancount/parser/grammar.c"
+#line 220 "beancount/parser/grammar.c"
 
 /* Token type.  */
 #ifndef YYTOKENTYPE
@@ -289,7 +284,7 @@ const char* token_to_string(int token);
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 147 "beancount/parser/grammar.y"
+#line 142 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -299,7 +294,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 303 "beancount/parser/grammar.c"
+#line 298 "beancount/parser/grammar.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -625,20 +620,20 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   281,   281,   284,   288,   292,   296,   301,   302,   306,
-     307,   308,   309,   315,   319,   324,   329,   334,   339,   344,
-     348,   353,   358,   363,   370,   378,   383,   389,   395,   399,
-     403,   407,   409,   414,   419,   424,   429,   435,   441,   446,
-     447,   448,   449,   450,   451,   452,   453,   454,   458,   464,
-     469,   473,   478,   483,   489,   494,   500,   505,   510,   516,
-     522,   528,   537,   543,   550,   554,   560,   566,   572,   578,
-     584,   590,   598,   605,   610,   615,   620,   625,   630,   635,
-     642,   648,   653,   658,   664,   669,   674,   680,   684,   688,
-     692,   699,   705,   711,   717,   723,   725,   732,   737,   742,
-     747,   752,   757,   767,   772,   778,   785,   786,   787,   788,
-     789,   790,   791,   792,   793,   794,   795,   796,   801,   807,
-     813,   818,   824,   825,   826,   827,   828,   829,   830,   831,
-     834,   838,   843,   861,   868
+       0,   276,   276,   279,   283,   287,   291,   296,   297,   301,
+     302,   303,   304,   310,   314,   319,   324,   329,   334,   339,
+     343,   348,   353,   358,   365,   373,   378,   384,   390,   394,
+     398,   402,   404,   409,   414,   419,   424,   430,   436,   441,
+     442,   443,   444,   445,   446,   447,   448,   449,   453,   459,
+     464,   468,   473,   478,   484,   489,   495,   500,   505,   511,
+     517,   523,   532,   538,   545,   549,   555,   561,   567,   573,
+     579,   585,   593,   600,   605,   610,   615,   620,   625,   630,
+     637,   643,   648,   653,   659,   664,   669,   675,   679,   683,
+     687,   694,   700,   706,   712,   718,   720,   727,   732,   737,
+     742,   747,   752,   762,   767,   773,   780,   781,   782,   783,
+     784,   785,   786,   787,   788,   789,   790,   791,   796,   802,
+     808,   813,   819,   820,   821,   822,   823,   824,   825,   826,
+     829,   833,   838,   856,   863
 };
 #endif
 
@@ -1697,136 +1692,136 @@ yyreduce:
   switch (yyn)
     {
   case 3:
-#line 285 "beancount/parser/grammar.y"
+#line 280 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1705 "beancount/parser/grammar.c"
+#line 1700 "beancount/parser/grammar.c"
     break;
 
   case 4:
-#line 289 "beancount/parser/grammar.y"
+#line 284 "beancount/parser/grammar.y"
     {
         (yyval.character) = (yyvsp[0].character);
     }
-#line 1713 "beancount/parser/grammar.c"
+#line 1708 "beancount/parser/grammar.c"
     break;
 
   case 5:
-#line 293 "beancount/parser/grammar.y"
+#line 288 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1721 "beancount/parser/grammar.c"
+#line 1716 "beancount/parser/grammar.c"
     break;
 
   case 6:
-#line 297 "beancount/parser/grammar.y"
+#line 292 "beancount/parser/grammar.y"
     {
         (yyval.character) = '#';
     }
-#line 1729 "beancount/parser/grammar.c"
+#line 1724 "beancount/parser/grammar.c"
     break;
 
   case 13:
-#line 316 "beancount/parser/grammar.y"
+#line 311 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1737 "beancount/parser/grammar.c"
+#line 1732 "beancount/parser/grammar.c"
     break;
 
   case 14:
-#line 320 "beancount/parser/grammar.y"
+#line 315 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Add((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
-                DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                DECREF((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1746 "beancount/parser/grammar.c"
+#line 1741 "beancount/parser/grammar.c"
     break;
 
   case 15:
-#line 325 "beancount/parser/grammar.y"
+#line 320 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Subtract((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
-                DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                DECREF((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1755 "beancount/parser/grammar.c"
+#line 1750 "beancount/parser/grammar.c"
     break;
 
   case 16:
-#line 330 "beancount/parser/grammar.y"
+#line 325 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Multiply((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
-                DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                DECREF((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1764 "beancount/parser/grammar.c"
+#line 1759 "beancount/parser/grammar.c"
     break;
 
   case 17:
-#line 335 "beancount/parser/grammar.y"
+#line 330 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_TrueDivide((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
-                DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                DECREF((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1773 "beancount/parser/grammar.c"
+#line 1768 "beancount/parser/grammar.c"
     break;
 
   case 18:
-#line 340 "beancount/parser/grammar.y"
+#line 335 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Negative((yyvsp[0].pyobj));
-                DECREF1((yyvsp[0].pyobj));
+                DECREF((yyvsp[0].pyobj));
             }
-#line 1782 "beancount/parser/grammar.c"
+#line 1777 "beancount/parser/grammar.c"
     break;
 
   case 19:
-#line 345 "beancount/parser/grammar.y"
+#line 340 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1790 "beancount/parser/grammar.c"
+#line 1785 "beancount/parser/grammar.c"
     break;
 
   case 20:
-#line 349 "beancount/parser/grammar.y"
+#line 344 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1798 "beancount/parser/grammar.c"
+#line 1793 "beancount/parser/grammar.c"
     break;
 
   case 21:
-#line 354 "beancount/parser/grammar.y"
+#line 349 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 1807 "beancount/parser/grammar.c"
+#line 1802 "beancount/parser/grammar.c"
     break;
 
   case 22:
-#line 359 "beancount/parser/grammar.y"
+#line 354 "beancount/parser/grammar.y"
     {
-                CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
             }
-#line 1816 "beancount/parser/grammar.c"
+#line 1811 "beancount/parser/grammar.c"
     break;
 
   case 23:
-#line 364 "beancount/parser/grammar.y"
+#line 359 "beancount/parser/grammar.y"
     {
                 CALL(,
                      (yyval.pyobj), "pipe_deprecated_error", "");
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1826 "beancount/parser/grammar.c"
+#line 1821 "beancount/parser/grammar.c"
     break;
 
   case 24:
-#line 371 "beancount/parser/grammar.y"
+#line 366 "beancount/parser/grammar.y"
     {
                /* Note: We're passing a bogus value here in order to avoid
                 * having to declare a second macro just for this one special
@@ -1834,711 +1829,711 @@ yyreduce:
                CALL(,
                     (yyval.pyobj), "tag_link_new", "O", Py_None);
            }
-#line 1838 "beancount/parser/grammar.c"
+#line 1833 "beancount/parser/grammar.c"
     break;
 
   case 25:
-#line 379 "beancount/parser/grammar.y"
+#line 374 "beancount/parser/grammar.y"
     {
-               CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+               CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1847 "beancount/parser/grammar.c"
+#line 1842 "beancount/parser/grammar.c"
     break;
 
   case 26:
-#line 384 "beancount/parser/grammar.y"
+#line 379 "beancount/parser/grammar.y"
     {
-               CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+               CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1856 "beancount/parser/grammar.c"
+#line 1851 "beancount/parser/grammar.c"
     break;
 
   case 27:
-#line 390 "beancount/parser/grammar.y"
+#line 385 "beancount/parser/grammar.y"
     {
-                CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                CALL(DECREF((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "transaction", "ObOOO", (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1865 "beancount/parser/grammar.c"
+#line 1860 "beancount/parser/grammar.c"
     break;
 
   case 28:
-#line 396 "beancount/parser/grammar.y"
+#line 391 "beancount/parser/grammar.y"
     {
             (yyval.character) = '\0';
         }
-#line 1873 "beancount/parser/grammar.c"
+#line 1868 "beancount/parser/grammar.c"
     break;
 
   case 29:
-#line 400 "beancount/parser/grammar.y"
+#line 395 "beancount/parser/grammar.y"
     {
             (yyval.character) = '*';
         }
-#line 1881 "beancount/parser/grammar.c"
+#line 1876 "beancount/parser/grammar.c"
     break;
 
   case 30:
-#line 404 "beancount/parser/grammar.y"
+#line 399 "beancount/parser/grammar.y"
     {
             (yyval.character) = '#';
         }
-#line 1889 "beancount/parser/grammar.c"
+#line 1884 "beancount/parser/grammar.c"
     break;
 
   case 32:
-#line 410 "beancount/parser/grammar.y"
+#line 405 "beancount/parser/grammar.y"
     {
                      (yyval.pyobj) = (yyvsp[0].pyobj);
                  }
-#line 1897 "beancount/parser/grammar.c"
+#line 1892 "beancount/parser/grammar.c"
     break;
 
   case 33:
-#line 415 "beancount/parser/grammar.y"
+#line 410 "beancount/parser/grammar.y"
     {
-            CALL(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
+            CALL(DECREF((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                  (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
         }
-#line 1906 "beancount/parser/grammar.c"
+#line 1901 "beancount/parser/grammar.c"
     break;
 
   case 34:
-#line 420 "beancount/parser/grammar.y"
+#line 415 "beancount/parser/grammar.y"
     {
-            CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
+            CALL(DECREF((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                  (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
         }
-#line 1915 "beancount/parser/grammar.c"
+#line 1910 "beancount/parser/grammar.c"
     break;
 
   case 35:
-#line 425 "beancount/parser/grammar.y"
+#line 420 "beancount/parser/grammar.y"
     {
-            CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
+            CALL(DECREF((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                  (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
         }
-#line 1924 "beancount/parser/grammar.c"
+#line 1919 "beancount/parser/grammar.c"
     break;
 
   case 36:
-#line 430 "beancount/parser/grammar.y"
+#line 425 "beancount/parser/grammar.y"
     {
-            CALL(DECREF1((yyvsp[-1].pyobj)),
+            CALL(DECREF((yyvsp[-1].pyobj)),
                  (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-1].pyobj), missing, Py_None, Py_None, Py_False, (yyvsp[-2].character));
         }
-#line 1933 "beancount/parser/grammar.c"
+#line 1928 "beancount/parser/grammar.c"
     break;
 
   case 37:
-#line 436 "beancount/parser/grammar.y"
+#line 431 "beancount/parser/grammar.y"
     {
-              CALL(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
+              CALL(DECREF((yyvsp[-1].string), (yyvsp[0].pyobj)),
                    (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
           }
-#line 1942 "beancount/parser/grammar.c"
+#line 1937 "beancount/parser/grammar.c"
     break;
 
   case 38:
-#line 442 "beancount/parser/grammar.y"
+#line 437 "beancount/parser/grammar.y"
     {
                    (yyval.pyobj) = (yyvsp[-1].pyobj);
                }
-#line 1950 "beancount/parser/grammar.c"
+#line 1945 "beancount/parser/grammar.c"
     break;
 
   case 47:
-#line 455 "beancount/parser/grammar.y"
+#line 450 "beancount/parser/grammar.y"
     {
                     (yyval.pyobj) = (yyvsp[0].pyobj);
                 }
-#line 1958 "beancount/parser/grammar.c"
+#line 1953 "beancount/parser/grammar.c"
     break;
 
   case 48:
-#line 459 "beancount/parser/grammar.y"
+#line 454 "beancount/parser/grammar.y"
     {
                     Py_INCREF(Py_None);
                     (yyval.pyobj) = Py_None;
                 }
-#line 1967 "beancount/parser/grammar.c"
+#line 1962 "beancount/parser/grammar.c"
     break;
 
   case 49:
-#line 465 "beancount/parser/grammar.y"
+#line 460 "beancount/parser/grammar.y"
     {
                        Py_INCREF(Py_None);
                        (yyval.pyobj) = Py_None;
                    }
-#line 1976 "beancount/parser/grammar.c"
+#line 1971 "beancount/parser/grammar.c"
     break;
 
   case 50:
-#line 470 "beancount/parser/grammar.y"
+#line 465 "beancount/parser/grammar.y"
     {
                        (yyval.pyobj) = (yyvsp[-3].pyobj);
                    }
-#line 1984 "beancount/parser/grammar.c"
+#line 1979 "beancount/parser/grammar.c"
     break;
 
   case 51:
-#line 474 "beancount/parser/grammar.y"
+#line 469 "beancount/parser/grammar.y"
     {
-                       CALL(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
+                       CALL(DECREF((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                             (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
                    }
-#line 1993 "beancount/parser/grammar.c"
+#line 1988 "beancount/parser/grammar.c"
     break;
 
   case 52:
-#line 479 "beancount/parser/grammar.y"
+#line 474 "beancount/parser/grammar.y"
     {
-                       CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                       CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2002 "beancount/parser/grammar.c"
+#line 1997 "beancount/parser/grammar.c"
     break;
 
   case 53:
-#line 484 "beancount/parser/grammar.y"
+#line 479 "beancount/parser/grammar.y"
     {
-                       CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                       CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2011 "beancount/parser/grammar.c"
+#line 2006 "beancount/parser/grammar.c"
     break;
 
   case 54:
-#line 490 "beancount/parser/grammar.y"
+#line 485 "beancount/parser/grammar.y"
     {
                    Py_INCREF(Py_None);
                    (yyval.pyobj) = Py_None;
                }
-#line 2020 "beancount/parser/grammar.c"
+#line 2015 "beancount/parser/grammar.c"
     break;
 
   case 55:
-#line 495 "beancount/parser/grammar.y"
+#line 490 "beancount/parser/grammar.y"
     {
-                   CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                   CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                }
-#line 2029 "beancount/parser/grammar.c"
+#line 2024 "beancount/parser/grammar.c"
     break;
 
   case 56:
-#line 501 "beancount/parser/grammar.y"
+#line 496 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
               }
-#line 2038 "beancount/parser/grammar.c"
+#line 2033 "beancount/parser/grammar.c"
     break;
 
   case 57:
-#line 506 "beancount/parser/grammar.y"
+#line 501 "beancount/parser/grammar.y"
     {
-                  CALL(DECREF1((yyvsp[0].pyobj)),
+                  CALL(DECREF((yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
               }
-#line 2047 "beancount/parser/grammar.c"
+#line 2042 "beancount/parser/grammar.c"
     break;
 
   case 58:
-#line 511 "beancount/parser/grammar.y"
+#line 506 "beancount/parser/grammar.y"
     {
-                  CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                  CALL(DECREF((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
               }
-#line 2056 "beancount/parser/grammar.c"
+#line 2051 "beancount/parser/grammar.c"
     break;
 
   case 59:
-#line 517 "beancount/parser/grammar.y"
+#line 512 "beancount/parser/grammar.y"
     {
-             CALL(DECREF1((yyvsp[-1].pyobj)),
+             CALL(DECREF((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
          }
-#line 2065 "beancount/parser/grammar.c"
+#line 2060 "beancount/parser/grammar.c"
     break;
 
   case 60:
-#line 523 "beancount/parser/grammar.y"
+#line 518 "beancount/parser/grammar.y"
     {
-           CALL(DECREF1((yyvsp[-1].pyobj)),
+           CALL(DECREF((yyvsp[-1].pyobj)),
                 (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
        }
-#line 2074 "beancount/parser/grammar.c"
+#line 2069 "beancount/parser/grammar.c"
     break;
 
   case 61:
-#line 529 "beancount/parser/grammar.y"
+#line 524 "beancount/parser/grammar.y"
     {
              /* Note: key_value is a tuple, Py_BuildValue() won't wrap it up
               * within a tuple, so expand in the method (it receives two
               * objects). See https://docs.python.org/3.4/c-api/arg.html. */
-             CALL(DECREF1((yyvsp[-1].pyobj)),
+             CALL(DECREF((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
          }
-#line 2086 "beancount/parser/grammar.c"
+#line 2081 "beancount/parser/grammar.c"
     break;
 
   case 62:
-#line 538 "beancount/parser/grammar.y"
+#line 533 "beancount/parser/grammar.y"
     {
-            CALL(DECREF1((yyvsp[-2].pyobj)),
+            CALL(DECREF((yyvsp[-2].pyobj)),
                  (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
         }
-#line 2095 "beancount/parser/grammar.c"
+#line 2090 "beancount/parser/grammar.c"
     break;
 
   case 63:
-#line 544 "beancount/parser/grammar.y"
+#line 539 "beancount/parser/grammar.y"
     {
-         CALL(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+         CALL(DECREF((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
               (yyval.pyobj), "open", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          ;
      }
-#line 2105 "beancount/parser/grammar.c"
+#line 2100 "beancount/parser/grammar.c"
     break;
 
   case 64:
-#line 551 "beancount/parser/grammar.y"
+#line 546 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2113 "beancount/parser/grammar.c"
+#line 2108 "beancount/parser/grammar.c"
     break;
 
   case 65:
-#line 555 "beancount/parser/grammar.y"
+#line 550 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2122 "beancount/parser/grammar.c"
+#line 2117 "beancount/parser/grammar.c"
     break;
 
   case 66:
-#line 561 "beancount/parser/grammar.y"
+#line 556 "beancount/parser/grammar.y"
     {
-          CALL(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+          CALL(DECREF((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "close", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2131 "beancount/parser/grammar.c"
+#line 2126 "beancount/parser/grammar.c"
     break;
 
   case 67:
-#line 567 "beancount/parser/grammar.y"
+#line 562 "beancount/parser/grammar.y"
     {
-              CALL(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+              CALL(DECREF((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                    (yyval.pyobj), "commodity", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
           }
-#line 2140 "beancount/parser/grammar.c"
+#line 2135 "beancount/parser/grammar.c"
     break;
 
   case 68:
-#line 573 "beancount/parser/grammar.y"
+#line 568 "beancount/parser/grammar.y"
     {
-        CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+        CALL(DECREF((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
              (yyval.pyobj), "pad", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
     }
-#line 2149 "beancount/parser/grammar.c"
+#line 2144 "beancount/parser/grammar.c"
     break;
 
   case 69:
-#line 579 "beancount/parser/grammar.y"
+#line 574 "beancount/parser/grammar.y"
     {
-            CALL(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
+            CALL(DECREF((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
                  (yyval.pyobj), "balance", "OOOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
         }
-#line 2158 "beancount/parser/grammar.c"
+#line 2153 "beancount/parser/grammar.c"
     break;
 
   case 70:
-#line 585 "beancount/parser/grammar.y"
+#line 580 "beancount/parser/grammar.y"
     {
-           CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+           CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                 (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
        }
-#line 2167 "beancount/parser/grammar.c"
+#line 2162 "beancount/parser/grammar.c"
     break;
 
   case 71:
-#line 591 "beancount/parser/grammar.y"
+#line 586 "beancount/parser/grammar.y"
     {
-                     CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                     CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = Py_None;
                      Py_INCREF(Py_None);
                      ;
                  }
-#line 2179 "beancount/parser/grammar.c"
+#line 2174 "beancount/parser/grammar.c"
     break;
 
   case 72:
-#line 599 "beancount/parser/grammar.y"
+#line 594 "beancount/parser/grammar.y"
     {
-                     CALL(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
+                     CALL(DECREF((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = (yyvsp[-1].pyobj);
                  }
-#line 2189 "beancount/parser/grammar.c"
+#line 2184 "beancount/parser/grammar.c"
     break;
 
   case 73:
-#line 606 "beancount/parser/grammar.y"
+#line 601 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing);
                  (yyval.pyobj) = missing;
              }
-#line 2198 "beancount/parser/grammar.c"
+#line 2193 "beancount/parser/grammar.c"
     break;
 
   case 74:
-#line 611 "beancount/parser/grammar.y"
+#line 606 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2206 "beancount/parser/grammar.c"
+#line 2201 "beancount/parser/grammar.c"
     break;
 
   case 75:
-#line 616 "beancount/parser/grammar.y"
+#line 611 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing);
                  (yyval.pyobj) = missing;
              }
-#line 2215 "beancount/parser/grammar.c"
+#line 2210 "beancount/parser/grammar.c"
     break;
 
   case 76:
-#line 621 "beancount/parser/grammar.y"
+#line 616 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2223 "beancount/parser/grammar.c"
+#line 2218 "beancount/parser/grammar.c"
     break;
 
   case 77:
-#line 626 "beancount/parser/grammar.y"
+#line 621 "beancount/parser/grammar.y"
     {
-                    CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                    CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2232 "beancount/parser/grammar.c"
+#line 2227 "beancount/parser/grammar.c"
     break;
 
   case 78:
-#line 631 "beancount/parser/grammar.y"
+#line 626 "beancount/parser/grammar.y"
     {
-                    CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                    CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2241 "beancount/parser/grammar.c"
+#line 2236 "beancount/parser/grammar.c"
     break;
 
   case 79:
-#line 636 "beancount/parser/grammar.y"
+#line 631 "beancount/parser/grammar.y"
     {
-                    CALL(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                    CALL(DECREF((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                     ;
                 }
-#line 2251 "beancount/parser/grammar.c"
+#line 2246 "beancount/parser/grammar.c"
     break;
 
   case 80:
-#line 643 "beancount/parser/grammar.y"
+#line 638 "beancount/parser/grammar.y"
     {
-                      CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                      CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                  }
-#line 2260 "beancount/parser/grammar.c"
+#line 2255 "beancount/parser/grammar.c"
     break;
 
   case 81:
-#line 649 "beancount/parser/grammar.y"
+#line 644 "beancount/parser/grammar.y"
     {
-              CALL(DECREF1((yyvsp[-1].pyobj)),
+              CALL(DECREF((yyvsp[-1].pyobj)),
                    (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
           }
-#line 2269 "beancount/parser/grammar.c"
+#line 2264 "beancount/parser/grammar.c"
     break;
 
   case 82:
-#line 654 "beancount/parser/grammar.y"
+#line 649 "beancount/parser/grammar.y"
     {
-              CALL(DECREF1((yyvsp[-1].pyobj)),
+              CALL(DECREF((yyvsp[-1].pyobj)),
                    (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
           }
-#line 2278 "beancount/parser/grammar.c"
+#line 2273 "beancount/parser/grammar.c"
     break;
 
   case 83:
-#line 659 "beancount/parser/grammar.y"
+#line 654 "beancount/parser/grammar.y"
     {
               Py_INCREF(Py_None);
               (yyval.pyobj) = Py_None;
           }
-#line 2287 "beancount/parser/grammar.c"
+#line 2282 "beancount/parser/grammar.c"
     break;
 
   case 84:
-#line 665 "beancount/parser/grammar.y"
+#line 660 "beancount/parser/grammar.y"
     {
                    /* We indicate that there was a cost if there */
                    (yyval.pyobj) = PyList_New(0);
                }
-#line 2296 "beancount/parser/grammar.c"
+#line 2291 "beancount/parser/grammar.c"
     break;
 
   case 85:
-#line 670 "beancount/parser/grammar.y"
+#line 665 "beancount/parser/grammar.y"
     {
-                   CALL(DECREF1((yyvsp[0].pyobj)),
+                   CALL(DECREF((yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
                }
-#line 2305 "beancount/parser/grammar.c"
+#line 2300 "beancount/parser/grammar.c"
     break;
 
   case 86:
-#line 675 "beancount/parser/grammar.y"
+#line 670 "beancount/parser/grammar.y"
     {
-                   CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                   CALL(DECREF((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                }
-#line 2314 "beancount/parser/grammar.c"
+#line 2309 "beancount/parser/grammar.c"
     break;
 
   case 87:
-#line 681 "beancount/parser/grammar.y"
+#line 676 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2322 "beancount/parser/grammar.c"
+#line 2317 "beancount/parser/grammar.c"
     break;
 
   case 88:
-#line 685 "beancount/parser/grammar.y"
+#line 680 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2330 "beancount/parser/grammar.c"
+#line 2325 "beancount/parser/grammar.c"
     break;
 
   case 89:
-#line 689 "beancount/parser/grammar.y"
+#line 684 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2338 "beancount/parser/grammar.c"
+#line 2333 "beancount/parser/grammar.c"
     break;
 
   case 90:
-#line 693 "beancount/parser/grammar.y"
+#line 688 "beancount/parser/grammar.y"
     {
               CALL(,
                    (yyval.pyobj), "cost_merge", "O", Py_None);
           }
-#line 2347 "beancount/parser/grammar.c"
+#line 2342 "beancount/parser/grammar.c"
     break;
 
   case 91:
-#line 700 "beancount/parser/grammar.y"
+#line 695 "beancount/parser/grammar.y"
     {
-          CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+          CALL(DECREF((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "price", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2356 "beancount/parser/grammar.c"
+#line 2351 "beancount/parser/grammar.c"
     break;
 
   case 92:
-#line 706 "beancount/parser/grammar.y"
+#line 701 "beancount/parser/grammar.y"
     {
-          CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+          CALL(DECREF((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "event", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2365 "beancount/parser/grammar.c"
+#line 2360 "beancount/parser/grammar.c"
     break;
 
   case 93:
-#line 712 "beancount/parser/grammar.y"
+#line 707 "beancount/parser/grammar.y"
     {
-             CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+             CALL(DECREF((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "query", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2374 "beancount/parser/grammar.c"
+#line 2369 "beancount/parser/grammar.c"
     break;
 
   case 94:
-#line 718 "beancount/parser/grammar.y"
+#line 713 "beancount/parser/grammar.y"
     {
-          CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+          CALL(DECREF((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "note", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2383 "beancount/parser/grammar.c"
+#line 2378 "beancount/parser/grammar.c"
     break;
 
   case 96:
-#line 726 "beancount/parser/grammar.y"
+#line 721 "beancount/parser/grammar.y"
     {
-             CALL(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+             CALL(DECREF((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "document", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2392 "beancount/parser/grammar.c"
+#line 2387 "beancount/parser/grammar.c"
     break;
 
   case 97:
-#line 733 "beancount/parser/grammar.y"
+#line 728 "beancount/parser/grammar.y"
     {
-                 CALL(DECREF1((yyvsp[0].pyobj)),
+                 CALL(DECREF((yyvsp[0].pyobj)),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2401 "beancount/parser/grammar.c"
+#line 2396 "beancount/parser/grammar.c"
     break;
 
   case 98:
-#line 738 "beancount/parser/grammar.y"
+#line 733 "beancount/parser/grammar.y"
     {
-                 CALL(DECREF1((yyvsp[0].pyobj)),
+                 CALL(DECREF((yyvsp[0].pyobj)),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2410 "beancount/parser/grammar.c"
+#line 2405 "beancount/parser/grammar.c"
     break;
 
   case 99:
-#line 743 "beancount/parser/grammar.y"
+#line 738 "beancount/parser/grammar.y"
     {
-                 CALL(DECREF1((yyvsp[0].pyobj)),
+                 CALL(DECREF((yyvsp[0].pyobj)),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2419 "beancount/parser/grammar.c"
+#line 2414 "beancount/parser/grammar.c"
     break;
 
   case 100:
-#line 748 "beancount/parser/grammar.y"
+#line 743 "beancount/parser/grammar.y"
     {
-                 CALL(DECREF1((yyvsp[0].pyobj)),
+                 CALL(DECREF((yyvsp[0].pyobj)),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2428 "beancount/parser/grammar.c"
+#line 2423 "beancount/parser/grammar.c"
     break;
 
   case 101:
-#line 753 "beancount/parser/grammar.y"
+#line 748 "beancount/parser/grammar.y"
     {
-                 CALL(DECREF1((yyvsp[0].pyobj)),
+                 CALL(DECREF((yyvsp[0].pyobj)),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2437 "beancount/parser/grammar.c"
+#line 2432 "beancount/parser/grammar.c"
     break;
 
   case 102:
-#line 758 "beancount/parser/grammar.y"
+#line 753 "beancount/parser/grammar.y"
     {
                  /* Obtain beancount.core.account.TYPE */
                  PyObject* module = PyImport_ImportModule("beancount.core.account");
                  PyObject* dtype = PyObject_GetAttrString(module, "TYPE");
                  Py_DECREF(module);
-                 CALL(DECREF2((yyvsp[0].pyobj), dtype),
+                 CALL(DECREF((yyvsp[0].pyobj), dtype),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
              }
-#line 2450 "beancount/parser/grammar.c"
+#line 2445 "beancount/parser/grammar.c"
     break;
 
   case 103:
-#line 768 "beancount/parser/grammar.y"
+#line 763 "beancount/parser/grammar.y"
     {
                       Py_INCREF(Py_None);
                       (yyval.pyobj) = Py_None;
                   }
-#line 2459 "beancount/parser/grammar.c"
+#line 2454 "beancount/parser/grammar.c"
     break;
 
   case 104:
-#line 773 "beancount/parser/grammar.y"
+#line 768 "beancount/parser/grammar.y"
     {
-                      CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                      CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                   }
-#line 2468 "beancount/parser/grammar.c"
+#line 2463 "beancount/parser/grammar.c"
     break;
 
   case 105:
-#line 779 "beancount/parser/grammar.y"
+#line 774 "beancount/parser/grammar.y"
     {
-           CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+           CALL(DECREF((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                 (yyval.pyobj), "custom", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
        }
-#line 2477 "beancount/parser/grammar.c"
+#line 2472 "beancount/parser/grammar.c"
     break;
 
   case 117:
-#line 797 "beancount/parser/grammar.y"
+#line 792 "beancount/parser/grammar.y"
     {
           (yyval.pyobj) = (yyvsp[0].pyobj);
       }
-#line 2485 "beancount/parser/grammar.c"
+#line 2480 "beancount/parser/grammar.c"
     break;
 
   case 118:
-#line 802 "beancount/parser/grammar.y"
+#line 797 "beancount/parser/grammar.y"
     {
-           CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
+           CALL(DECREF((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                 (yyval.pyobj), "option", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2494 "beancount/parser/grammar.c"
+#line 2489 "beancount/parser/grammar.c"
     break;
 
   case 119:
-#line 808 "beancount/parser/grammar.y"
+#line 803 "beancount/parser/grammar.y"
     {
-           CALL(DECREF1((yyvsp[-1].pyobj)),
+           CALL(DECREF((yyvsp[-1].pyobj)),
                 (yyval.pyobj), "include", "O", (yyvsp[-1].pyobj));
        }
-#line 2503 "beancount/parser/grammar.c"
+#line 2498 "beancount/parser/grammar.c"
     break;
 
   case 120:
-#line 814 "beancount/parser/grammar.y"
+#line 809 "beancount/parser/grammar.y"
     {
-           CALL(DECREF1((yyvsp[-1].pyobj)),
+           CALL(DECREF((yyvsp[-1].pyobj)),
                 (yyval.pyobj), "plugin", "OO", (yyvsp[-1].pyobj), Py_None);
        }
-#line 2512 "beancount/parser/grammar.c"
+#line 2507 "beancount/parser/grammar.c"
     break;
 
   case 121:
-#line 819 "beancount/parser/grammar.y"
+#line 814 "beancount/parser/grammar.y"
     {
-           CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
+           CALL(DECREF((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                 (yyval.pyobj), "plugin", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2521 "beancount/parser/grammar.c"
+#line 2516 "beancount/parser/grammar.c"
     break;
 
   case 130:
-#line 835 "beancount/parser/grammar.y"
+#line 830 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2529 "beancount/parser/grammar.c"
+#line 2524 "beancount/parser/grammar.c"
     break;
 
   case 131:
-#line 839 "beancount/parser/grammar.y"
+#line 834 "beancount/parser/grammar.y"
     {
-                 CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                 CALL(DECREF((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
              }
-#line 2538 "beancount/parser/grammar.c"
+#line 2533 "beancount/parser/grammar.c"
     break;
 
   case 132:
-#line 844 "beancount/parser/grammar.y"
+#line 839 "beancount/parser/grammar.y"
     {
                  /*
                   * Ignore the error and continue reducing ({3d95e55b654e}).
@@ -2556,20 +2551,20 @@ yyreduce:
                   */
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2560 "beancount/parser/grammar.c"
+#line 2555 "beancount/parser/grammar.c"
     break;
 
   case 133:
-#line 862 "beancount/parser/grammar.y"
+#line 857 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
              }
-#line 2569 "beancount/parser/grammar.c"
+#line 2564 "beancount/parser/grammar.c"
     break;
 
   case 134:
-#line 869 "beancount/parser/grammar.y"
+#line 864 "beancount/parser/grammar.y"
     {
          /* If a Python exception has been raised and not handled, abort. In
           * case of unrecoverable error, the lexer raises a Python exception and
@@ -2578,14 +2573,14 @@ yyreduce:
          if (PyErr_Occurred()) {
              YYABORT;
          }
-         CALL(DECREF1((yyvsp[0].pyobj)),
+         CALL(DECREF((yyvsp[0].pyobj)),
               (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2585 "beancount/parser/grammar.c"
+#line 2580 "beancount/parser/grammar.c"
     break;
 
 
-#line 2589 "beancount/parser/grammar.c"
+#line 2584 "beancount/parser/grammar.c"
 
       default: break;
     }
@@ -2823,7 +2818,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 884 "beancount/parser/grammar.y"
+#line 879 "beancount/parser/grammar.y"
 
 
 /* Get a printable version of a token name. */

--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -72,6 +72,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include "parser.h"
+#include "grammar.h"
 #include "lexer.h"
 
 extern YY_DECL;
@@ -89,11 +90,7 @@ extern YY_DECL;
         YYERROR;                                                                \
     }
 
-
-/* First line of reported file/line string. This is used as #line. */
-int yy_firstline;
-
-#define FILE_LINE_ARGS  yy_filename, ((yyloc).first_line + yy_firstline)
+#define FILE_LINE_ARGS  yyget_filename(scanner), ((yyloc).first_line + yyget_firstline(scanner))
 
 
 /* Build a grammar error from the exception context. */
@@ -114,7 +111,8 @@ void build_grammar_error_from_exception(yyscan_t scanner)
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "siOOO",
-                                           yy_filename, yyget_lineno(scanner) + yy_firstline,
+                                           yyget_filename(scanner),
+                                           yyget_lineno(scanner) + yyget_firstline(scanner),
                                            pvalue, ptype, ptraceback ?: Py_None);
         if (rv == NULL) {
             /* Note: Leave the internal error trickling up its detail. */
@@ -144,7 +142,8 @@ void yyerror(YYLTYPE *locp, yyscan_t scanner, char const* message)
     else {
         /* Register a syntax error with the builder. */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "sis",
-                                           yy_filename, yyget_lineno(scanner) + yy_firstline,
+                                           yyget_filename(scanner),
+                                           yyget_lineno(scanner) + yyget_firstline(scanner),
                                            message);
         if (rv == NULL) {
             PyErr_SetString(PyExc_RuntimeError,
@@ -167,7 +166,7 @@ const char* getTokenName(int token);
 #define DECREF6(x1, x2, x3, x4, x5, x6)    DECREF5(x1, x2, x3, x4, x5); Py_DECREF(x6);
 
 
-#line 171 "beancount/parser/grammar.c"
+#line 170 "beancount/parser/grammar.c"
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus
@@ -267,7 +266,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 125 "beancount/parser/grammar.y"
+#line 124 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -277,7 +276,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 281 "beancount/parser/grammar.c"
+#line 280 "beancount/parser/grammar.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -603,20 +602,20 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   259,   259,   262,   266,   270,   274,   279,   280,   284,
-     285,   286,   287,   293,   297,   302,   307,   312,   317,   322,
-     326,   331,   336,   341,   348,   356,   361,   367,   373,   377,
-     381,   385,   387,   392,   397,   402,   407,   413,   419,   424,
-     425,   426,   427,   428,   429,   430,   431,   432,   436,   442,
-     447,   451,   456,   461,   467,   472,   478,   483,   488,   494,
-     500,   506,   515,   521,   528,   532,   538,   544,   550,   556,
-     562,   568,   576,   583,   588,   593,   598,   603,   608,   613,
-     620,   626,   631,   636,   642,   647,   652,   658,   662,   666,
-     670,   677,   683,   689,   695,   701,   703,   710,   715,   720,
-     725,   730,   735,   745,   750,   756,   763,   764,   765,   766,
-     767,   768,   769,   770,   771,   772,   773,   774,   779,   785,
-     791,   796,   802,   803,   804,   805,   806,   807,   808,   809,
-     812,   816,   821,   839,   846
+       0,   258,   258,   261,   265,   269,   273,   278,   279,   283,
+     284,   285,   286,   292,   296,   301,   306,   311,   316,   321,
+     325,   330,   335,   340,   347,   355,   360,   366,   372,   376,
+     380,   384,   386,   391,   396,   401,   406,   412,   418,   423,
+     424,   425,   426,   427,   428,   429,   430,   431,   435,   441,
+     446,   450,   455,   460,   466,   471,   477,   482,   487,   493,
+     499,   505,   514,   520,   527,   531,   537,   543,   549,   555,
+     561,   567,   575,   582,   587,   592,   597,   602,   607,   612,
+     619,   625,   630,   635,   641,   646,   651,   657,   661,   665,
+     669,   676,   682,   688,   694,   700,   702,   709,   714,   719,
+     724,   729,   734,   744,   749,   755,   762,   763,   764,   765,
+     766,   767,   768,   769,   770,   771,   772,   773,   778,   784,
+     790,   795,   801,   802,   803,   804,   805,   806,   807,   808,
+     811,   815,   820,   838,   845
 };
 #endif
 
@@ -1673,136 +1672,136 @@ yyreduce:
   switch (yyn)
     {
   case 3:
-#line 263 "beancount/parser/grammar.y"
+#line 262 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1681 "beancount/parser/grammar.c"
+#line 1680 "beancount/parser/grammar.c"
     break;
 
   case 4:
-#line 267 "beancount/parser/grammar.y"
+#line 266 "beancount/parser/grammar.y"
     {
         (yyval.character) = (yyvsp[0].character);
     }
-#line 1689 "beancount/parser/grammar.c"
+#line 1688 "beancount/parser/grammar.c"
     break;
 
   case 5:
-#line 271 "beancount/parser/grammar.y"
+#line 270 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1697 "beancount/parser/grammar.c"
+#line 1696 "beancount/parser/grammar.c"
     break;
 
   case 6:
-#line 275 "beancount/parser/grammar.y"
+#line 274 "beancount/parser/grammar.y"
     {
         (yyval.character) = '#';
     }
-#line 1705 "beancount/parser/grammar.c"
+#line 1704 "beancount/parser/grammar.c"
     break;
 
   case 13:
-#line 294 "beancount/parser/grammar.y"
+#line 293 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1713 "beancount/parser/grammar.c"
+#line 1712 "beancount/parser/grammar.c"
     break;
 
   case 14:
-#line 298 "beancount/parser/grammar.y"
+#line 297 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Add((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1722 "beancount/parser/grammar.c"
+#line 1721 "beancount/parser/grammar.c"
     break;
 
   case 15:
-#line 303 "beancount/parser/grammar.y"
+#line 302 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Subtract((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1731 "beancount/parser/grammar.c"
+#line 1730 "beancount/parser/grammar.c"
     break;
 
   case 16:
-#line 308 "beancount/parser/grammar.y"
+#line 307 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Multiply((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1740 "beancount/parser/grammar.c"
+#line 1739 "beancount/parser/grammar.c"
     break;
 
   case 17:
-#line 313 "beancount/parser/grammar.y"
+#line 312 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_TrueDivide((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1749 "beancount/parser/grammar.c"
+#line 1748 "beancount/parser/grammar.c"
     break;
 
   case 18:
-#line 318 "beancount/parser/grammar.y"
+#line 317 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Negative((yyvsp[0].pyobj));
                 DECREF1((yyvsp[0].pyobj));
             }
-#line 1758 "beancount/parser/grammar.c"
+#line 1757 "beancount/parser/grammar.c"
     break;
 
   case 19:
-#line 323 "beancount/parser/grammar.y"
+#line 322 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1766 "beancount/parser/grammar.c"
+#line 1765 "beancount/parser/grammar.c"
     break;
 
   case 20:
-#line 327 "beancount/parser/grammar.y"
+#line 326 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1774 "beancount/parser/grammar.c"
+#line 1773 "beancount/parser/grammar.c"
     break;
 
   case 21:
-#line 332 "beancount/parser/grammar.y"
+#line 331 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 1783 "beancount/parser/grammar.c"
+#line 1782 "beancount/parser/grammar.c"
     break;
 
   case 22:
-#line 337 "beancount/parser/grammar.y"
+#line 336 "beancount/parser/grammar.y"
     {
                 BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
             }
-#line 1792 "beancount/parser/grammar.c"
+#line 1791 "beancount/parser/grammar.c"
     break;
 
   case 23:
-#line 342 "beancount/parser/grammar.y"
+#line 341 "beancount/parser/grammar.y"
     {
                 BUILDY(,
                        (yyval.pyobj), "pipe_deprecated_error", "si", FILE_LINE_ARGS);
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1802 "beancount/parser/grammar.c"
+#line 1801 "beancount/parser/grammar.c"
     break;
 
   case 24:
-#line 349 "beancount/parser/grammar.y"
+#line 348 "beancount/parser/grammar.y"
     {
                /* Note: We're passing a bogus value here in order to avoid
                 * having to declare a second macro just for this one special
@@ -1810,247 +1809,247 @@ yyreduce:
                BUILDY(,
                       (yyval.pyobj), "tag_link_new", "O", Py_None);
            }
-#line 1814 "beancount/parser/grammar.c"
+#line 1813 "beancount/parser/grammar.c"
     break;
 
   case 25:
-#line 357 "beancount/parser/grammar.y"
+#line 356 "beancount/parser/grammar.y"
     {
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1823 "beancount/parser/grammar.c"
+#line 1822 "beancount/parser/grammar.c"
     break;
 
   case 26:
-#line 362 "beancount/parser/grammar.y"
+#line 361 "beancount/parser/grammar.y"
     {
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1832 "beancount/parser/grammar.c"
+#line 1831 "beancount/parser/grammar.c"
     break;
 
   case 27:
-#line 368 "beancount/parser/grammar.y"
+#line 367 "beancount/parser/grammar.y"
     {
                 BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "transaction", "siObOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1841 "beancount/parser/grammar.c"
+#line 1840 "beancount/parser/grammar.c"
     break;
 
   case 28:
-#line 374 "beancount/parser/grammar.y"
+#line 373 "beancount/parser/grammar.y"
     {
             (yyval.character) = '\0';
         }
-#line 1849 "beancount/parser/grammar.c"
+#line 1848 "beancount/parser/grammar.c"
     break;
 
   case 29:
-#line 378 "beancount/parser/grammar.y"
+#line 377 "beancount/parser/grammar.y"
     {
             (yyval.character) = '*';
         }
-#line 1857 "beancount/parser/grammar.c"
+#line 1856 "beancount/parser/grammar.c"
     break;
 
   case 30:
-#line 382 "beancount/parser/grammar.y"
+#line 381 "beancount/parser/grammar.y"
     {
             (yyval.character) = '#';
         }
-#line 1865 "beancount/parser/grammar.c"
+#line 1864 "beancount/parser/grammar.c"
     break;
 
   case 32:
-#line 388 "beancount/parser/grammar.y"
+#line 387 "beancount/parser/grammar.y"
     {
                      (yyval.pyobj) = (yyvsp[0].pyobj);
                  }
-#line 1873 "beancount/parser/grammar.c"
+#line 1872 "beancount/parser/grammar.c"
     break;
 
   case 33:
-#line 393 "beancount/parser/grammar.y"
+#line 392 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
         }
-#line 1882 "beancount/parser/grammar.c"
+#line 1881 "beancount/parser/grammar.c"
     break;
 
   case 34:
-#line 398 "beancount/parser/grammar.y"
+#line 397 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
         }
-#line 1891 "beancount/parser/grammar.c"
+#line 1890 "beancount/parser/grammar.c"
     break;
 
   case 35:
-#line 403 "beancount/parser/grammar.y"
+#line 402 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
         }
-#line 1900 "beancount/parser/grammar.c"
+#line 1899 "beancount/parser/grammar.c"
     break;
 
   case 36:
-#line 408 "beancount/parser/grammar.y"
+#line 407 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF1((yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-1].pyobj), missing_obj, Py_None, Py_None, Py_False, (yyvsp[-2].character));
         }
-#line 1909 "beancount/parser/grammar.c"
+#line 1908 "beancount/parser/grammar.c"
     break;
 
   case 37:
-#line 414 "beancount/parser/grammar.y"
+#line 413 "beancount/parser/grammar.y"
     {
               BUILDY(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
           }
-#line 1918 "beancount/parser/grammar.c"
+#line 1917 "beancount/parser/grammar.c"
     break;
 
   case 38:
-#line 420 "beancount/parser/grammar.y"
+#line 419 "beancount/parser/grammar.y"
     {
                    (yyval.pyobj) = (yyvsp[-1].pyobj);
                }
-#line 1926 "beancount/parser/grammar.c"
+#line 1925 "beancount/parser/grammar.c"
     break;
 
   case 47:
-#line 433 "beancount/parser/grammar.y"
+#line 432 "beancount/parser/grammar.y"
     {
                     (yyval.pyobj) = (yyvsp[0].pyobj);
                 }
-#line 1934 "beancount/parser/grammar.c"
+#line 1933 "beancount/parser/grammar.c"
     break;
 
   case 48:
-#line 437 "beancount/parser/grammar.y"
+#line 436 "beancount/parser/grammar.y"
     {
                     Py_INCREF(Py_None);
                     (yyval.pyobj) = Py_None;
                 }
-#line 1943 "beancount/parser/grammar.c"
+#line 1942 "beancount/parser/grammar.c"
     break;
 
   case 49:
-#line 443 "beancount/parser/grammar.y"
+#line 442 "beancount/parser/grammar.y"
     {
                        Py_INCREF(Py_None);
                        (yyval.pyobj) = Py_None;
                    }
-#line 1952 "beancount/parser/grammar.c"
+#line 1951 "beancount/parser/grammar.c"
     break;
 
   case 50:
-#line 448 "beancount/parser/grammar.y"
+#line 447 "beancount/parser/grammar.y"
     {
                        (yyval.pyobj) = (yyvsp[-3].pyobj);
                    }
-#line 1960 "beancount/parser/grammar.c"
+#line 1959 "beancount/parser/grammar.c"
     break;
 
   case 51:
-#line 452 "beancount/parser/grammar.y"
+#line 451 "beancount/parser/grammar.y"
     {
                        BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
                    }
-#line 1969 "beancount/parser/grammar.c"
+#line 1968 "beancount/parser/grammar.c"
     break;
 
   case 52:
-#line 457 "beancount/parser/grammar.y"
+#line 456 "beancount/parser/grammar.y"
     {
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 1978 "beancount/parser/grammar.c"
+#line 1977 "beancount/parser/grammar.c"
     break;
 
   case 53:
-#line 462 "beancount/parser/grammar.y"
+#line 461 "beancount/parser/grammar.y"
     {
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 1987 "beancount/parser/grammar.c"
+#line 1986 "beancount/parser/grammar.c"
     break;
 
   case 54:
-#line 468 "beancount/parser/grammar.y"
+#line 467 "beancount/parser/grammar.y"
     {
                    Py_INCREF(Py_None);
                    (yyval.pyobj) = Py_None;
                }
-#line 1996 "beancount/parser/grammar.c"
+#line 1995 "beancount/parser/grammar.c"
     break;
 
   case 55:
-#line 473 "beancount/parser/grammar.y"
+#line 472 "beancount/parser/grammar.y"
     {
                    BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                }
-#line 2005 "beancount/parser/grammar.c"
+#line 2004 "beancount/parser/grammar.c"
     break;
 
   case 56:
-#line 479 "beancount/parser/grammar.y"
+#line 478 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
               }
-#line 2014 "beancount/parser/grammar.c"
+#line 2013 "beancount/parser/grammar.c"
     break;
 
   case 57:
-#line 484 "beancount/parser/grammar.y"
+#line 483 "beancount/parser/grammar.y"
     {
                   BUILDY(DECREF1((yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
               }
-#line 2023 "beancount/parser/grammar.c"
+#line 2022 "beancount/parser/grammar.c"
     break;
 
   case 58:
-#line 489 "beancount/parser/grammar.y"
+#line 488 "beancount/parser/grammar.y"
     {
                   BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
               }
-#line 2032 "beancount/parser/grammar.c"
+#line 2031 "beancount/parser/grammar.c"
     break;
 
   case 59:
-#line 495 "beancount/parser/grammar.y"
+#line 494 "beancount/parser/grammar.y"
     {
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
          }
-#line 2041 "beancount/parser/grammar.c"
+#line 2040 "beancount/parser/grammar.c"
     break;
 
   case 60:
-#line 501 "beancount/parser/grammar.y"
+#line 500 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
        }
-#line 2050 "beancount/parser/grammar.c"
+#line 2049 "beancount/parser/grammar.c"
     break;
 
   case 61:
-#line 507 "beancount/parser/grammar.y"
+#line 506 "beancount/parser/grammar.y"
     {
              /* Note: key_value is a tuple, Py_BuildValue() won't wrap it up
               * within a tuple, so expand in the method (it receives two
@@ -2058,92 +2057,92 @@ yyreduce:
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
          }
-#line 2062 "beancount/parser/grammar.c"
+#line 2061 "beancount/parser/grammar.c"
     break;
 
   case 62:
-#line 516 "beancount/parser/grammar.y"
+#line 515 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF1((yyvsp[-2].pyobj)),
                    (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
         }
-#line 2071 "beancount/parser/grammar.c"
+#line 2070 "beancount/parser/grammar.c"
     break;
 
   case 63:
-#line 522 "beancount/parser/grammar.y"
+#line 521 "beancount/parser/grammar.y"
     {
          BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                 (yyval.pyobj), "open", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          ;
      }
-#line 2081 "beancount/parser/grammar.c"
+#line 2080 "beancount/parser/grammar.c"
     break;
 
   case 64:
-#line 529 "beancount/parser/grammar.y"
+#line 528 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2089 "beancount/parser/grammar.c"
+#line 2088 "beancount/parser/grammar.c"
     break;
 
   case 65:
-#line 533 "beancount/parser/grammar.y"
+#line 532 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2098 "beancount/parser/grammar.c"
+#line 2097 "beancount/parser/grammar.c"
     break;
 
   case 66:
-#line 539 "beancount/parser/grammar.y"
+#line 538 "beancount/parser/grammar.y"
     {
           BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "close", "siOOO", FILE_LINE_ARGS, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2107 "beancount/parser/grammar.c"
+#line 2106 "beancount/parser/grammar.c"
     break;
 
   case 67:
-#line 545 "beancount/parser/grammar.y"
+#line 544 "beancount/parser/grammar.y"
     {
               BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "commodity", "siOOO", FILE_LINE_ARGS, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
           }
-#line 2116 "beancount/parser/grammar.c"
+#line 2115 "beancount/parser/grammar.c"
     break;
 
   case 68:
-#line 551 "beancount/parser/grammar.y"
+#line 550 "beancount/parser/grammar.y"
     {
         BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "pad", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
     }
-#line 2125 "beancount/parser/grammar.c"
+#line 2124 "beancount/parser/grammar.c"
     break;
 
   case 69:
-#line 557 "beancount/parser/grammar.y"
+#line 556 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
                    (yyval.pyobj), "balance", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
         }
-#line 2134 "beancount/parser/grammar.c"
+#line 2133 "beancount/parser/grammar.c"
     break;
 
   case 70:
-#line 563 "beancount/parser/grammar.y"
+#line 562 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
        }
-#line 2143 "beancount/parser/grammar.c"
+#line 2142 "beancount/parser/grammar.c"
     break;
 
   case 71:
-#line 569 "beancount/parser/grammar.y"
+#line 568 "beancount/parser/grammar.y"
     {
                      BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
@@ -2151,269 +2150,269 @@ yyreduce:
                      Py_INCREF(Py_None);
                      ;
                  }
-#line 2155 "beancount/parser/grammar.c"
+#line 2154 "beancount/parser/grammar.c"
     break;
 
   case 72:
-#line 577 "beancount/parser/grammar.y"
+#line 576 "beancount/parser/grammar.y"
     {
                      BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = (yyvsp[-1].pyobj);
                  }
-#line 2165 "beancount/parser/grammar.c"
+#line 2164 "beancount/parser/grammar.c"
     break;
 
   case 73:
-#line 584 "beancount/parser/grammar.y"
+#line 583 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2174 "beancount/parser/grammar.c"
+#line 2173 "beancount/parser/grammar.c"
     break;
 
   case 74:
-#line 589 "beancount/parser/grammar.y"
+#line 588 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2182 "beancount/parser/grammar.c"
+#line 2181 "beancount/parser/grammar.c"
     break;
 
   case 75:
-#line 594 "beancount/parser/grammar.y"
+#line 593 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2191 "beancount/parser/grammar.c"
+#line 2190 "beancount/parser/grammar.c"
     break;
 
   case 76:
-#line 599 "beancount/parser/grammar.y"
+#line 598 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2199 "beancount/parser/grammar.c"
+#line 2198 "beancount/parser/grammar.c"
     break;
 
   case 77:
-#line 604 "beancount/parser/grammar.y"
+#line 603 "beancount/parser/grammar.y"
     {
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2208 "beancount/parser/grammar.c"
+#line 2207 "beancount/parser/grammar.c"
     break;
 
   case 78:
-#line 609 "beancount/parser/grammar.y"
+#line 608 "beancount/parser/grammar.y"
     {
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2217 "beancount/parser/grammar.c"
+#line 2216 "beancount/parser/grammar.c"
     break;
 
   case 79:
-#line 614 "beancount/parser/grammar.y"
+#line 613 "beancount/parser/grammar.y"
     {
                     BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                     ;
                 }
-#line 2227 "beancount/parser/grammar.c"
+#line 2226 "beancount/parser/grammar.c"
     break;
 
   case 80:
-#line 621 "beancount/parser/grammar.y"
+#line 620 "beancount/parser/grammar.y"
     {
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                  }
-#line 2236 "beancount/parser/grammar.c"
+#line 2235 "beancount/parser/grammar.c"
     break;
 
   case 81:
-#line 627 "beancount/parser/grammar.y"
+#line 626 "beancount/parser/grammar.y"
     {
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
           }
-#line 2245 "beancount/parser/grammar.c"
+#line 2244 "beancount/parser/grammar.c"
     break;
 
   case 82:
-#line 632 "beancount/parser/grammar.y"
+#line 631 "beancount/parser/grammar.y"
     {
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
           }
-#line 2254 "beancount/parser/grammar.c"
+#line 2253 "beancount/parser/grammar.c"
     break;
 
   case 83:
-#line 637 "beancount/parser/grammar.y"
+#line 636 "beancount/parser/grammar.y"
     {
               Py_INCREF(Py_None);
               (yyval.pyobj) = Py_None;
           }
-#line 2263 "beancount/parser/grammar.c"
+#line 2262 "beancount/parser/grammar.c"
     break;
 
   case 84:
-#line 643 "beancount/parser/grammar.y"
+#line 642 "beancount/parser/grammar.y"
     {
                    /* We indicate that there was a cost if there */
                    (yyval.pyobj) = PyList_New(0);
                }
-#line 2272 "beancount/parser/grammar.c"
+#line 2271 "beancount/parser/grammar.c"
     break;
 
   case 85:
-#line 648 "beancount/parser/grammar.y"
+#line 647 "beancount/parser/grammar.y"
     {
                    BUILDY(DECREF1((yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
                }
-#line 2281 "beancount/parser/grammar.c"
+#line 2280 "beancount/parser/grammar.c"
     break;
 
   case 86:
-#line 653 "beancount/parser/grammar.y"
+#line 652 "beancount/parser/grammar.y"
     {
                    BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                }
-#line 2290 "beancount/parser/grammar.c"
+#line 2289 "beancount/parser/grammar.c"
     break;
 
   case 87:
-#line 659 "beancount/parser/grammar.y"
+#line 658 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2298 "beancount/parser/grammar.c"
+#line 2297 "beancount/parser/grammar.c"
     break;
 
   case 88:
-#line 663 "beancount/parser/grammar.y"
+#line 662 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2306 "beancount/parser/grammar.c"
+#line 2305 "beancount/parser/grammar.c"
     break;
 
   case 89:
-#line 667 "beancount/parser/grammar.y"
+#line 666 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2314 "beancount/parser/grammar.c"
+#line 2313 "beancount/parser/grammar.c"
     break;
 
   case 90:
-#line 671 "beancount/parser/grammar.y"
+#line 670 "beancount/parser/grammar.y"
     {
               BUILDY(,
                      (yyval.pyobj), "cost_merge", "O", Py_None);
           }
-#line 2323 "beancount/parser/grammar.c"
+#line 2322 "beancount/parser/grammar.c"
     break;
 
   case 91:
-#line 678 "beancount/parser/grammar.y"
+#line 677 "beancount/parser/grammar.y"
     {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "price", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2332 "beancount/parser/grammar.c"
+#line 2331 "beancount/parser/grammar.c"
     break;
 
   case 92:
-#line 684 "beancount/parser/grammar.y"
+#line 683 "beancount/parser/grammar.y"
     {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "event", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2341 "beancount/parser/grammar.c"
+#line 2340 "beancount/parser/grammar.c"
     break;
 
   case 93:
-#line 690 "beancount/parser/grammar.y"
+#line 689 "beancount/parser/grammar.y"
     {
              BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "query", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2350 "beancount/parser/grammar.c"
+#line 2349 "beancount/parser/grammar.c"
     break;
 
   case 94:
-#line 696 "beancount/parser/grammar.y"
+#line 695 "beancount/parser/grammar.y"
     {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "note", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2359 "beancount/parser/grammar.c"
+#line 2358 "beancount/parser/grammar.c"
     break;
 
   case 96:
-#line 704 "beancount/parser/grammar.y"
+#line 703 "beancount/parser/grammar.y"
     {
              BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "document", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2368 "beancount/parser/grammar.c"
+#line 2367 "beancount/parser/grammar.c"
     break;
 
   case 97:
-#line 711 "beancount/parser/grammar.y"
+#line 710 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2377 "beancount/parser/grammar.c"
+#line 2376 "beancount/parser/grammar.c"
     break;
 
   case 98:
-#line 716 "beancount/parser/grammar.y"
+#line 715 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2386 "beancount/parser/grammar.c"
+#line 2385 "beancount/parser/grammar.c"
     break;
 
   case 99:
-#line 721 "beancount/parser/grammar.y"
+#line 720 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2395 "beancount/parser/grammar.c"
+#line 2394 "beancount/parser/grammar.c"
     break;
 
   case 100:
-#line 726 "beancount/parser/grammar.y"
+#line 725 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2404 "beancount/parser/grammar.c"
+#line 2403 "beancount/parser/grammar.c"
     break;
 
   case 101:
-#line 731 "beancount/parser/grammar.y"
+#line 730 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2413 "beancount/parser/grammar.c"
+#line 2412 "beancount/parser/grammar.c"
     break;
 
   case 102:
-#line 736 "beancount/parser/grammar.y"
+#line 735 "beancount/parser/grammar.y"
     {
                  /* Obtain beancount.core.account.TYPE */
                  PyObject* module = PyImport_ImportModule("beancount.core.account");
@@ -2422,99 +2421,99 @@ yyreduce:
                  BUILDY(DECREF2((yyvsp[0].pyobj), dtype),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
              }
-#line 2426 "beancount/parser/grammar.c"
+#line 2425 "beancount/parser/grammar.c"
     break;
 
   case 103:
-#line 746 "beancount/parser/grammar.y"
+#line 745 "beancount/parser/grammar.y"
     {
                       Py_INCREF(Py_None);
                       (yyval.pyobj) = Py_None;
                   }
-#line 2435 "beancount/parser/grammar.c"
+#line 2434 "beancount/parser/grammar.c"
     break;
 
   case 104:
-#line 751 "beancount/parser/grammar.y"
+#line 750 "beancount/parser/grammar.y"
     {
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                   }
-#line 2444 "beancount/parser/grammar.c"
+#line 2443 "beancount/parser/grammar.c"
     break;
 
   case 105:
-#line 757 "beancount/parser/grammar.y"
+#line 756 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "custom", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
        }
-#line 2453 "beancount/parser/grammar.c"
+#line 2452 "beancount/parser/grammar.c"
     break;
 
   case 117:
-#line 775 "beancount/parser/grammar.y"
+#line 774 "beancount/parser/grammar.y"
     {
           (yyval.pyobj) = (yyvsp[0].pyobj);
       }
-#line 2461 "beancount/parser/grammar.c"
+#line 2460 "beancount/parser/grammar.c"
     break;
 
   case 118:
-#line 780 "beancount/parser/grammar.y"
+#line 779 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "option", "siOO", FILE_LINE_ARGS, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2470 "beancount/parser/grammar.c"
+#line 2469 "beancount/parser/grammar.c"
     break;
 
   case 119:
-#line 786 "beancount/parser/grammar.y"
+#line 785 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "include", "siO", FILE_LINE_ARGS, (yyvsp[-1].pyobj));
        }
-#line 2479 "beancount/parser/grammar.c"
+#line 2478 "beancount/parser/grammar.c"
     break;
 
   case 120:
-#line 792 "beancount/parser/grammar.y"
+#line 791 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "siOO", FILE_LINE_ARGS, (yyvsp[-1].pyobj), Py_None);
        }
-#line 2488 "beancount/parser/grammar.c"
+#line 2487 "beancount/parser/grammar.c"
     break;
 
   case 121:
-#line 797 "beancount/parser/grammar.y"
+#line 796 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "siOO", FILE_LINE_ARGS, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2497 "beancount/parser/grammar.c"
+#line 2496 "beancount/parser/grammar.c"
     break;
 
   case 130:
-#line 813 "beancount/parser/grammar.y"
+#line 812 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2505 "beancount/parser/grammar.c"
+#line 2504 "beancount/parser/grammar.c"
     break;
 
   case 131:
-#line 817 "beancount/parser/grammar.y"
+#line 816 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
              }
-#line 2514 "beancount/parser/grammar.c"
+#line 2513 "beancount/parser/grammar.c"
     break;
 
   case 132:
-#line 822 "beancount/parser/grammar.y"
+#line 821 "beancount/parser/grammar.y"
     {
                  /*
                   * Ignore the error and continue reducing ({3d95e55b654e}).
@@ -2532,29 +2531,29 @@ yyreduce:
                   */
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2536 "beancount/parser/grammar.c"
+#line 2535 "beancount/parser/grammar.c"
     break;
 
   case 133:
-#line 840 "beancount/parser/grammar.y"
+#line 839 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
              }
-#line 2545 "beancount/parser/grammar.c"
+#line 2544 "beancount/parser/grammar.c"
     break;
 
   case 134:
-#line 847 "beancount/parser/grammar.y"
+#line 846 "beancount/parser/grammar.y"
     {
          BUILDY(DECREF1((yyvsp[0].pyobj)),
                 (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2554 "beancount/parser/grammar.c"
+#line 2553 "beancount/parser/grammar.c"
     break;
 
 
-#line 2558 "beancount/parser/grammar.c"
+#line 2557 "beancount/parser/grammar.c"
 
       default: break;
     }
@@ -2792,7 +2791,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 855 "beancount/parser/grammar.y"
+#line 854 "beancount/parser/grammar.y"
 
 
 /* A function that will convert a token name to a string, used in debugging. */

--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.4.  */
+/* A Bison parser, made by GNU Bison 3.4.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -48,7 +48,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.4"
+#define YYBISON_VERSION "3.4.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -101,9 +101,9 @@ void build_grammar_error_from_exception(void)
     TRACE_ERROR("Grammar Builder Exception");
 
     /* Get the exception context. */
-    PyObject* ptype;
-    PyObject* pvalue;
-    PyObject* ptraceback;
+    PyObject* ptype = NULL;
+    PyObject* pvalue = NULL;
+    PyObject* ptraceback = NULL;
     PyErr_Fetch(&ptype, &pvalue, &ptraceback);
     PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
 
@@ -114,7 +114,7 @@ void build_grammar_error_from_exception(void)
         /* Build and accumulate a new error object. {27d1d459c5cd} */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "siOOO",
                                            yy_filename, yylineno + yy_firstline,
-                                           pvalue, ptype, ptraceback);
+                                           pvalue, ptype, ptraceback ?: Py_None);
         if (rv == NULL) {
             /* Note: Leave the internal error trickling up its detail. */
             /* PyErr_SetString(PyExc_RuntimeError, */
@@ -1034,7 +1034,9 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YY
   if (yytype < YYNTOKENS)
     YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
 # endif
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   YYUSE (yytype);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
@@ -1672,7 +1674,7 @@ yyreduce:
     {
         (yyval.character) = '*';
     }
-#line 1676 "beancount/parser/grammar.c"
+#line 1678 "beancount/parser/grammar.c"
     break;
 
   case 4:
@@ -1680,7 +1682,7 @@ yyreduce:
     {
         (yyval.character) = (yyvsp[0].character);
     }
-#line 1684 "beancount/parser/grammar.c"
+#line 1686 "beancount/parser/grammar.c"
     break;
 
   case 5:
@@ -1688,7 +1690,7 @@ yyreduce:
     {
         (yyval.character) = '*';
     }
-#line 1692 "beancount/parser/grammar.c"
+#line 1694 "beancount/parser/grammar.c"
     break;
 
   case 6:
@@ -1696,7 +1698,7 @@ yyreduce:
     {
         (yyval.character) = '#';
     }
-#line 1700 "beancount/parser/grammar.c"
+#line 1702 "beancount/parser/grammar.c"
     break;
 
   case 13:
@@ -1704,7 +1706,7 @@ yyreduce:
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1708 "beancount/parser/grammar.c"
+#line 1710 "beancount/parser/grammar.c"
     break;
 
   case 14:
@@ -1713,7 +1715,7 @@ yyreduce:
                 (yyval.pyobj) = PyNumber_Add((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1717 "beancount/parser/grammar.c"
+#line 1719 "beancount/parser/grammar.c"
     break;
 
   case 15:
@@ -1722,7 +1724,7 @@ yyreduce:
                 (yyval.pyobj) = PyNumber_Subtract((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1726 "beancount/parser/grammar.c"
+#line 1728 "beancount/parser/grammar.c"
     break;
 
   case 16:
@@ -1731,7 +1733,7 @@ yyreduce:
                 (yyval.pyobj) = PyNumber_Multiply((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1735 "beancount/parser/grammar.c"
+#line 1737 "beancount/parser/grammar.c"
     break;
 
   case 17:
@@ -1740,7 +1742,7 @@ yyreduce:
                 (yyval.pyobj) = PyNumber_TrueDivide((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1744 "beancount/parser/grammar.c"
+#line 1746 "beancount/parser/grammar.c"
     break;
 
   case 18:
@@ -1749,7 +1751,7 @@ yyreduce:
                 (yyval.pyobj) = PyNumber_Negative((yyvsp[0].pyobj));
                 DECREF1((yyvsp[0].pyobj));
             }
-#line 1753 "beancount/parser/grammar.c"
+#line 1755 "beancount/parser/grammar.c"
     break;
 
   case 19:
@@ -1757,7 +1759,7 @@ yyreduce:
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1761 "beancount/parser/grammar.c"
+#line 1763 "beancount/parser/grammar.c"
     break;
 
   case 20:
@@ -1765,7 +1767,7 @@ yyreduce:
     {
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1769 "beancount/parser/grammar.c"
+#line 1771 "beancount/parser/grammar.c"
     break;
 
   case 21:
@@ -1774,7 +1776,7 @@ yyreduce:
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 1778 "beancount/parser/grammar.c"
+#line 1780 "beancount/parser/grammar.c"
     break;
 
   case 22:
@@ -1783,7 +1785,7 @@ yyreduce:
                 BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
             }
-#line 1787 "beancount/parser/grammar.c"
+#line 1789 "beancount/parser/grammar.c"
     break;
 
   case 23:
@@ -1793,7 +1795,7 @@ yyreduce:
                        (yyval.pyobj), "pipe_deprecated_error", "si", FILE_LINE_ARGS);
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1797 "beancount/parser/grammar.c"
+#line 1799 "beancount/parser/grammar.c"
     break;
 
   case 24:
@@ -1805,7 +1807,7 @@ yyreduce:
                BUILDY(,
                       (yyval.pyobj), "tag_link_new", "O", Py_None);
            }
-#line 1809 "beancount/parser/grammar.c"
+#line 1811 "beancount/parser/grammar.c"
     break;
 
   case 25:
@@ -1814,7 +1816,7 @@ yyreduce:
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1818 "beancount/parser/grammar.c"
+#line 1820 "beancount/parser/grammar.c"
     break;
 
   case 26:
@@ -1823,7 +1825,7 @@ yyreduce:
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1827 "beancount/parser/grammar.c"
+#line 1829 "beancount/parser/grammar.c"
     break;
 
   case 27:
@@ -1832,7 +1834,7 @@ yyreduce:
                 BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "transaction", "siObOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1836 "beancount/parser/grammar.c"
+#line 1838 "beancount/parser/grammar.c"
     break;
 
   case 28:
@@ -1840,7 +1842,7 @@ yyreduce:
     {
             (yyval.character) = '\0';
         }
-#line 1844 "beancount/parser/grammar.c"
+#line 1846 "beancount/parser/grammar.c"
     break;
 
   case 29:
@@ -1848,7 +1850,7 @@ yyreduce:
     {
             (yyval.character) = '*';
         }
-#line 1852 "beancount/parser/grammar.c"
+#line 1854 "beancount/parser/grammar.c"
     break;
 
   case 30:
@@ -1856,7 +1858,7 @@ yyreduce:
     {
             (yyval.character) = '#';
         }
-#line 1860 "beancount/parser/grammar.c"
+#line 1862 "beancount/parser/grammar.c"
     break;
 
   case 32:
@@ -1864,7 +1866,7 @@ yyreduce:
     {
                      (yyval.pyobj) = (yyvsp[0].pyobj);
                  }
-#line 1868 "beancount/parser/grammar.c"
+#line 1870 "beancount/parser/grammar.c"
     break;
 
   case 33:
@@ -1873,7 +1875,7 @@ yyreduce:
             BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
         }
-#line 1877 "beancount/parser/grammar.c"
+#line 1879 "beancount/parser/grammar.c"
     break;
 
   case 34:
@@ -1882,7 +1884,7 @@ yyreduce:
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
         }
-#line 1886 "beancount/parser/grammar.c"
+#line 1888 "beancount/parser/grammar.c"
     break;
 
   case 35:
@@ -1891,7 +1893,7 @@ yyreduce:
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
         }
-#line 1895 "beancount/parser/grammar.c"
+#line 1897 "beancount/parser/grammar.c"
     break;
 
   case 36:
@@ -1900,7 +1902,7 @@ yyreduce:
             BUILDY(DECREF1((yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-1].pyobj), missing_obj, Py_None, Py_None, Py_False, (yyvsp[-2].character));
         }
-#line 1904 "beancount/parser/grammar.c"
+#line 1906 "beancount/parser/grammar.c"
     break;
 
   case 37:
@@ -1909,7 +1911,7 @@ yyreduce:
               BUILDY(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
           }
-#line 1913 "beancount/parser/grammar.c"
+#line 1915 "beancount/parser/grammar.c"
     break;
 
   case 38:
@@ -1917,7 +1919,7 @@ yyreduce:
     {
                    (yyval.pyobj) = (yyvsp[-1].pyobj);
                }
-#line 1921 "beancount/parser/grammar.c"
+#line 1923 "beancount/parser/grammar.c"
     break;
 
   case 47:
@@ -1925,7 +1927,7 @@ yyreduce:
     {
                     (yyval.pyobj) = (yyvsp[0].pyobj);
                 }
-#line 1929 "beancount/parser/grammar.c"
+#line 1931 "beancount/parser/grammar.c"
     break;
 
   case 48:
@@ -1934,7 +1936,7 @@ yyreduce:
                     Py_INCREF(Py_None);
                     (yyval.pyobj) = Py_None;
                 }
-#line 1938 "beancount/parser/grammar.c"
+#line 1940 "beancount/parser/grammar.c"
     break;
 
   case 49:
@@ -1943,7 +1945,7 @@ yyreduce:
                        Py_INCREF(Py_None);
                        (yyval.pyobj) = Py_None;
                    }
-#line 1947 "beancount/parser/grammar.c"
+#line 1949 "beancount/parser/grammar.c"
     break;
 
   case 50:
@@ -1951,7 +1953,7 @@ yyreduce:
     {
                        (yyval.pyobj) = (yyvsp[-3].pyobj);
                    }
-#line 1955 "beancount/parser/grammar.c"
+#line 1957 "beancount/parser/grammar.c"
     break;
 
   case 51:
@@ -1960,7 +1962,7 @@ yyreduce:
                        BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
                    }
-#line 1964 "beancount/parser/grammar.c"
+#line 1966 "beancount/parser/grammar.c"
     break;
 
   case 52:
@@ -1969,7 +1971,7 @@ yyreduce:
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 1973 "beancount/parser/grammar.c"
+#line 1975 "beancount/parser/grammar.c"
     break;
 
   case 53:
@@ -1978,7 +1980,7 @@ yyreduce:
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 1982 "beancount/parser/grammar.c"
+#line 1984 "beancount/parser/grammar.c"
     break;
 
   case 54:
@@ -1987,7 +1989,7 @@ yyreduce:
                    Py_INCREF(Py_None);
                    (yyval.pyobj) = Py_None;
                }
-#line 1991 "beancount/parser/grammar.c"
+#line 1993 "beancount/parser/grammar.c"
     break;
 
   case 55:
@@ -1996,7 +1998,7 @@ yyreduce:
                    BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                }
-#line 2000 "beancount/parser/grammar.c"
+#line 2002 "beancount/parser/grammar.c"
     break;
 
   case 56:
@@ -2005,7 +2007,7 @@ yyreduce:
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
               }
-#line 2009 "beancount/parser/grammar.c"
+#line 2011 "beancount/parser/grammar.c"
     break;
 
   case 57:
@@ -2014,7 +2016,7 @@ yyreduce:
                   BUILDY(DECREF1((yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
               }
-#line 2018 "beancount/parser/grammar.c"
+#line 2020 "beancount/parser/grammar.c"
     break;
 
   case 58:
@@ -2023,7 +2025,7 @@ yyreduce:
                   BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
               }
-#line 2027 "beancount/parser/grammar.c"
+#line 2029 "beancount/parser/grammar.c"
     break;
 
   case 59:
@@ -2032,7 +2034,7 @@ yyreduce:
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
          }
-#line 2036 "beancount/parser/grammar.c"
+#line 2038 "beancount/parser/grammar.c"
     break;
 
   case 60:
@@ -2041,7 +2043,7 @@ yyreduce:
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
        }
-#line 2045 "beancount/parser/grammar.c"
+#line 2047 "beancount/parser/grammar.c"
     break;
 
   case 61:
@@ -2053,7 +2055,7 @@ yyreduce:
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
          }
-#line 2057 "beancount/parser/grammar.c"
+#line 2059 "beancount/parser/grammar.c"
     break;
 
   case 62:
@@ -2062,7 +2064,7 @@ yyreduce:
             BUILDY(DECREF1((yyvsp[-2].pyobj)),
                    (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
         }
-#line 2066 "beancount/parser/grammar.c"
+#line 2068 "beancount/parser/grammar.c"
     break;
 
   case 63:
@@ -2072,7 +2074,7 @@ yyreduce:
                 (yyval.pyobj), "open", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          ;
      }
-#line 2076 "beancount/parser/grammar.c"
+#line 2078 "beancount/parser/grammar.c"
     break;
 
   case 64:
@@ -2080,7 +2082,7 @@ yyreduce:
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2084 "beancount/parser/grammar.c"
+#line 2086 "beancount/parser/grammar.c"
     break;
 
   case 65:
@@ -2089,7 +2091,7 @@ yyreduce:
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2093 "beancount/parser/grammar.c"
+#line 2095 "beancount/parser/grammar.c"
     break;
 
   case 66:
@@ -2098,7 +2100,7 @@ yyreduce:
           BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "close", "siOOO", FILE_LINE_ARGS, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2102 "beancount/parser/grammar.c"
+#line 2104 "beancount/parser/grammar.c"
     break;
 
   case 67:
@@ -2107,7 +2109,7 @@ yyreduce:
               BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "commodity", "siOOO", FILE_LINE_ARGS, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
           }
-#line 2111 "beancount/parser/grammar.c"
+#line 2113 "beancount/parser/grammar.c"
     break;
 
   case 68:
@@ -2116,7 +2118,7 @@ yyreduce:
         BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "pad", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
     }
-#line 2120 "beancount/parser/grammar.c"
+#line 2122 "beancount/parser/grammar.c"
     break;
 
   case 69:
@@ -2125,7 +2127,7 @@ yyreduce:
             BUILDY(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
                    (yyval.pyobj), "balance", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
         }
-#line 2129 "beancount/parser/grammar.c"
+#line 2131 "beancount/parser/grammar.c"
     break;
 
   case 70:
@@ -2134,7 +2136,7 @@ yyreduce:
            BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
        }
-#line 2138 "beancount/parser/grammar.c"
+#line 2140 "beancount/parser/grammar.c"
     break;
 
   case 71:
@@ -2146,7 +2148,7 @@ yyreduce:
                      Py_INCREF(Py_None);
                      ;
                  }
-#line 2150 "beancount/parser/grammar.c"
+#line 2152 "beancount/parser/grammar.c"
     break;
 
   case 72:
@@ -2156,7 +2158,7 @@ yyreduce:
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = (yyvsp[-1].pyobj);
                  }
-#line 2160 "beancount/parser/grammar.c"
+#line 2162 "beancount/parser/grammar.c"
     break;
 
   case 73:
@@ -2165,7 +2167,7 @@ yyreduce:
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2169 "beancount/parser/grammar.c"
+#line 2171 "beancount/parser/grammar.c"
     break;
 
   case 74:
@@ -2173,7 +2175,7 @@ yyreduce:
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2177 "beancount/parser/grammar.c"
+#line 2179 "beancount/parser/grammar.c"
     break;
 
   case 75:
@@ -2182,7 +2184,7 @@ yyreduce:
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2186 "beancount/parser/grammar.c"
+#line 2188 "beancount/parser/grammar.c"
     break;
 
   case 76:
@@ -2190,7 +2192,7 @@ yyreduce:
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2194 "beancount/parser/grammar.c"
+#line 2196 "beancount/parser/grammar.c"
     break;
 
   case 77:
@@ -2199,7 +2201,7 @@ yyreduce:
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2203 "beancount/parser/grammar.c"
+#line 2205 "beancount/parser/grammar.c"
     break;
 
   case 78:
@@ -2208,7 +2210,7 @@ yyreduce:
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2212 "beancount/parser/grammar.c"
+#line 2214 "beancount/parser/grammar.c"
     break;
 
   case 79:
@@ -2218,7 +2220,7 @@ yyreduce:
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                     ;
                 }
-#line 2222 "beancount/parser/grammar.c"
+#line 2224 "beancount/parser/grammar.c"
     break;
 
   case 80:
@@ -2227,7 +2229,7 @@ yyreduce:
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                  }
-#line 2231 "beancount/parser/grammar.c"
+#line 2233 "beancount/parser/grammar.c"
     break;
 
   case 81:
@@ -2236,7 +2238,7 @@ yyreduce:
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
           }
-#line 2240 "beancount/parser/grammar.c"
+#line 2242 "beancount/parser/grammar.c"
     break;
 
   case 82:
@@ -2245,7 +2247,7 @@ yyreduce:
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
           }
-#line 2249 "beancount/parser/grammar.c"
+#line 2251 "beancount/parser/grammar.c"
     break;
 
   case 83:
@@ -2254,7 +2256,7 @@ yyreduce:
               Py_INCREF(Py_None);
               (yyval.pyobj) = Py_None;
           }
-#line 2258 "beancount/parser/grammar.c"
+#line 2260 "beancount/parser/grammar.c"
     break;
 
   case 84:
@@ -2263,7 +2265,7 @@ yyreduce:
                    /* We indicate that there was a cost if there */
                    (yyval.pyobj) = PyList_New(0);
                }
-#line 2267 "beancount/parser/grammar.c"
+#line 2269 "beancount/parser/grammar.c"
     break;
 
   case 85:
@@ -2272,7 +2274,7 @@ yyreduce:
                    BUILDY(DECREF1((yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
                }
-#line 2276 "beancount/parser/grammar.c"
+#line 2278 "beancount/parser/grammar.c"
     break;
 
   case 86:
@@ -2281,7 +2283,7 @@ yyreduce:
                    BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                }
-#line 2285 "beancount/parser/grammar.c"
+#line 2287 "beancount/parser/grammar.c"
     break;
 
   case 87:
@@ -2289,7 +2291,7 @@ yyreduce:
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2293 "beancount/parser/grammar.c"
+#line 2295 "beancount/parser/grammar.c"
     break;
 
   case 88:
@@ -2297,7 +2299,7 @@ yyreduce:
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2301 "beancount/parser/grammar.c"
+#line 2303 "beancount/parser/grammar.c"
     break;
 
   case 89:
@@ -2305,7 +2307,7 @@ yyreduce:
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2309 "beancount/parser/grammar.c"
+#line 2311 "beancount/parser/grammar.c"
     break;
 
   case 90:
@@ -2314,7 +2316,7 @@ yyreduce:
               BUILDY(,
                      (yyval.pyobj), "cost_merge", "O", Py_None);
           }
-#line 2318 "beancount/parser/grammar.c"
+#line 2320 "beancount/parser/grammar.c"
     break;
 
   case 91:
@@ -2323,7 +2325,7 @@ yyreduce:
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "price", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2327 "beancount/parser/grammar.c"
+#line 2329 "beancount/parser/grammar.c"
     break;
 
   case 92:
@@ -2332,7 +2334,7 @@ yyreduce:
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "event", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2336 "beancount/parser/grammar.c"
+#line 2338 "beancount/parser/grammar.c"
     break;
 
   case 93:
@@ -2341,7 +2343,7 @@ yyreduce:
              BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "query", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2345 "beancount/parser/grammar.c"
+#line 2347 "beancount/parser/grammar.c"
     break;
 
   case 94:
@@ -2350,7 +2352,7 @@ yyreduce:
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "note", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2354 "beancount/parser/grammar.c"
+#line 2356 "beancount/parser/grammar.c"
     break;
 
   case 96:
@@ -2359,7 +2361,7 @@ yyreduce:
              BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "document", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2363 "beancount/parser/grammar.c"
+#line 2365 "beancount/parser/grammar.c"
     break;
 
   case 97:
@@ -2368,7 +2370,7 @@ yyreduce:
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2372 "beancount/parser/grammar.c"
+#line 2374 "beancount/parser/grammar.c"
     break;
 
   case 98:
@@ -2377,7 +2379,7 @@ yyreduce:
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2381 "beancount/parser/grammar.c"
+#line 2383 "beancount/parser/grammar.c"
     break;
 
   case 99:
@@ -2386,7 +2388,7 @@ yyreduce:
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2390 "beancount/parser/grammar.c"
+#line 2392 "beancount/parser/grammar.c"
     break;
 
   case 100:
@@ -2395,7 +2397,7 @@ yyreduce:
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2399 "beancount/parser/grammar.c"
+#line 2401 "beancount/parser/grammar.c"
     break;
 
   case 101:
@@ -2404,7 +2406,7 @@ yyreduce:
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2408 "beancount/parser/grammar.c"
+#line 2410 "beancount/parser/grammar.c"
     break;
 
   case 102:
@@ -2417,7 +2419,7 @@ yyreduce:
                  BUILDY(DECREF2((yyvsp[0].pyobj), dtype),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
              }
-#line 2421 "beancount/parser/grammar.c"
+#line 2423 "beancount/parser/grammar.c"
     break;
 
   case 103:
@@ -2426,7 +2428,7 @@ yyreduce:
                       Py_INCREF(Py_None);
                       (yyval.pyobj) = Py_None;
                   }
-#line 2430 "beancount/parser/grammar.c"
+#line 2432 "beancount/parser/grammar.c"
     break;
 
   case 104:
@@ -2435,7 +2437,7 @@ yyreduce:
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                   }
-#line 2439 "beancount/parser/grammar.c"
+#line 2441 "beancount/parser/grammar.c"
     break;
 
   case 105:
@@ -2444,7 +2446,7 @@ yyreduce:
            BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "custom", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
        }
-#line 2448 "beancount/parser/grammar.c"
+#line 2450 "beancount/parser/grammar.c"
     break;
 
   case 117:
@@ -2452,7 +2454,7 @@ yyreduce:
     {
           (yyval.pyobj) = (yyvsp[0].pyobj);
       }
-#line 2456 "beancount/parser/grammar.c"
+#line 2458 "beancount/parser/grammar.c"
     break;
 
   case 118:
@@ -2461,7 +2463,7 @@ yyreduce:
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "option", "siOO", FILE_LINE_ARGS, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2465 "beancount/parser/grammar.c"
+#line 2467 "beancount/parser/grammar.c"
     break;
 
   case 119:
@@ -2470,7 +2472,7 @@ yyreduce:
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "include", "siO", FILE_LINE_ARGS, (yyvsp[-1].pyobj));
        }
-#line 2474 "beancount/parser/grammar.c"
+#line 2476 "beancount/parser/grammar.c"
     break;
 
   case 120:
@@ -2479,7 +2481,7 @@ yyreduce:
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "siOO", FILE_LINE_ARGS, (yyvsp[-1].pyobj), Py_None);
        }
-#line 2483 "beancount/parser/grammar.c"
+#line 2485 "beancount/parser/grammar.c"
     break;
 
   case 121:
@@ -2488,7 +2490,7 @@ yyreduce:
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "siOO", FILE_LINE_ARGS, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2492 "beancount/parser/grammar.c"
+#line 2494 "beancount/parser/grammar.c"
     break;
 
   case 130:
@@ -2496,7 +2498,7 @@ yyreduce:
     {
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2500 "beancount/parser/grammar.c"
+#line 2502 "beancount/parser/grammar.c"
     break;
 
   case 131:
@@ -2505,7 +2507,7 @@ yyreduce:
                  BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
              }
-#line 2509 "beancount/parser/grammar.c"
+#line 2511 "beancount/parser/grammar.c"
     break;
 
   case 132:
@@ -2527,7 +2529,7 @@ yyreduce:
                   */
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2531 "beancount/parser/grammar.c"
+#line 2533 "beancount/parser/grammar.c"
     break;
 
   case 133:
@@ -2536,7 +2538,7 @@ yyreduce:
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
              }
-#line 2540 "beancount/parser/grammar.c"
+#line 2542 "beancount/parser/grammar.c"
     break;
 
   case 134:
@@ -2545,11 +2547,11 @@ yyreduce:
          BUILDY(DECREF1((yyvsp[0].pyobj)),
                 (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2549 "beancount/parser/grammar.c"
+#line 2551 "beancount/parser/grammar.c"
     break;
 
 
-#line 2553 "beancount/parser/grammar.c"
+#line 2555 "beancount/parser/grammar.c"
 
       default: break;
     }

--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -66,7 +66,7 @@
 
 
 /* First part of user prologue.  */
-#line 49 "beancount/parser/grammar.y"
+#line 52 "beancount/parser/grammar.y"
 
 
 #include "grammar.h"
@@ -138,10 +138,6 @@ void yyerror(YYLTYPE *locp, yyscan_t scanner, PyObject* builder, char const* mes
     Py_XDECREF(rv);
 }
 
-/* Get a printable version of a token name. */
-const char* getTokenName(int token);
-
-
 /* Macros to clean up memory for temporaries in rule reductions. */
 #define DECREF1(x1)                        Py_DECREF(x1);
 #define DECREF2(x1, x2)                    DECREF1(x1); Py_DECREF(x2);
@@ -151,7 +147,7 @@ const char* getTokenName(int token);
 #define DECREF6(x1, x2, x3, x4, x5, x6)    DECREF5(x1, x2, x3, x4, x5); Py_DECREF(x6);
 
 
-#line 155 "beancount/parser/grammar.c"
+#line 151 "beancount/parser/grammar.c"
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus
@@ -221,8 +217,11 @@ typedef struct YYLTYPE {
         }                                                               \
     } while (0)
 
+/* Get a printable version of a token name. */
+const char* token_to_string(int token);
 
-#line 226 "beancount/parser/grammar.c"
+
+#line 225 "beancount/parser/grammar.c"
 
 /* Token type.  */
 #ifndef YYTOKENTYPE
@@ -290,7 +289,7 @@ typedef struct YYLTYPE {
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 148 "beancount/parser/grammar.y"
+#line 147 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -300,7 +299,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 304 "beancount/parser/grammar.c"
+#line 303 "beancount/parser/grammar.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -626,20 +625,20 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   282,   282,   285,   289,   293,   297,   302,   303,   307,
-     308,   309,   310,   316,   320,   325,   330,   335,   340,   345,
-     349,   354,   359,   364,   371,   379,   384,   390,   396,   400,
-     404,   408,   410,   415,   420,   425,   430,   436,   442,   447,
-     448,   449,   450,   451,   452,   453,   454,   455,   459,   465,
-     470,   474,   479,   484,   490,   495,   501,   506,   511,   517,
-     523,   529,   538,   544,   551,   555,   561,   567,   573,   579,
-     585,   591,   599,   606,   611,   616,   621,   626,   631,   636,
-     643,   649,   654,   659,   665,   670,   675,   681,   685,   689,
-     693,   700,   706,   712,   718,   724,   726,   733,   738,   743,
-     748,   753,   758,   768,   773,   779,   786,   787,   788,   789,
-     790,   791,   792,   793,   794,   795,   796,   797,   802,   808,
-     814,   819,   825,   826,   827,   828,   829,   830,   831,   832,
-     835,   839,   844,   862,   869
+       0,   281,   281,   284,   288,   292,   296,   301,   302,   306,
+     307,   308,   309,   315,   319,   324,   329,   334,   339,   344,
+     348,   353,   358,   363,   370,   378,   383,   389,   395,   399,
+     403,   407,   409,   414,   419,   424,   429,   435,   441,   446,
+     447,   448,   449,   450,   451,   452,   453,   454,   458,   464,
+     469,   473,   478,   483,   489,   494,   500,   505,   510,   516,
+     522,   528,   537,   543,   550,   554,   560,   566,   572,   578,
+     584,   590,   598,   605,   610,   615,   620,   625,   630,   635,
+     642,   648,   653,   658,   664,   669,   674,   680,   684,   688,
+     692,   699,   705,   711,   717,   723,   725,   732,   737,   742,
+     747,   752,   757,   767,   772,   778,   785,   786,   787,   788,
+     789,   790,   791,   792,   793,   794,   795,   796,   801,   807,
+     813,   818,   824,   825,   826,   827,   828,   829,   830,   831,
+     834,   838,   843,   861,   868
 };
 #endif
 
@@ -1698,136 +1697,136 @@ yyreduce:
   switch (yyn)
     {
   case 3:
-#line 286 "beancount/parser/grammar.y"
+#line 285 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1706 "beancount/parser/grammar.c"
+#line 1705 "beancount/parser/grammar.c"
     break;
 
   case 4:
-#line 290 "beancount/parser/grammar.y"
+#line 289 "beancount/parser/grammar.y"
     {
         (yyval.character) = (yyvsp[0].character);
     }
-#line 1714 "beancount/parser/grammar.c"
+#line 1713 "beancount/parser/grammar.c"
     break;
 
   case 5:
-#line 294 "beancount/parser/grammar.y"
+#line 293 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1722 "beancount/parser/grammar.c"
+#line 1721 "beancount/parser/grammar.c"
     break;
 
   case 6:
-#line 298 "beancount/parser/grammar.y"
+#line 297 "beancount/parser/grammar.y"
     {
         (yyval.character) = '#';
     }
-#line 1730 "beancount/parser/grammar.c"
+#line 1729 "beancount/parser/grammar.c"
     break;
 
   case 13:
-#line 317 "beancount/parser/grammar.y"
+#line 316 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1738 "beancount/parser/grammar.c"
+#line 1737 "beancount/parser/grammar.c"
     break;
 
   case 14:
-#line 321 "beancount/parser/grammar.y"
+#line 320 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Add((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1747 "beancount/parser/grammar.c"
+#line 1746 "beancount/parser/grammar.c"
     break;
 
   case 15:
-#line 326 "beancount/parser/grammar.y"
+#line 325 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Subtract((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1756 "beancount/parser/grammar.c"
+#line 1755 "beancount/parser/grammar.c"
     break;
 
   case 16:
-#line 331 "beancount/parser/grammar.y"
+#line 330 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Multiply((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1765 "beancount/parser/grammar.c"
+#line 1764 "beancount/parser/grammar.c"
     break;
 
   case 17:
-#line 336 "beancount/parser/grammar.y"
+#line 335 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_TrueDivide((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1774 "beancount/parser/grammar.c"
+#line 1773 "beancount/parser/grammar.c"
     break;
 
   case 18:
-#line 341 "beancount/parser/grammar.y"
+#line 340 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Negative((yyvsp[0].pyobj));
                 DECREF1((yyvsp[0].pyobj));
             }
-#line 1783 "beancount/parser/grammar.c"
+#line 1782 "beancount/parser/grammar.c"
     break;
 
   case 19:
-#line 346 "beancount/parser/grammar.y"
+#line 345 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1791 "beancount/parser/grammar.c"
+#line 1790 "beancount/parser/grammar.c"
     break;
 
   case 20:
-#line 350 "beancount/parser/grammar.y"
+#line 349 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1799 "beancount/parser/grammar.c"
+#line 1798 "beancount/parser/grammar.c"
     break;
 
   case 21:
-#line 355 "beancount/parser/grammar.y"
+#line 354 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 1808 "beancount/parser/grammar.c"
+#line 1807 "beancount/parser/grammar.c"
     break;
 
   case 22:
-#line 360 "beancount/parser/grammar.y"
+#line 359 "beancount/parser/grammar.y"
     {
                 CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
             }
-#line 1817 "beancount/parser/grammar.c"
+#line 1816 "beancount/parser/grammar.c"
     break;
 
   case 23:
-#line 365 "beancount/parser/grammar.y"
+#line 364 "beancount/parser/grammar.y"
     {
                 CALL(,
                      (yyval.pyobj), "pipe_deprecated_error", "");
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1827 "beancount/parser/grammar.c"
+#line 1826 "beancount/parser/grammar.c"
     break;
 
   case 24:
-#line 372 "beancount/parser/grammar.y"
+#line 371 "beancount/parser/grammar.y"
     {
                /* Note: We're passing a bogus value here in order to avoid
                 * having to declare a second macro just for this one special
@@ -1835,247 +1834,247 @@ yyreduce:
                CALL(,
                     (yyval.pyobj), "tag_link_new", "O", Py_None);
            }
-#line 1839 "beancount/parser/grammar.c"
+#line 1838 "beancount/parser/grammar.c"
     break;
 
   case 25:
-#line 380 "beancount/parser/grammar.y"
+#line 379 "beancount/parser/grammar.y"
     {
                CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1848 "beancount/parser/grammar.c"
+#line 1847 "beancount/parser/grammar.c"
     break;
 
   case 26:
-#line 385 "beancount/parser/grammar.y"
+#line 384 "beancount/parser/grammar.y"
     {
                CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1857 "beancount/parser/grammar.c"
+#line 1856 "beancount/parser/grammar.c"
     break;
 
   case 27:
-#line 391 "beancount/parser/grammar.y"
+#line 390 "beancount/parser/grammar.y"
     {
                 CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "transaction", "ObOOO", (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1866 "beancount/parser/grammar.c"
+#line 1865 "beancount/parser/grammar.c"
     break;
 
   case 28:
-#line 397 "beancount/parser/grammar.y"
+#line 396 "beancount/parser/grammar.y"
     {
             (yyval.character) = '\0';
         }
-#line 1874 "beancount/parser/grammar.c"
+#line 1873 "beancount/parser/grammar.c"
     break;
 
   case 29:
-#line 401 "beancount/parser/grammar.y"
+#line 400 "beancount/parser/grammar.y"
     {
             (yyval.character) = '*';
         }
-#line 1882 "beancount/parser/grammar.c"
+#line 1881 "beancount/parser/grammar.c"
     break;
 
   case 30:
-#line 405 "beancount/parser/grammar.y"
+#line 404 "beancount/parser/grammar.y"
     {
             (yyval.character) = '#';
         }
-#line 1890 "beancount/parser/grammar.c"
+#line 1889 "beancount/parser/grammar.c"
     break;
 
   case 32:
-#line 411 "beancount/parser/grammar.y"
+#line 410 "beancount/parser/grammar.y"
     {
                      (yyval.pyobj) = (yyvsp[0].pyobj);
                  }
-#line 1898 "beancount/parser/grammar.c"
+#line 1897 "beancount/parser/grammar.c"
     break;
 
   case 33:
-#line 416 "beancount/parser/grammar.y"
+#line 415 "beancount/parser/grammar.y"
     {
             CALL(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                  (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
         }
-#line 1907 "beancount/parser/grammar.c"
+#line 1906 "beancount/parser/grammar.c"
     break;
 
   case 34:
-#line 421 "beancount/parser/grammar.y"
+#line 420 "beancount/parser/grammar.y"
     {
             CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                  (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
         }
-#line 1916 "beancount/parser/grammar.c"
+#line 1915 "beancount/parser/grammar.c"
     break;
 
   case 35:
-#line 426 "beancount/parser/grammar.y"
+#line 425 "beancount/parser/grammar.y"
     {
             CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                  (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
         }
-#line 1925 "beancount/parser/grammar.c"
+#line 1924 "beancount/parser/grammar.c"
     break;
 
   case 36:
-#line 431 "beancount/parser/grammar.y"
+#line 430 "beancount/parser/grammar.y"
     {
             CALL(DECREF1((yyvsp[-1].pyobj)),
                  (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-1].pyobj), missing, Py_None, Py_None, Py_False, (yyvsp[-2].character));
         }
-#line 1934 "beancount/parser/grammar.c"
+#line 1933 "beancount/parser/grammar.c"
     break;
 
   case 37:
-#line 437 "beancount/parser/grammar.y"
+#line 436 "beancount/parser/grammar.y"
     {
               CALL(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
                    (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
           }
-#line 1943 "beancount/parser/grammar.c"
+#line 1942 "beancount/parser/grammar.c"
     break;
 
   case 38:
-#line 443 "beancount/parser/grammar.y"
+#line 442 "beancount/parser/grammar.y"
     {
                    (yyval.pyobj) = (yyvsp[-1].pyobj);
                }
-#line 1951 "beancount/parser/grammar.c"
+#line 1950 "beancount/parser/grammar.c"
     break;
 
   case 47:
-#line 456 "beancount/parser/grammar.y"
+#line 455 "beancount/parser/grammar.y"
     {
                     (yyval.pyobj) = (yyvsp[0].pyobj);
                 }
-#line 1959 "beancount/parser/grammar.c"
+#line 1958 "beancount/parser/grammar.c"
     break;
 
   case 48:
-#line 460 "beancount/parser/grammar.y"
+#line 459 "beancount/parser/grammar.y"
     {
                     Py_INCREF(Py_None);
                     (yyval.pyobj) = Py_None;
                 }
-#line 1968 "beancount/parser/grammar.c"
+#line 1967 "beancount/parser/grammar.c"
     break;
 
   case 49:
-#line 466 "beancount/parser/grammar.y"
+#line 465 "beancount/parser/grammar.y"
     {
                        Py_INCREF(Py_None);
                        (yyval.pyobj) = Py_None;
                    }
-#line 1977 "beancount/parser/grammar.c"
+#line 1976 "beancount/parser/grammar.c"
     break;
 
   case 50:
-#line 471 "beancount/parser/grammar.y"
+#line 470 "beancount/parser/grammar.y"
     {
                        (yyval.pyobj) = (yyvsp[-3].pyobj);
                    }
-#line 1985 "beancount/parser/grammar.c"
+#line 1984 "beancount/parser/grammar.c"
     break;
 
   case 51:
-#line 475 "beancount/parser/grammar.y"
+#line 474 "beancount/parser/grammar.y"
     {
                        CALL(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                             (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
                    }
-#line 1994 "beancount/parser/grammar.c"
+#line 1993 "beancount/parser/grammar.c"
     break;
 
   case 52:
-#line 480 "beancount/parser/grammar.y"
+#line 479 "beancount/parser/grammar.y"
     {
                        CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2003 "beancount/parser/grammar.c"
+#line 2002 "beancount/parser/grammar.c"
     break;
 
   case 53:
-#line 485 "beancount/parser/grammar.y"
+#line 484 "beancount/parser/grammar.y"
     {
                        CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2012 "beancount/parser/grammar.c"
+#line 2011 "beancount/parser/grammar.c"
     break;
 
   case 54:
-#line 491 "beancount/parser/grammar.y"
+#line 490 "beancount/parser/grammar.y"
     {
                    Py_INCREF(Py_None);
                    (yyval.pyobj) = Py_None;
                }
-#line 2021 "beancount/parser/grammar.c"
+#line 2020 "beancount/parser/grammar.c"
     break;
 
   case 55:
-#line 496 "beancount/parser/grammar.y"
+#line 495 "beancount/parser/grammar.y"
     {
                    CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                }
-#line 2030 "beancount/parser/grammar.c"
+#line 2029 "beancount/parser/grammar.c"
     break;
 
   case 56:
-#line 502 "beancount/parser/grammar.y"
+#line 501 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
               }
-#line 2039 "beancount/parser/grammar.c"
+#line 2038 "beancount/parser/grammar.c"
     break;
 
   case 57:
-#line 507 "beancount/parser/grammar.y"
+#line 506 "beancount/parser/grammar.y"
     {
                   CALL(DECREF1((yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
               }
-#line 2048 "beancount/parser/grammar.c"
+#line 2047 "beancount/parser/grammar.c"
     break;
 
   case 58:
-#line 512 "beancount/parser/grammar.y"
+#line 511 "beancount/parser/grammar.y"
     {
                   CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
               }
-#line 2057 "beancount/parser/grammar.c"
+#line 2056 "beancount/parser/grammar.c"
     break;
 
   case 59:
-#line 518 "beancount/parser/grammar.y"
+#line 517 "beancount/parser/grammar.y"
     {
              CALL(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
          }
-#line 2066 "beancount/parser/grammar.c"
+#line 2065 "beancount/parser/grammar.c"
     break;
 
   case 60:
-#line 524 "beancount/parser/grammar.y"
+#line 523 "beancount/parser/grammar.y"
     {
            CALL(DECREF1((yyvsp[-1].pyobj)),
                 (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
        }
-#line 2075 "beancount/parser/grammar.c"
+#line 2074 "beancount/parser/grammar.c"
     break;
 
   case 61:
-#line 530 "beancount/parser/grammar.y"
+#line 529 "beancount/parser/grammar.y"
     {
              /* Note: key_value is a tuple, Py_BuildValue() won't wrap it up
               * within a tuple, so expand in the method (it receives two
@@ -2083,92 +2082,92 @@ yyreduce:
              CALL(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
          }
-#line 2087 "beancount/parser/grammar.c"
+#line 2086 "beancount/parser/grammar.c"
     break;
 
   case 62:
-#line 539 "beancount/parser/grammar.y"
+#line 538 "beancount/parser/grammar.y"
     {
             CALL(DECREF1((yyvsp[-2].pyobj)),
                  (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
         }
-#line 2096 "beancount/parser/grammar.c"
+#line 2095 "beancount/parser/grammar.c"
     break;
 
   case 63:
-#line 545 "beancount/parser/grammar.y"
+#line 544 "beancount/parser/grammar.y"
     {
          CALL(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
               (yyval.pyobj), "open", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          ;
      }
-#line 2106 "beancount/parser/grammar.c"
+#line 2105 "beancount/parser/grammar.c"
     break;
 
   case 64:
-#line 552 "beancount/parser/grammar.y"
+#line 551 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2114 "beancount/parser/grammar.c"
+#line 2113 "beancount/parser/grammar.c"
     break;
 
   case 65:
-#line 556 "beancount/parser/grammar.y"
+#line 555 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2123 "beancount/parser/grammar.c"
+#line 2122 "beancount/parser/grammar.c"
     break;
 
   case 66:
-#line 562 "beancount/parser/grammar.y"
+#line 561 "beancount/parser/grammar.y"
     {
           CALL(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "close", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2132 "beancount/parser/grammar.c"
+#line 2131 "beancount/parser/grammar.c"
     break;
 
   case 67:
-#line 568 "beancount/parser/grammar.y"
+#line 567 "beancount/parser/grammar.y"
     {
               CALL(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                    (yyval.pyobj), "commodity", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
           }
-#line 2141 "beancount/parser/grammar.c"
+#line 2140 "beancount/parser/grammar.c"
     break;
 
   case 68:
-#line 574 "beancount/parser/grammar.y"
+#line 573 "beancount/parser/grammar.y"
     {
         CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
              (yyval.pyobj), "pad", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
     }
-#line 2150 "beancount/parser/grammar.c"
+#line 2149 "beancount/parser/grammar.c"
     break;
 
   case 69:
-#line 580 "beancount/parser/grammar.y"
+#line 579 "beancount/parser/grammar.y"
     {
             CALL(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
                  (yyval.pyobj), "balance", "OOOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
         }
-#line 2159 "beancount/parser/grammar.c"
+#line 2158 "beancount/parser/grammar.c"
     break;
 
   case 70:
-#line 586 "beancount/parser/grammar.y"
+#line 585 "beancount/parser/grammar.y"
     {
            CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                 (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
        }
-#line 2168 "beancount/parser/grammar.c"
+#line 2167 "beancount/parser/grammar.c"
     break;
 
   case 71:
-#line 592 "beancount/parser/grammar.y"
+#line 591 "beancount/parser/grammar.y"
     {
                      CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
@@ -2176,269 +2175,269 @@ yyreduce:
                      Py_INCREF(Py_None);
                      ;
                  }
-#line 2180 "beancount/parser/grammar.c"
+#line 2179 "beancount/parser/grammar.c"
     break;
 
   case 72:
-#line 600 "beancount/parser/grammar.y"
+#line 599 "beancount/parser/grammar.y"
     {
                      CALL(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = (yyvsp[-1].pyobj);
                  }
-#line 2190 "beancount/parser/grammar.c"
+#line 2189 "beancount/parser/grammar.c"
     break;
 
   case 73:
-#line 607 "beancount/parser/grammar.y"
+#line 606 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing);
                  (yyval.pyobj) = missing;
              }
-#line 2199 "beancount/parser/grammar.c"
+#line 2198 "beancount/parser/grammar.c"
     break;
 
   case 74:
-#line 612 "beancount/parser/grammar.y"
+#line 611 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2207 "beancount/parser/grammar.c"
+#line 2206 "beancount/parser/grammar.c"
     break;
 
   case 75:
-#line 617 "beancount/parser/grammar.y"
+#line 616 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing);
                  (yyval.pyobj) = missing;
              }
-#line 2216 "beancount/parser/grammar.c"
+#line 2215 "beancount/parser/grammar.c"
     break;
 
   case 76:
-#line 622 "beancount/parser/grammar.y"
+#line 621 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2224 "beancount/parser/grammar.c"
+#line 2223 "beancount/parser/grammar.c"
     break;
 
   case 77:
-#line 627 "beancount/parser/grammar.y"
+#line 626 "beancount/parser/grammar.y"
     {
                     CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2233 "beancount/parser/grammar.c"
+#line 2232 "beancount/parser/grammar.c"
     break;
 
   case 78:
-#line 632 "beancount/parser/grammar.y"
+#line 631 "beancount/parser/grammar.y"
     {
                     CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2242 "beancount/parser/grammar.c"
+#line 2241 "beancount/parser/grammar.c"
     break;
 
   case 79:
-#line 637 "beancount/parser/grammar.y"
+#line 636 "beancount/parser/grammar.y"
     {
                     CALL(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                     ;
                 }
-#line 2252 "beancount/parser/grammar.c"
+#line 2251 "beancount/parser/grammar.c"
     break;
 
   case 80:
-#line 644 "beancount/parser/grammar.y"
+#line 643 "beancount/parser/grammar.y"
     {
                       CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                  }
-#line 2261 "beancount/parser/grammar.c"
+#line 2260 "beancount/parser/grammar.c"
     break;
 
   case 81:
-#line 650 "beancount/parser/grammar.y"
+#line 649 "beancount/parser/grammar.y"
     {
               CALL(DECREF1((yyvsp[-1].pyobj)),
                    (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
           }
-#line 2270 "beancount/parser/grammar.c"
+#line 2269 "beancount/parser/grammar.c"
     break;
 
   case 82:
-#line 655 "beancount/parser/grammar.y"
+#line 654 "beancount/parser/grammar.y"
     {
               CALL(DECREF1((yyvsp[-1].pyobj)),
                    (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
           }
-#line 2279 "beancount/parser/grammar.c"
+#line 2278 "beancount/parser/grammar.c"
     break;
 
   case 83:
-#line 660 "beancount/parser/grammar.y"
+#line 659 "beancount/parser/grammar.y"
     {
               Py_INCREF(Py_None);
               (yyval.pyobj) = Py_None;
           }
-#line 2288 "beancount/parser/grammar.c"
+#line 2287 "beancount/parser/grammar.c"
     break;
 
   case 84:
-#line 666 "beancount/parser/grammar.y"
+#line 665 "beancount/parser/grammar.y"
     {
                    /* We indicate that there was a cost if there */
                    (yyval.pyobj) = PyList_New(0);
                }
-#line 2297 "beancount/parser/grammar.c"
+#line 2296 "beancount/parser/grammar.c"
     break;
 
   case 85:
-#line 671 "beancount/parser/grammar.y"
+#line 670 "beancount/parser/grammar.y"
     {
                    CALL(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
                }
-#line 2306 "beancount/parser/grammar.c"
+#line 2305 "beancount/parser/grammar.c"
     break;
 
   case 86:
-#line 676 "beancount/parser/grammar.y"
+#line 675 "beancount/parser/grammar.y"
     {
                    CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                }
-#line 2315 "beancount/parser/grammar.c"
+#line 2314 "beancount/parser/grammar.c"
     break;
 
   case 87:
-#line 682 "beancount/parser/grammar.y"
+#line 681 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2323 "beancount/parser/grammar.c"
+#line 2322 "beancount/parser/grammar.c"
     break;
 
   case 88:
-#line 686 "beancount/parser/grammar.y"
+#line 685 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2331 "beancount/parser/grammar.c"
+#line 2330 "beancount/parser/grammar.c"
     break;
 
   case 89:
-#line 690 "beancount/parser/grammar.y"
+#line 689 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2339 "beancount/parser/grammar.c"
+#line 2338 "beancount/parser/grammar.c"
     break;
 
   case 90:
-#line 694 "beancount/parser/grammar.y"
+#line 693 "beancount/parser/grammar.y"
     {
               CALL(,
                    (yyval.pyobj), "cost_merge", "O", Py_None);
           }
-#line 2348 "beancount/parser/grammar.c"
+#line 2347 "beancount/parser/grammar.c"
     break;
 
   case 91:
-#line 701 "beancount/parser/grammar.y"
+#line 700 "beancount/parser/grammar.y"
     {
           CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "price", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2357 "beancount/parser/grammar.c"
+#line 2356 "beancount/parser/grammar.c"
     break;
 
   case 92:
-#line 707 "beancount/parser/grammar.y"
+#line 706 "beancount/parser/grammar.y"
     {
           CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "event", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2366 "beancount/parser/grammar.c"
+#line 2365 "beancount/parser/grammar.c"
     break;
 
   case 93:
-#line 713 "beancount/parser/grammar.y"
+#line 712 "beancount/parser/grammar.y"
     {
              CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "query", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2375 "beancount/parser/grammar.c"
+#line 2374 "beancount/parser/grammar.c"
     break;
 
   case 94:
-#line 719 "beancount/parser/grammar.y"
+#line 718 "beancount/parser/grammar.y"
     {
           CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "note", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2384 "beancount/parser/grammar.c"
+#line 2383 "beancount/parser/grammar.c"
     break;
 
   case 96:
-#line 727 "beancount/parser/grammar.y"
+#line 726 "beancount/parser/grammar.y"
     {
              CALL(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "document", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2393 "beancount/parser/grammar.c"
+#line 2392 "beancount/parser/grammar.c"
     break;
 
   case 97:
-#line 734 "beancount/parser/grammar.y"
+#line 733 "beancount/parser/grammar.y"
     {
                  CALL(DECREF1((yyvsp[0].pyobj)),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2402 "beancount/parser/grammar.c"
+#line 2401 "beancount/parser/grammar.c"
     break;
 
   case 98:
-#line 739 "beancount/parser/grammar.y"
+#line 738 "beancount/parser/grammar.y"
     {
                  CALL(DECREF1((yyvsp[0].pyobj)),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2411 "beancount/parser/grammar.c"
+#line 2410 "beancount/parser/grammar.c"
     break;
 
   case 99:
-#line 744 "beancount/parser/grammar.y"
+#line 743 "beancount/parser/grammar.y"
     {
                  CALL(DECREF1((yyvsp[0].pyobj)),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2420 "beancount/parser/grammar.c"
+#line 2419 "beancount/parser/grammar.c"
     break;
 
   case 100:
-#line 749 "beancount/parser/grammar.y"
+#line 748 "beancount/parser/grammar.y"
     {
                  CALL(DECREF1((yyvsp[0].pyobj)),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2429 "beancount/parser/grammar.c"
+#line 2428 "beancount/parser/grammar.c"
     break;
 
   case 101:
-#line 754 "beancount/parser/grammar.y"
+#line 753 "beancount/parser/grammar.y"
     {
                  CALL(DECREF1((yyvsp[0].pyobj)),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2438 "beancount/parser/grammar.c"
+#line 2437 "beancount/parser/grammar.c"
     break;
 
   case 102:
-#line 759 "beancount/parser/grammar.y"
+#line 758 "beancount/parser/grammar.y"
     {
                  /* Obtain beancount.core.account.TYPE */
                  PyObject* module = PyImport_ImportModule("beancount.core.account");
@@ -2447,99 +2446,99 @@ yyreduce:
                  CALL(DECREF2((yyvsp[0].pyobj), dtype),
                       (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
              }
-#line 2451 "beancount/parser/grammar.c"
+#line 2450 "beancount/parser/grammar.c"
     break;
 
   case 103:
-#line 769 "beancount/parser/grammar.y"
+#line 768 "beancount/parser/grammar.y"
     {
                       Py_INCREF(Py_None);
                       (yyval.pyobj) = Py_None;
                   }
-#line 2460 "beancount/parser/grammar.c"
+#line 2459 "beancount/parser/grammar.c"
     break;
 
   case 104:
-#line 774 "beancount/parser/grammar.y"
+#line 773 "beancount/parser/grammar.y"
     {
                       CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                   }
-#line 2469 "beancount/parser/grammar.c"
+#line 2468 "beancount/parser/grammar.c"
     break;
 
   case 105:
-#line 780 "beancount/parser/grammar.y"
+#line 779 "beancount/parser/grammar.y"
     {
            CALL(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                 (yyval.pyobj), "custom", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
        }
-#line 2478 "beancount/parser/grammar.c"
+#line 2477 "beancount/parser/grammar.c"
     break;
 
   case 117:
-#line 798 "beancount/parser/grammar.y"
+#line 797 "beancount/parser/grammar.y"
     {
           (yyval.pyobj) = (yyvsp[0].pyobj);
       }
-#line 2486 "beancount/parser/grammar.c"
+#line 2485 "beancount/parser/grammar.c"
     break;
 
   case 118:
-#line 803 "beancount/parser/grammar.y"
+#line 802 "beancount/parser/grammar.y"
     {
            CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                 (yyval.pyobj), "option", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2495 "beancount/parser/grammar.c"
+#line 2494 "beancount/parser/grammar.c"
     break;
 
   case 119:
-#line 809 "beancount/parser/grammar.y"
+#line 808 "beancount/parser/grammar.y"
     {
            CALL(DECREF1((yyvsp[-1].pyobj)),
                 (yyval.pyobj), "include", "O", (yyvsp[-1].pyobj));
        }
-#line 2504 "beancount/parser/grammar.c"
+#line 2503 "beancount/parser/grammar.c"
     break;
 
   case 120:
-#line 815 "beancount/parser/grammar.y"
+#line 814 "beancount/parser/grammar.y"
     {
            CALL(DECREF1((yyvsp[-1].pyobj)),
                 (yyval.pyobj), "plugin", "OO", (yyvsp[-1].pyobj), Py_None);
        }
-#line 2513 "beancount/parser/grammar.c"
+#line 2512 "beancount/parser/grammar.c"
     break;
 
   case 121:
-#line 820 "beancount/parser/grammar.y"
+#line 819 "beancount/parser/grammar.y"
     {
            CALL(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                 (yyval.pyobj), "plugin", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2522 "beancount/parser/grammar.c"
+#line 2521 "beancount/parser/grammar.c"
     break;
 
   case 130:
-#line 836 "beancount/parser/grammar.y"
+#line 835 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2530 "beancount/parser/grammar.c"
+#line 2529 "beancount/parser/grammar.c"
     break;
 
   case 131:
-#line 840 "beancount/parser/grammar.y"
+#line 839 "beancount/parser/grammar.y"
     {
                  CALL(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
              }
-#line 2539 "beancount/parser/grammar.c"
+#line 2538 "beancount/parser/grammar.c"
     break;
 
   case 132:
-#line 845 "beancount/parser/grammar.y"
+#line 844 "beancount/parser/grammar.y"
     {
                  /*
                   * Ignore the error and continue reducing ({3d95e55b654e}).
@@ -2557,20 +2556,20 @@ yyreduce:
                   */
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2561 "beancount/parser/grammar.c"
+#line 2560 "beancount/parser/grammar.c"
     break;
 
   case 133:
-#line 863 "beancount/parser/grammar.y"
+#line 862 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
              }
-#line 2570 "beancount/parser/grammar.c"
+#line 2569 "beancount/parser/grammar.c"
     break;
 
   case 134:
-#line 870 "beancount/parser/grammar.y"
+#line 869 "beancount/parser/grammar.y"
     {
          /* If a Python exception has been raised and not handled, abort. In
           * case of unrecoverable error, the lexer raises a Python exception and
@@ -2582,11 +2581,11 @@ yyreduce:
          CALL(DECREF1((yyvsp[0].pyobj)),
               (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2586 "beancount/parser/grammar.c"
+#line 2585 "beancount/parser/grammar.c"
     break;
 
 
-#line 2590 "beancount/parser/grammar.c"
+#line 2589 "beancount/parser/grammar.c"
 
       default: break;
     }
@@ -2824,62 +2823,11 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 885 "beancount/parser/grammar.y"
+#line 884 "beancount/parser/grammar.y"
 
 
-/* A function that will convert a token name to a string, used in debugging. */
-const char* getTokenName(int token)
+/* Get a printable version of a token name. */
+const char* token_to_string(int token)
 {
-    switch ( token ) {
-        case LEX_ERROR : return "LEX_ERROR";
-        case INDENT    : return "INDENT";
-        case EOL       : return "EOL";
-        case COMMENT   : return "COMMENT";
-        case SKIPPED   : return "SKIPPED";
-        case PIPE      : return "PIPE";
-        case ATAT      : return "ATAT";
-        case AT        : return "AT";
-        case LCURL     : return "LCURL";
-        case RCURL     : return "RCURL";
-        case EQUAL     : return "EQUAL";
-        case COMMA     : return "COMMA";
-        case TILDE     : return "TILDE";
-        case HASH      : return "HASH";
-        case PLUS      : return "PLUS";
-        case MINUS     : return "MINUS";
-        case ASTERISK  : return "ASTERISK";
-        case SLASH     : return "SLASH";
-        case COLON     : return "COLON";
-        case LPAREN    : return "LPAREN";
-        case RPAREN    : return "RPAREN";
-        case FLAG      : return "FLAG";
-        case TXN       : return "TXN";
-        case BALANCE   : return "BALANCE";
-        case OPEN      : return "OPEN";
-        case CLOSE     : return "CLOSE";
-        case PAD       : return "PAD";
-        case EVENT     : return "EVENT";
-        case QUERY     : return "QUERY";
-        case CUSTOM    : return "CUSTOM";
-        case PRICE     : return "PRICE";
-        case NOTE      : return "NOTE";
-        case DOCUMENT  : return "DOCUMENT";
-        case PUSHTAG   : return "PUSHTAG";
-        case POPTAG    : return "POPTAG";
-        case PUSHMETA  : return "PUSHMETA";
-        case POPMETA   : return "POPMETA";
-        case OPTION    : return "OPTION";
-        case PLUGIN    : return "PLUGIN";
-        case DATE      : return "DATE";
-        case ACCOUNT   : return "ACCOUNT";
-        case CURRENCY  : return "CURRENCY";
-        case STRING    : return "STRING";
-        case NUMBER    : return "NUMBER";
-        case TAG       : return "TAG";
-        case LINK      : return "LINK";
-        case KEY       : return "KEY";
-        case BOOL      : return "BOOL";
-        case NONE      : return "NULL";
-    }
-    return "<NO_STRING_TRANSLATION>";
+    return yytname[YYTRANSLATE(token)];
 }

--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -82,7 +82,7 @@ extern YY_DECL;
  * in the handler. Always run the code to clean the references provided by the
  * reduced rule. {05bb0fb60e86}
  */
-#define BUILDY(clean, target, method_name, format, ...)                         \
+#define BUILD(clean, target, method_name, format, ...)                          \
     target = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);    \
     clean;                                                                      \
     if (target == NULL) {                                                       \
@@ -96,59 +96,52 @@ extern YY_DECL;
 /* Build a grammar error from the exception context. */
 void build_grammar_error_from_exception(yyscan_t scanner, PyObject* parser, PyObject* builder)
 {
-    TRACE_ERROR("Grammar Builder Exception");
+    PyObject* traceback = NULL;
+    PyObject* value = NULL;
+    PyObject* type = NULL;
+    PyObject* rv = NULL;
 
     /* Get the exception context. */
-    PyObject* ptype = NULL;
-    PyObject* pvalue = NULL;
-    PyObject* ptraceback = NULL;
-    PyErr_Fetch(&ptype, &pvalue, &ptraceback);
-    PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
+    PyErr_Fetch(&type, &value, &traceback);
+    PyErr_NormalizeException(&type, &value, &traceback);
 
-    /* Clear the exception. */
-    PyErr_Clear();
+    if (value) {
+        /* traceback can be NULL. This is the case for exceptions
+         * raised in C code for example. Replace NULL with Py_None to
+         * keep PyObject_CallMethod() happy. */
+        traceback = traceback ? traceback : Py_None;
 
-    if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
-        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "OiOOO",
-                                           ((Parser*)parser)->filename,
-                                           yyget_lineno(scanner) + ((Parser*)parser)->line,
-                                           pvalue, ptype, ptraceback ?: Py_None);
-        if (rv == NULL) {
-            /* Note: Leave the internal error trickling up its detail. */
-            /* PyErr_SetString(PyExc_RuntimeError, */
-            /*                 "Internal error: While building exception"); */
-        }
-    }
-    else {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "Internal error: No exception");
+        rv = PyObject_CallMethod(builder, "build_grammar_error", "OiOOO",
+                                 ((Parser*)parser)->filename,
+                                 yyget_lineno(scanner) + ((Parser*)parser)->line,
+                                 value, type, traceback);
+    } else {
+        PyErr_SetString(PyExc_RuntimeError, "No exception");
     }
 
-    Py_XDECREF(ptype);
-    Py_XDECREF(pvalue);
-    Py_XDECREF(ptraceback);
+    Py_XDECREF(rv);
+    Py_XDECREF(type);
+    Py_XDECREF(value);
+    Py_XDECREF(traceback);
 }
 
 /* Error-handling function. {ca6aab8b9748} */
 void yyerror(YYLTYPE *locp, yyscan_t scanner, PyObject* parser, PyObject* builder, char const* message)
 {
+    PyObject* rv = NULL;
+
     /* Skip lex errors: they have already been registered the lexer itself. */
-    if (strstr(message, "LEX_ERROR") != NULL) {
+    if (strstr(message, "LEX_ERROR"))
         return;
-    }
-    else {
-        /* Register a syntax error with the builder. */
-        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "Ois",
-                                           ((Parser*)parser)->filename,
-                                           yyget_lineno(scanner) + ((Parser*)parser)->line,
-                                           message);
-        if (rv == NULL) {
-            PyErr_SetString(PyExc_RuntimeError,
-                            "Internal error: Building exception from yyerror()");
-        }
-        Py_XDECREF(rv);
-    }
+
+    /* Register a syntax error with the builder. */
+    rv = PyObject_CallMethod(builder, "build_grammar_error", "Ois",
+                             ((Parser*)parser)->filename,
+                             yyget_lineno(scanner) + ((Parser*)parser)->line,
+                             message);
+
+    Py_XDECREF(rv);
 }
 
 /* Get a printable version of a token name. */
@@ -164,7 +157,7 @@ const char* getTokenName(int token);
 #define DECREF6(x1, x2, x3, x4, x5, x6)    DECREF5(x1, x2, x3, x4, x5); Py_DECREF(x6);
 
 
-#line 168 "beancount/parser/grammar.c"
+#line 161 "beancount/parser/grammar.c"
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus
@@ -264,7 +257,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 124 "beancount/parser/grammar.y"
+#line 117 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -274,7 +267,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 278 "beancount/parser/grammar.c"
+#line 271 "beancount/parser/grammar.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -600,20 +593,20 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   258,   258,   261,   265,   269,   273,   278,   279,   283,
-     284,   285,   286,   292,   296,   301,   306,   311,   316,   321,
-     325,   330,   335,   340,   347,   355,   360,   366,   372,   376,
-     380,   384,   386,   391,   396,   401,   406,   412,   418,   423,
-     424,   425,   426,   427,   428,   429,   430,   431,   435,   441,
-     446,   450,   455,   460,   466,   471,   477,   482,   487,   493,
-     499,   505,   514,   520,   527,   531,   537,   543,   549,   555,
-     561,   567,   575,   582,   587,   592,   597,   602,   607,   612,
-     619,   625,   630,   635,   641,   646,   651,   657,   661,   665,
-     669,   676,   682,   688,   694,   700,   702,   709,   714,   719,
-     724,   729,   734,   744,   749,   755,   762,   763,   764,   765,
-     766,   767,   768,   769,   770,   771,   772,   773,   778,   784,
-     790,   795,   801,   802,   803,   804,   805,   806,   807,   808,
-     811,   815,   820,   838,   845
+       0,   251,   251,   254,   258,   262,   266,   271,   272,   276,
+     277,   278,   279,   285,   289,   294,   299,   304,   309,   314,
+     318,   323,   328,   333,   340,   348,   353,   359,   365,   369,
+     373,   377,   379,   384,   389,   394,   399,   405,   411,   416,
+     417,   418,   419,   420,   421,   422,   423,   424,   428,   434,
+     439,   443,   448,   453,   459,   464,   470,   475,   480,   486,
+     492,   498,   507,   513,   520,   524,   530,   536,   542,   548,
+     554,   560,   568,   575,   580,   585,   590,   595,   600,   605,
+     612,   618,   623,   628,   634,   639,   644,   650,   654,   658,
+     662,   669,   675,   681,   687,   693,   695,   702,   707,   712,
+     717,   722,   727,   737,   742,   748,   755,   756,   757,   758,
+     759,   760,   761,   762,   763,   764,   765,   766,   771,   777,
+     783,   788,   794,   795,   796,   797,   798,   799,   800,   801,
+     804,   808,   813,   831,   838
 };
 #endif
 
@@ -1674,848 +1667,848 @@ yyreduce:
   switch (yyn)
     {
   case 3:
-#line 262 "beancount/parser/grammar.y"
+#line 255 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1682 "beancount/parser/grammar.c"
+#line 1675 "beancount/parser/grammar.c"
     break;
 
   case 4:
-#line 266 "beancount/parser/grammar.y"
+#line 259 "beancount/parser/grammar.y"
     {
         (yyval.character) = (yyvsp[0].character);
     }
-#line 1690 "beancount/parser/grammar.c"
+#line 1683 "beancount/parser/grammar.c"
     break;
 
   case 5:
-#line 270 "beancount/parser/grammar.y"
+#line 263 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1698 "beancount/parser/grammar.c"
+#line 1691 "beancount/parser/grammar.c"
     break;
 
   case 6:
-#line 274 "beancount/parser/grammar.y"
+#line 267 "beancount/parser/grammar.y"
     {
         (yyval.character) = '#';
     }
-#line 1706 "beancount/parser/grammar.c"
+#line 1699 "beancount/parser/grammar.c"
     break;
 
   case 13:
-#line 293 "beancount/parser/grammar.y"
+#line 286 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1714 "beancount/parser/grammar.c"
+#line 1707 "beancount/parser/grammar.c"
     break;
 
   case 14:
-#line 297 "beancount/parser/grammar.y"
+#line 290 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Add((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1723 "beancount/parser/grammar.c"
+#line 1716 "beancount/parser/grammar.c"
     break;
 
   case 15:
-#line 302 "beancount/parser/grammar.y"
+#line 295 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Subtract((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1732 "beancount/parser/grammar.c"
+#line 1725 "beancount/parser/grammar.c"
     break;
 
   case 16:
-#line 307 "beancount/parser/grammar.y"
+#line 300 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Multiply((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1741 "beancount/parser/grammar.c"
+#line 1734 "beancount/parser/grammar.c"
     break;
 
   case 17:
-#line 312 "beancount/parser/grammar.y"
+#line 305 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_TrueDivide((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1750 "beancount/parser/grammar.c"
+#line 1743 "beancount/parser/grammar.c"
     break;
 
   case 18:
-#line 317 "beancount/parser/grammar.y"
+#line 310 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Negative((yyvsp[0].pyobj));
                 DECREF1((yyvsp[0].pyobj));
             }
-#line 1759 "beancount/parser/grammar.c"
+#line 1752 "beancount/parser/grammar.c"
     break;
 
   case 19:
-#line 322 "beancount/parser/grammar.y"
+#line 315 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1767 "beancount/parser/grammar.c"
+#line 1760 "beancount/parser/grammar.c"
     break;
 
   case 20:
-#line 326 "beancount/parser/grammar.y"
+#line 319 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1775 "beancount/parser/grammar.c"
+#line 1768 "beancount/parser/grammar.c"
     break;
 
   case 21:
-#line 331 "beancount/parser/grammar.y"
+#line 324 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 1784 "beancount/parser/grammar.c"
+#line 1777 "beancount/parser/grammar.c"
     break;
 
   case 22:
-#line 336 "beancount/parser/grammar.y"
+#line 329 "beancount/parser/grammar.y"
     {
-                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
             }
-#line 1793 "beancount/parser/grammar.c"
+#line 1786 "beancount/parser/grammar.c"
     break;
 
   case 23:
-#line 341 "beancount/parser/grammar.y"
+#line 334 "beancount/parser/grammar.y"
     {
-                BUILDY(,
+                BUILD(,
                        (yyval.pyobj), "pipe_deprecated_error", "Oi", FILENAME, LINENO);
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1803 "beancount/parser/grammar.c"
+#line 1796 "beancount/parser/grammar.c"
     break;
 
   case 24:
-#line 348 "beancount/parser/grammar.y"
+#line 341 "beancount/parser/grammar.y"
     {
                /* Note: We're passing a bogus value here in order to avoid
                 * having to declare a second macro just for this one special
                 * case. */
-               BUILDY(,
+               BUILD(,
                       (yyval.pyobj), "tag_link_new", "O", Py_None);
            }
-#line 1815 "beancount/parser/grammar.c"
+#line 1808 "beancount/parser/grammar.c"
     break;
 
   case 25:
-#line 356 "beancount/parser/grammar.y"
+#line 349 "beancount/parser/grammar.y"
     {
-               BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+               BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1824 "beancount/parser/grammar.c"
+#line 1817 "beancount/parser/grammar.c"
     break;
 
   case 26:
-#line 361 "beancount/parser/grammar.y"
+#line 354 "beancount/parser/grammar.y"
     {
-               BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+               BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1833 "beancount/parser/grammar.c"
+#line 1826 "beancount/parser/grammar.c"
     break;
 
   case 27:
-#line 367 "beancount/parser/grammar.y"
+#line 360 "beancount/parser/grammar.y"
     {
-                BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "transaction", "OiObOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1842 "beancount/parser/grammar.c"
+#line 1835 "beancount/parser/grammar.c"
     break;
 
   case 28:
-#line 373 "beancount/parser/grammar.y"
+#line 366 "beancount/parser/grammar.y"
     {
             (yyval.character) = '\0';
         }
-#line 1850 "beancount/parser/grammar.c"
+#line 1843 "beancount/parser/grammar.c"
     break;
 
   case 29:
-#line 377 "beancount/parser/grammar.y"
+#line 370 "beancount/parser/grammar.y"
     {
             (yyval.character) = '*';
         }
-#line 1858 "beancount/parser/grammar.c"
+#line 1851 "beancount/parser/grammar.c"
     break;
 
   case 30:
-#line 381 "beancount/parser/grammar.y"
+#line 374 "beancount/parser/grammar.y"
     {
             (yyval.character) = '#';
         }
-#line 1866 "beancount/parser/grammar.c"
+#line 1859 "beancount/parser/grammar.c"
     break;
 
   case 32:
-#line 387 "beancount/parser/grammar.y"
+#line 380 "beancount/parser/grammar.y"
     {
                      (yyval.pyobj) = (yyvsp[0].pyobj);
                  }
-#line 1874 "beancount/parser/grammar.c"
+#line 1867 "beancount/parser/grammar.c"
     break;
 
   case 33:
-#line 392 "beancount/parser/grammar.y"
+#line 385 "beancount/parser/grammar.y"
     {
-            BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
+            BUILD(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
         }
-#line 1883 "beancount/parser/grammar.c"
+#line 1876 "beancount/parser/grammar.c"
     break;
 
   case 34:
-#line 397 "beancount/parser/grammar.y"
+#line 390 "beancount/parser/grammar.y"
     {
-            BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
+            BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
         }
-#line 1892 "beancount/parser/grammar.c"
+#line 1885 "beancount/parser/grammar.c"
     break;
 
   case 35:
-#line 402 "beancount/parser/grammar.y"
+#line 395 "beancount/parser/grammar.y"
     {
-            BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
+            BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
         }
-#line 1901 "beancount/parser/grammar.c"
+#line 1894 "beancount/parser/grammar.c"
     break;
 
   case 36:
-#line 407 "beancount/parser/grammar.y"
+#line 400 "beancount/parser/grammar.y"
     {
-            BUILDY(DECREF1((yyvsp[-1].pyobj)),
+            BUILD(DECREF1((yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OiOOOOOb", FILENAME, LINENO, (yyvsp[-1].pyobj), missing, Py_None, Py_None, Py_False, (yyvsp[-2].character));
         }
-#line 1910 "beancount/parser/grammar.c"
+#line 1903 "beancount/parser/grammar.c"
     break;
 
   case 37:
-#line 413 "beancount/parser/grammar.y"
+#line 406 "beancount/parser/grammar.y"
     {
-              BUILDY(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
+              BUILD(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
           }
-#line 1919 "beancount/parser/grammar.c"
+#line 1912 "beancount/parser/grammar.c"
     break;
 
   case 38:
-#line 419 "beancount/parser/grammar.y"
+#line 412 "beancount/parser/grammar.y"
     {
                    (yyval.pyobj) = (yyvsp[-1].pyobj);
                }
-#line 1927 "beancount/parser/grammar.c"
+#line 1920 "beancount/parser/grammar.c"
     break;
 
   case 47:
-#line 432 "beancount/parser/grammar.y"
+#line 425 "beancount/parser/grammar.y"
     {
                     (yyval.pyobj) = (yyvsp[0].pyobj);
                 }
-#line 1935 "beancount/parser/grammar.c"
+#line 1928 "beancount/parser/grammar.c"
     break;
 
   case 48:
-#line 436 "beancount/parser/grammar.y"
+#line 429 "beancount/parser/grammar.y"
     {
                     Py_INCREF(Py_None);
                     (yyval.pyobj) = Py_None;
                 }
-#line 1944 "beancount/parser/grammar.c"
+#line 1937 "beancount/parser/grammar.c"
     break;
 
   case 49:
-#line 442 "beancount/parser/grammar.y"
+#line 435 "beancount/parser/grammar.y"
     {
                        Py_INCREF(Py_None);
                        (yyval.pyobj) = Py_None;
                    }
-#line 1953 "beancount/parser/grammar.c"
+#line 1946 "beancount/parser/grammar.c"
     break;
 
   case 50:
-#line 447 "beancount/parser/grammar.y"
+#line 440 "beancount/parser/grammar.y"
     {
                        (yyval.pyobj) = (yyvsp[-3].pyobj);
                    }
-#line 1961 "beancount/parser/grammar.c"
+#line 1954 "beancount/parser/grammar.c"
     break;
 
   case 51:
-#line 451 "beancount/parser/grammar.y"
+#line 444 "beancount/parser/grammar.y"
     {
-                       BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
+                       BUILD(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
                    }
-#line 1970 "beancount/parser/grammar.c"
+#line 1963 "beancount/parser/grammar.c"
     break;
 
   case 52:
-#line 456 "beancount/parser/grammar.y"
+#line 449 "beancount/parser/grammar.y"
     {
-                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                       BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 1979 "beancount/parser/grammar.c"
+#line 1972 "beancount/parser/grammar.c"
     break;
 
   case 53:
-#line 461 "beancount/parser/grammar.y"
+#line 454 "beancount/parser/grammar.y"
     {
-                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                       BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 1988 "beancount/parser/grammar.c"
+#line 1981 "beancount/parser/grammar.c"
     break;
 
   case 54:
-#line 467 "beancount/parser/grammar.y"
+#line 460 "beancount/parser/grammar.y"
     {
                    Py_INCREF(Py_None);
                    (yyval.pyobj) = Py_None;
                }
-#line 1997 "beancount/parser/grammar.c"
+#line 1990 "beancount/parser/grammar.c"
     break;
 
   case 55:
-#line 472 "beancount/parser/grammar.y"
+#line 465 "beancount/parser/grammar.y"
     {
-                   BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                   BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                }
-#line 2006 "beancount/parser/grammar.c"
+#line 1999 "beancount/parser/grammar.c"
     break;
 
   case 56:
-#line 478 "beancount/parser/grammar.y"
+#line 471 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
               }
-#line 2015 "beancount/parser/grammar.c"
+#line 2008 "beancount/parser/grammar.c"
     break;
 
   case 57:
-#line 483 "beancount/parser/grammar.y"
+#line 476 "beancount/parser/grammar.y"
     {
-                  BUILDY(DECREF1((yyvsp[0].pyobj)),
+                  BUILD(DECREF1((yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
               }
-#line 2024 "beancount/parser/grammar.c"
+#line 2017 "beancount/parser/grammar.c"
     break;
 
   case 58:
-#line 488 "beancount/parser/grammar.y"
+#line 481 "beancount/parser/grammar.y"
     {
-                  BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                  BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
               }
-#line 2033 "beancount/parser/grammar.c"
+#line 2026 "beancount/parser/grammar.c"
     break;
 
   case 59:
-#line 494 "beancount/parser/grammar.y"
+#line 487 "beancount/parser/grammar.y"
     {
-             BUILDY(DECREF1((yyvsp[-1].pyobj)),
+             BUILD(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
          }
-#line 2042 "beancount/parser/grammar.c"
+#line 2035 "beancount/parser/grammar.c"
     break;
 
   case 60:
-#line 500 "beancount/parser/grammar.y"
+#line 493 "beancount/parser/grammar.y"
     {
-           BUILDY(DECREF1((yyvsp[-1].pyobj)),
+           BUILD(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
        }
-#line 2051 "beancount/parser/grammar.c"
+#line 2044 "beancount/parser/grammar.c"
     break;
 
   case 61:
-#line 506 "beancount/parser/grammar.y"
+#line 499 "beancount/parser/grammar.y"
     {
              /* Note: key_value is a tuple, Py_BuildValue() won't wrap it up
               * within a tuple, so expand in the method (it receives two
               * objects). See https://docs.python.org/3.4/c-api/arg.html. */
-             BUILDY(DECREF1((yyvsp[-1].pyobj)),
+             BUILD(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
          }
-#line 2063 "beancount/parser/grammar.c"
+#line 2056 "beancount/parser/grammar.c"
     break;
 
   case 62:
-#line 515 "beancount/parser/grammar.y"
+#line 508 "beancount/parser/grammar.y"
     {
-            BUILDY(DECREF1((yyvsp[-2].pyobj)),
+            BUILD(DECREF1((yyvsp[-2].pyobj)),
                    (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
         }
-#line 2072 "beancount/parser/grammar.c"
+#line 2065 "beancount/parser/grammar.c"
     break;
 
   case 63:
-#line 521 "beancount/parser/grammar.y"
+#line 514 "beancount/parser/grammar.y"
     {
-         BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+         BUILD(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                 (yyval.pyobj), "open", "OiOOOOO", FILENAME, LINENO, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          ;
      }
-#line 2082 "beancount/parser/grammar.c"
+#line 2075 "beancount/parser/grammar.c"
     break;
 
   case 64:
-#line 528 "beancount/parser/grammar.y"
+#line 521 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2090 "beancount/parser/grammar.c"
+#line 2083 "beancount/parser/grammar.c"
     break;
 
   case 65:
-#line 532 "beancount/parser/grammar.y"
+#line 525 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2099 "beancount/parser/grammar.c"
+#line 2092 "beancount/parser/grammar.c"
     break;
 
   case 66:
-#line 538 "beancount/parser/grammar.y"
+#line 531 "beancount/parser/grammar.y"
     {
-          BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+          BUILD(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "close", "OiOOO", FILENAME, LINENO, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2108 "beancount/parser/grammar.c"
+#line 2101 "beancount/parser/grammar.c"
     break;
 
   case 67:
-#line 544 "beancount/parser/grammar.y"
+#line 537 "beancount/parser/grammar.y"
     {
-              BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+              BUILD(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "commodity", "OiOOO", FILENAME, LINENO, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
           }
-#line 2117 "beancount/parser/grammar.c"
+#line 2110 "beancount/parser/grammar.c"
     break;
 
   case 68:
-#line 550 "beancount/parser/grammar.y"
+#line 543 "beancount/parser/grammar.y"
     {
-        BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+        BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "pad", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
     }
-#line 2126 "beancount/parser/grammar.c"
+#line 2119 "beancount/parser/grammar.c"
     break;
 
   case 69:
-#line 556 "beancount/parser/grammar.y"
+#line 549 "beancount/parser/grammar.y"
     {
-            BUILDY(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
+            BUILD(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
                    (yyval.pyobj), "balance", "OiOOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
         }
-#line 2135 "beancount/parser/grammar.c"
+#line 2128 "beancount/parser/grammar.c"
     break;
 
   case 70:
-#line 562 "beancount/parser/grammar.y"
+#line 555 "beancount/parser/grammar.y"
     {
-           BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+           BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
        }
-#line 2144 "beancount/parser/grammar.c"
+#line 2137 "beancount/parser/grammar.c"
     break;
 
   case 71:
-#line 568 "beancount/parser/grammar.y"
+#line 561 "beancount/parser/grammar.y"
     {
-                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                     BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = Py_None;
                      Py_INCREF(Py_None);
                      ;
                  }
-#line 2156 "beancount/parser/grammar.c"
+#line 2149 "beancount/parser/grammar.c"
     break;
 
   case 72:
-#line 576 "beancount/parser/grammar.y"
+#line 569 "beancount/parser/grammar.y"
     {
-                     BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
+                     BUILD(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = (yyvsp[-1].pyobj);
                  }
-#line 2166 "beancount/parser/grammar.c"
+#line 2159 "beancount/parser/grammar.c"
     break;
 
   case 73:
-#line 583 "beancount/parser/grammar.y"
+#line 576 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing);
                  (yyval.pyobj) = missing;
              }
-#line 2175 "beancount/parser/grammar.c"
+#line 2168 "beancount/parser/grammar.c"
     break;
 
   case 74:
-#line 588 "beancount/parser/grammar.y"
+#line 581 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2183 "beancount/parser/grammar.c"
+#line 2176 "beancount/parser/grammar.c"
     break;
 
   case 75:
-#line 593 "beancount/parser/grammar.y"
+#line 586 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing);
                  (yyval.pyobj) = missing;
              }
-#line 2192 "beancount/parser/grammar.c"
+#line 2185 "beancount/parser/grammar.c"
     break;
 
   case 76:
-#line 598 "beancount/parser/grammar.y"
+#line 591 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2200 "beancount/parser/grammar.c"
+#line 2193 "beancount/parser/grammar.c"
     break;
 
   case 77:
-#line 603 "beancount/parser/grammar.y"
+#line 596 "beancount/parser/grammar.y"
     {
-                    BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                    BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2209 "beancount/parser/grammar.c"
+#line 2202 "beancount/parser/grammar.c"
     break;
 
   case 78:
-#line 608 "beancount/parser/grammar.y"
+#line 601 "beancount/parser/grammar.y"
     {
-                    BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                    BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2218 "beancount/parser/grammar.c"
+#line 2211 "beancount/parser/grammar.c"
     break;
 
   case 79:
-#line 613 "beancount/parser/grammar.y"
+#line 606 "beancount/parser/grammar.y"
     {
-                    BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                    BUILD(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                     ;
                 }
-#line 2228 "beancount/parser/grammar.c"
+#line 2221 "beancount/parser/grammar.c"
     break;
 
   case 80:
-#line 620 "beancount/parser/grammar.y"
+#line 613 "beancount/parser/grammar.y"
     {
-                      BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                      BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                  }
-#line 2237 "beancount/parser/grammar.c"
+#line 2230 "beancount/parser/grammar.c"
     break;
 
   case 81:
-#line 626 "beancount/parser/grammar.y"
+#line 619 "beancount/parser/grammar.y"
     {
-              BUILDY(DECREF1((yyvsp[-1].pyobj)),
+              BUILD(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
           }
-#line 2246 "beancount/parser/grammar.c"
+#line 2239 "beancount/parser/grammar.c"
     break;
 
   case 82:
-#line 631 "beancount/parser/grammar.y"
+#line 624 "beancount/parser/grammar.y"
     {
-              BUILDY(DECREF1((yyvsp[-1].pyobj)),
+              BUILD(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
           }
-#line 2255 "beancount/parser/grammar.c"
+#line 2248 "beancount/parser/grammar.c"
     break;
 
   case 83:
-#line 636 "beancount/parser/grammar.y"
+#line 629 "beancount/parser/grammar.y"
     {
               Py_INCREF(Py_None);
               (yyval.pyobj) = Py_None;
           }
-#line 2264 "beancount/parser/grammar.c"
+#line 2257 "beancount/parser/grammar.c"
     break;
 
   case 84:
-#line 642 "beancount/parser/grammar.y"
+#line 635 "beancount/parser/grammar.y"
     {
                    /* We indicate that there was a cost if there */
                    (yyval.pyobj) = PyList_New(0);
                }
-#line 2273 "beancount/parser/grammar.c"
+#line 2266 "beancount/parser/grammar.c"
     break;
 
   case 85:
-#line 647 "beancount/parser/grammar.y"
+#line 640 "beancount/parser/grammar.y"
     {
-                   BUILDY(DECREF1((yyvsp[0].pyobj)),
+                   BUILD(DECREF1((yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
                }
-#line 2282 "beancount/parser/grammar.c"
+#line 2275 "beancount/parser/grammar.c"
     break;
 
   case 86:
-#line 652 "beancount/parser/grammar.y"
+#line 645 "beancount/parser/grammar.y"
     {
-                   BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+                   BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                }
-#line 2291 "beancount/parser/grammar.c"
+#line 2284 "beancount/parser/grammar.c"
     break;
 
   case 87:
-#line 658 "beancount/parser/grammar.y"
+#line 651 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2299 "beancount/parser/grammar.c"
+#line 2292 "beancount/parser/grammar.c"
     break;
 
   case 88:
-#line 662 "beancount/parser/grammar.y"
+#line 655 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2307 "beancount/parser/grammar.c"
+#line 2300 "beancount/parser/grammar.c"
     break;
 
   case 89:
-#line 666 "beancount/parser/grammar.y"
+#line 659 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2315 "beancount/parser/grammar.c"
+#line 2308 "beancount/parser/grammar.c"
     break;
 
   case 90:
-#line 670 "beancount/parser/grammar.y"
+#line 663 "beancount/parser/grammar.y"
     {
-              BUILDY(,
+              BUILD(,
                      (yyval.pyobj), "cost_merge", "O", Py_None);
           }
-#line 2324 "beancount/parser/grammar.c"
+#line 2317 "beancount/parser/grammar.c"
     break;
 
   case 91:
-#line 677 "beancount/parser/grammar.y"
+#line 670 "beancount/parser/grammar.y"
     {
-          BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+          BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "price", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2333 "beancount/parser/grammar.c"
+#line 2326 "beancount/parser/grammar.c"
     break;
 
   case 92:
-#line 683 "beancount/parser/grammar.y"
+#line 676 "beancount/parser/grammar.y"
     {
-          BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+          BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "event", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2342 "beancount/parser/grammar.c"
+#line 2335 "beancount/parser/grammar.c"
     break;
 
   case 93:
-#line 689 "beancount/parser/grammar.y"
+#line 682 "beancount/parser/grammar.y"
     {
-             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+             BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "query", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2351 "beancount/parser/grammar.c"
+#line 2344 "beancount/parser/grammar.c"
     break;
 
   case 94:
-#line 695 "beancount/parser/grammar.y"
+#line 688 "beancount/parser/grammar.y"
     {
-          BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+          BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "note", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2360 "beancount/parser/grammar.c"
+#line 2353 "beancount/parser/grammar.c"
     break;
 
   case 96:
-#line 703 "beancount/parser/grammar.y"
+#line 696 "beancount/parser/grammar.y"
     {
-             BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+             BUILD(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "document", "OiOOOOO", FILENAME, LINENO, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2369 "beancount/parser/grammar.c"
+#line 2362 "beancount/parser/grammar.c"
     break;
 
   case 97:
-#line 710 "beancount/parser/grammar.y"
+#line 703 "beancount/parser/grammar.y"
     {
-                 BUILDY(DECREF1((yyvsp[0].pyobj)),
+                 BUILD(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2378 "beancount/parser/grammar.c"
+#line 2371 "beancount/parser/grammar.c"
     break;
 
   case 98:
-#line 715 "beancount/parser/grammar.y"
+#line 708 "beancount/parser/grammar.y"
     {
-                 BUILDY(DECREF1((yyvsp[0].pyobj)),
+                 BUILD(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2387 "beancount/parser/grammar.c"
+#line 2380 "beancount/parser/grammar.c"
     break;
 
   case 99:
-#line 720 "beancount/parser/grammar.y"
+#line 713 "beancount/parser/grammar.y"
     {
-                 BUILDY(DECREF1((yyvsp[0].pyobj)),
+                 BUILD(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2396 "beancount/parser/grammar.c"
+#line 2389 "beancount/parser/grammar.c"
     break;
 
   case 100:
-#line 725 "beancount/parser/grammar.y"
+#line 718 "beancount/parser/grammar.y"
     {
-                 BUILDY(DECREF1((yyvsp[0].pyobj)),
+                 BUILD(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2405 "beancount/parser/grammar.c"
+#line 2398 "beancount/parser/grammar.c"
     break;
 
   case 101:
-#line 730 "beancount/parser/grammar.y"
+#line 723 "beancount/parser/grammar.y"
     {
-                 BUILDY(DECREF1((yyvsp[0].pyobj)),
+                 BUILD(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2414 "beancount/parser/grammar.c"
+#line 2407 "beancount/parser/grammar.c"
     break;
 
   case 102:
-#line 735 "beancount/parser/grammar.y"
+#line 728 "beancount/parser/grammar.y"
     {
                  /* Obtain beancount.core.account.TYPE */
                  PyObject* module = PyImport_ImportModule("beancount.core.account");
                  PyObject* dtype = PyObject_GetAttrString(module, "TYPE");
                  Py_DECREF(module);
-                 BUILDY(DECREF2((yyvsp[0].pyobj), dtype),
+                 BUILD(DECREF2((yyvsp[0].pyobj), dtype),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
              }
-#line 2427 "beancount/parser/grammar.c"
+#line 2420 "beancount/parser/grammar.c"
     break;
 
   case 103:
-#line 745 "beancount/parser/grammar.y"
+#line 738 "beancount/parser/grammar.y"
     {
                       Py_INCREF(Py_None);
                       (yyval.pyobj) = Py_None;
                   }
-#line 2436 "beancount/parser/grammar.c"
+#line 2429 "beancount/parser/grammar.c"
     break;
 
   case 104:
-#line 750 "beancount/parser/grammar.y"
+#line 743 "beancount/parser/grammar.y"
     {
-                      BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                      BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                   }
-#line 2445 "beancount/parser/grammar.c"
+#line 2438 "beancount/parser/grammar.c"
     break;
 
   case 105:
-#line 756 "beancount/parser/grammar.y"
+#line 749 "beancount/parser/grammar.y"
     {
-           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
+           BUILD(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "custom", "OiOOOO", FILENAME, LINENO, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
        }
-#line 2454 "beancount/parser/grammar.c"
+#line 2447 "beancount/parser/grammar.c"
     break;
 
   case 117:
-#line 774 "beancount/parser/grammar.y"
+#line 767 "beancount/parser/grammar.y"
     {
           (yyval.pyobj) = (yyvsp[0].pyobj);
       }
-#line 2462 "beancount/parser/grammar.c"
+#line 2455 "beancount/parser/grammar.c"
     break;
 
   case 118:
-#line 779 "beancount/parser/grammar.y"
+#line 772 "beancount/parser/grammar.y"
     {
-           BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
+           BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "option", "OiOO", FILENAME, LINENO, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2471 "beancount/parser/grammar.c"
+#line 2464 "beancount/parser/grammar.c"
     break;
 
   case 119:
-#line 785 "beancount/parser/grammar.y"
+#line 778 "beancount/parser/grammar.y"
     {
-           BUILDY(DECREF1((yyvsp[-1].pyobj)),
+           BUILD(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "include", "OiO", FILENAME, LINENO, (yyvsp[-1].pyobj));
        }
-#line 2480 "beancount/parser/grammar.c"
+#line 2473 "beancount/parser/grammar.c"
     break;
 
   case 120:
-#line 791 "beancount/parser/grammar.y"
+#line 784 "beancount/parser/grammar.y"
     {
-           BUILDY(DECREF1((yyvsp[-1].pyobj)),
+           BUILD(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "OiOO", FILENAME, LINENO, (yyvsp[-1].pyobj), Py_None);
        }
-#line 2489 "beancount/parser/grammar.c"
+#line 2482 "beancount/parser/grammar.c"
     break;
 
   case 121:
-#line 796 "beancount/parser/grammar.y"
+#line 789 "beancount/parser/grammar.y"
     {
-           BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
+           BUILD(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "OiOO", FILENAME, LINENO, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2498 "beancount/parser/grammar.c"
+#line 2491 "beancount/parser/grammar.c"
     break;
 
   case 130:
-#line 812 "beancount/parser/grammar.y"
+#line 805 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2506 "beancount/parser/grammar.c"
+#line 2499 "beancount/parser/grammar.c"
     break;
 
   case 131:
-#line 816 "beancount/parser/grammar.y"
+#line 809 "beancount/parser/grammar.y"
     {
-                 BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
+                 BUILD(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
              }
-#line 2515 "beancount/parser/grammar.c"
+#line 2508 "beancount/parser/grammar.c"
     break;
 
   case 132:
-#line 821 "beancount/parser/grammar.y"
+#line 814 "beancount/parser/grammar.y"
     {
                  /*
                   * Ignore the error and continue reducing ({3d95e55b654e}).
@@ -2533,20 +2526,20 @@ yyreduce:
                   */
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2537 "beancount/parser/grammar.c"
+#line 2530 "beancount/parser/grammar.c"
     break;
 
   case 133:
-#line 839 "beancount/parser/grammar.y"
+#line 832 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
              }
-#line 2546 "beancount/parser/grammar.c"
+#line 2539 "beancount/parser/grammar.c"
     break;
 
   case 134:
-#line 846 "beancount/parser/grammar.y"
+#line 839 "beancount/parser/grammar.y"
     {
          /* If a Python exception has been raised and not handled, abort. In
           * case of unrecoverable error, the lexer raises a Python exception and
@@ -2555,14 +2548,14 @@ yyreduce:
          if (PyErr_Occurred()) {
              YYABORT;
          }
-         BUILDY(DECREF1((yyvsp[0].pyobj)),
+         BUILD(DECREF1((yyvsp[0].pyobj)),
                 (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2562 "beancount/parser/grammar.c"
+#line 2555 "beancount/parser/grammar.c"
     break;
 
 
-#line 2566 "beancount/parser/grammar.c"
+#line 2559 "beancount/parser/grammar.c"
 
       default: break;
     }
@@ -2800,7 +2793,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 861 "beancount/parser/grammar.y"
+#line 854 "beancount/parser/grammar.y"
 
 
 /* A function that will convert a token name to a string, used in debugging. */

--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -54,7 +54,7 @@
 #define YYSKELETON_NAME "yacc.c"
 
 /* Pure parsers.  */
-#define YYPURE 1
+#define YYPURE 2
 
 /* Push parsers.  */
 #define YYPUSH 0
@@ -74,6 +74,7 @@
 #include "parser.h"
 #include "lexer.h"
 
+extern YY_DECL;
 
 /*
  * Call a builder method and detect and handle a Python exception being raised
@@ -84,7 +85,7 @@
     target = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);    \
     clean;                                                                      \
     if (target == NULL) {                                                       \
-        build_grammar_error_from_exception();                                   \
+        build_grammar_error_from_exception(scanner);                            \
         YYERROR;                                                                \
     }
 
@@ -96,7 +97,7 @@ int yy_firstline;
 
 
 /* Build a grammar error from the exception context. */
-void build_grammar_error_from_exception(void)
+void build_grammar_error_from_exception(yyscan_t scanner)
 {
     TRACE_ERROR("Grammar Builder Exception");
 
@@ -113,7 +114,7 @@ void build_grammar_error_from_exception(void)
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "siOOO",
-                                           yy_filename, yylineno + yy_firstline,
+                                           yy_filename, yyget_lineno(scanner) + yy_firstline,
                                            pvalue, ptype, ptraceback ?: Py_None);
         if (rv == NULL) {
             /* Note: Leave the internal error trickling up its detail. */
@@ -134,7 +135,7 @@ void build_grammar_error_from_exception(void)
 
 
 /* Error-handling function. {ca6aab8b9748} */
-void yyerror(char const* message)
+void yyerror(YYLTYPE *locp, yyscan_t scanner, char const* message)
 {
     /* Skip lex errors: they have already been registered the lexer itself. */
     if (strstr(message, "LEX_ERROR") != NULL) {
@@ -143,7 +144,7 @@ void yyerror(char const* message)
     else {
         /* Register a syntax error with the builder. */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "sis",
-                                           yy_filename, yylineno + yy_firstline,
+                                           yy_filename, yyget_lineno(scanner) + yy_firstline,
                                            message);
         if (rv == NULL) {
             PyErr_SetString(PyExc_RuntimeError,
@@ -166,7 +167,7 @@ const char* getTokenName(int token);
 #define DECREF6(x1, x2, x3, x4, x5, x6)    DECREF5(x1, x2, x3, x4, x5); Py_DECREF(x6);
 
 
-#line 170 "beancount/parser/grammar.c"
+#line 171 "beancount/parser/grammar.c"
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus
@@ -266,7 +267,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 126 "beancount/parser/grammar.y"
+#line 125 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -276,7 +277,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 280 "beancount/parser/grammar.c"
+#line 281 "beancount/parser/grammar.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -300,7 +301,7 @@ struct YYLTYPE
 
 
 
-int yyparse (void);
+int yyparse (yyscan_t scanner);
 
 #endif /* !YY_YY_BEANCOUNT_PARSER_GRAMMAR_H_INCLUDED  */
 
@@ -602,20 +603,20 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   260,   260,   263,   267,   271,   275,   280,   281,   285,
-     286,   287,   288,   294,   298,   303,   308,   313,   318,   323,
-     327,   332,   337,   342,   349,   357,   362,   368,   374,   378,
-     382,   386,   388,   393,   398,   403,   408,   414,   420,   425,
-     426,   427,   428,   429,   430,   431,   432,   433,   437,   443,
-     448,   452,   457,   462,   468,   473,   479,   484,   489,   495,
-     501,   507,   516,   522,   529,   533,   539,   545,   551,   557,
-     563,   569,   577,   584,   589,   594,   599,   604,   609,   614,
-     621,   627,   632,   637,   643,   648,   653,   659,   663,   667,
-     671,   678,   684,   690,   696,   702,   704,   711,   716,   721,
-     726,   731,   736,   746,   751,   757,   764,   765,   766,   767,
-     768,   769,   770,   771,   772,   773,   774,   775,   780,   786,
-     792,   797,   803,   804,   805,   806,   807,   808,   809,   810,
-     813,   817,   822,   840,   847
+       0,   259,   259,   262,   266,   270,   274,   279,   280,   284,
+     285,   286,   287,   293,   297,   302,   307,   312,   317,   322,
+     326,   331,   336,   341,   348,   356,   361,   367,   373,   377,
+     381,   385,   387,   392,   397,   402,   407,   413,   419,   424,
+     425,   426,   427,   428,   429,   430,   431,   432,   436,   442,
+     447,   451,   456,   461,   467,   472,   478,   483,   488,   494,
+     500,   506,   515,   521,   528,   532,   538,   544,   550,   556,
+     562,   568,   576,   583,   588,   593,   598,   603,   608,   613,
+     620,   626,   631,   636,   642,   647,   652,   658,   662,   666,
+     670,   677,   683,   689,   695,   701,   703,   710,   715,   720,
+     725,   730,   735,   745,   750,   756,   763,   764,   765,   766,
+     767,   768,   769,   770,   771,   772,   773,   774,   779,   785,
+     791,   796,   802,   803,   804,   805,   806,   807,   808,   809,
+     812,   816,   821,   839,   846
 };
 #endif
 
@@ -910,7 +911,7 @@ static const yytype_uint8 yyr2[] =
       }                                                           \
     else                                                          \
       {                                                           \
-        yyerror (YY_("syntax error: cannot back up")); \
+        yyerror (&yylloc, scanner, YY_("syntax error: cannot back up")); \
         YYERROR;                                                  \
       }                                                           \
   while (0)
@@ -1012,7 +1013,7 @@ do {                                                                      \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value, Location); \
+                  Type, Value, Location, scanner); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -1023,11 +1024,12 @@ do {                                                                      \
 `-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
+yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner)
 {
   FILE *yyoutput = yyo;
   YYUSE (yyoutput);
   YYUSE (yylocationp);
+  YYUSE (scanner);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
@@ -1045,14 +1047,14 @@ yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YY
 `---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
+yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner)
 {
   YYFPRINTF (yyo, "%s %s (",
              yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
   YY_LOCATION_PRINT (yyo, *yylocationp);
   YYFPRINTF (yyo, ": ");
-  yy_symbol_value_print (yyo, yytype, yyvaluep, yylocationp);
+  yy_symbol_value_print (yyo, yytype, yyvaluep, yylocationp, scanner);
   YYFPRINTF (yyo, ")");
 }
 
@@ -1085,7 +1087,7 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule)
+yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, yyscan_t scanner)
 {
   unsigned long yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -1099,7 +1101,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule
       yy_symbol_print (stderr,
                        yystos[yyssp[yyi + 1 - yynrhs]],
                        &yyvsp[(yyi + 1) - (yynrhs)]
-                       , &(yylsp[(yyi + 1) - (yynrhs)])                       );
+                       , &(yylsp[(yyi + 1) - (yynrhs)])                       , scanner);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -1107,7 +1109,7 @@ yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule
 # define YY_REDUCE_PRINT(Rule)          \
 do {                                    \
   if (yydebug)                          \
-    yy_reduce_print (yyssp, yyvsp, yylsp, Rule); \
+    yy_reduce_print (yyssp, yyvsp, yylsp, Rule, scanner); \
 } while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
@@ -1370,10 +1372,11 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp)
+yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, yyscan_t scanner)
 {
   YYUSE (yyvaluep);
   YYUSE (yylocationp);
+  YYUSE (scanner);
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
@@ -1391,7 +1394,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
 `----------*/
 
 int
-yyparse (void)
+yyparse (yyscan_t scanner)
 {
 /* The lookahead symbol.  */
 int yychar;
@@ -1589,7 +1592,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = yylex (&yylval, &yylloc);
+      yychar = yylex (&yylval, &yylloc, scanner);
     }
 
   if (yychar <= YYEOF)
@@ -1670,136 +1673,136 @@ yyreduce:
   switch (yyn)
     {
   case 3:
-#line 264 "beancount/parser/grammar.y"
+#line 263 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1678 "beancount/parser/grammar.c"
+#line 1681 "beancount/parser/grammar.c"
     break;
 
   case 4:
-#line 268 "beancount/parser/grammar.y"
+#line 267 "beancount/parser/grammar.y"
     {
         (yyval.character) = (yyvsp[0].character);
     }
-#line 1686 "beancount/parser/grammar.c"
+#line 1689 "beancount/parser/grammar.c"
     break;
 
   case 5:
-#line 272 "beancount/parser/grammar.y"
+#line 271 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1694 "beancount/parser/grammar.c"
+#line 1697 "beancount/parser/grammar.c"
     break;
 
   case 6:
-#line 276 "beancount/parser/grammar.y"
+#line 275 "beancount/parser/grammar.y"
     {
         (yyval.character) = '#';
     }
-#line 1702 "beancount/parser/grammar.c"
+#line 1705 "beancount/parser/grammar.c"
     break;
 
   case 13:
-#line 295 "beancount/parser/grammar.y"
+#line 294 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1710 "beancount/parser/grammar.c"
+#line 1713 "beancount/parser/grammar.c"
     break;
 
   case 14:
-#line 299 "beancount/parser/grammar.y"
+#line 298 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Add((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1719 "beancount/parser/grammar.c"
+#line 1722 "beancount/parser/grammar.c"
     break;
 
   case 15:
-#line 304 "beancount/parser/grammar.y"
+#line 303 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Subtract((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1728 "beancount/parser/grammar.c"
+#line 1731 "beancount/parser/grammar.c"
     break;
 
   case 16:
-#line 309 "beancount/parser/grammar.y"
+#line 308 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Multiply((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1737 "beancount/parser/grammar.c"
+#line 1740 "beancount/parser/grammar.c"
     break;
 
   case 17:
-#line 314 "beancount/parser/grammar.y"
+#line 313 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_TrueDivide((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1746 "beancount/parser/grammar.c"
+#line 1749 "beancount/parser/grammar.c"
     break;
 
   case 18:
-#line 319 "beancount/parser/grammar.y"
+#line 318 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = PyNumber_Negative((yyvsp[0].pyobj));
                 DECREF1((yyvsp[0].pyobj));
             }
-#line 1755 "beancount/parser/grammar.c"
+#line 1758 "beancount/parser/grammar.c"
     break;
 
   case 19:
-#line 324 "beancount/parser/grammar.y"
+#line 323 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1763 "beancount/parser/grammar.c"
+#line 1766 "beancount/parser/grammar.c"
     break;
 
   case 20:
-#line 328 "beancount/parser/grammar.y"
+#line 327 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1771 "beancount/parser/grammar.c"
+#line 1774 "beancount/parser/grammar.c"
     break;
 
   case 21:
-#line 333 "beancount/parser/grammar.y"
+#line 332 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 1780 "beancount/parser/grammar.c"
+#line 1783 "beancount/parser/grammar.c"
     break;
 
   case 22:
-#line 338 "beancount/parser/grammar.y"
+#line 337 "beancount/parser/grammar.y"
     {
                 BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
             }
-#line 1789 "beancount/parser/grammar.c"
+#line 1792 "beancount/parser/grammar.c"
     break;
 
   case 23:
-#line 343 "beancount/parser/grammar.y"
+#line 342 "beancount/parser/grammar.y"
     {
                 BUILDY(,
                        (yyval.pyobj), "pipe_deprecated_error", "si", FILE_LINE_ARGS);
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 1799 "beancount/parser/grammar.c"
+#line 1802 "beancount/parser/grammar.c"
     break;
 
   case 24:
-#line 350 "beancount/parser/grammar.y"
+#line 349 "beancount/parser/grammar.y"
     {
                /* Note: We're passing a bogus value here in order to avoid
                 * having to declare a second macro just for this one special
@@ -1807,247 +1810,247 @@ yyreduce:
                BUILDY(,
                       (yyval.pyobj), "tag_link_new", "O", Py_None);
            }
-#line 1811 "beancount/parser/grammar.c"
+#line 1814 "beancount/parser/grammar.c"
     break;
 
   case 25:
-#line 358 "beancount/parser/grammar.y"
+#line 357 "beancount/parser/grammar.y"
     {
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1820 "beancount/parser/grammar.c"
+#line 1823 "beancount/parser/grammar.c"
     break;
 
   case 26:
-#line 363 "beancount/parser/grammar.y"
+#line 362 "beancount/parser/grammar.y"
     {
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 1829 "beancount/parser/grammar.c"
+#line 1832 "beancount/parser/grammar.c"
     break;
 
   case 27:
-#line 369 "beancount/parser/grammar.y"
+#line 368 "beancount/parser/grammar.y"
     {
                 BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "transaction", "siObOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 1838 "beancount/parser/grammar.c"
+#line 1841 "beancount/parser/grammar.c"
     break;
 
   case 28:
-#line 375 "beancount/parser/grammar.y"
+#line 374 "beancount/parser/grammar.y"
     {
             (yyval.character) = '\0';
         }
-#line 1846 "beancount/parser/grammar.c"
+#line 1849 "beancount/parser/grammar.c"
     break;
 
   case 29:
-#line 379 "beancount/parser/grammar.y"
+#line 378 "beancount/parser/grammar.y"
     {
             (yyval.character) = '*';
         }
-#line 1854 "beancount/parser/grammar.c"
+#line 1857 "beancount/parser/grammar.c"
     break;
 
   case 30:
-#line 383 "beancount/parser/grammar.y"
+#line 382 "beancount/parser/grammar.y"
     {
             (yyval.character) = '#';
         }
-#line 1862 "beancount/parser/grammar.c"
+#line 1865 "beancount/parser/grammar.c"
     break;
 
   case 32:
-#line 389 "beancount/parser/grammar.y"
+#line 388 "beancount/parser/grammar.y"
     {
                      (yyval.pyobj) = (yyvsp[0].pyobj);
                  }
-#line 1870 "beancount/parser/grammar.c"
+#line 1873 "beancount/parser/grammar.c"
     break;
 
   case 33:
-#line 394 "beancount/parser/grammar.y"
+#line 393 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
         }
-#line 1879 "beancount/parser/grammar.c"
+#line 1882 "beancount/parser/grammar.c"
     break;
 
   case 34:
-#line 399 "beancount/parser/grammar.y"
+#line 398 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
         }
-#line 1888 "beancount/parser/grammar.c"
+#line 1891 "beancount/parser/grammar.c"
     break;
 
   case 35:
-#line 404 "beancount/parser/grammar.y"
+#line 403 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
         }
-#line 1897 "beancount/parser/grammar.c"
+#line 1900 "beancount/parser/grammar.c"
     break;
 
   case 36:
-#line 409 "beancount/parser/grammar.y"
+#line 408 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF1((yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-1].pyobj), missing_obj, Py_None, Py_None, Py_False, (yyvsp[-2].character));
         }
-#line 1906 "beancount/parser/grammar.c"
+#line 1909 "beancount/parser/grammar.c"
     break;
 
   case 37:
-#line 415 "beancount/parser/grammar.y"
+#line 414 "beancount/parser/grammar.y"
     {
               BUILDY(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
           }
-#line 1915 "beancount/parser/grammar.c"
+#line 1918 "beancount/parser/grammar.c"
     break;
 
   case 38:
-#line 421 "beancount/parser/grammar.y"
+#line 420 "beancount/parser/grammar.y"
     {
                    (yyval.pyobj) = (yyvsp[-1].pyobj);
                }
-#line 1923 "beancount/parser/grammar.c"
+#line 1926 "beancount/parser/grammar.c"
     break;
 
   case 47:
-#line 434 "beancount/parser/grammar.y"
+#line 433 "beancount/parser/grammar.y"
     {
                     (yyval.pyobj) = (yyvsp[0].pyobj);
                 }
-#line 1931 "beancount/parser/grammar.c"
+#line 1934 "beancount/parser/grammar.c"
     break;
 
   case 48:
-#line 438 "beancount/parser/grammar.y"
+#line 437 "beancount/parser/grammar.y"
     {
                     Py_INCREF(Py_None);
                     (yyval.pyobj) = Py_None;
                 }
-#line 1940 "beancount/parser/grammar.c"
+#line 1943 "beancount/parser/grammar.c"
     break;
 
   case 49:
-#line 444 "beancount/parser/grammar.y"
+#line 443 "beancount/parser/grammar.y"
     {
                        Py_INCREF(Py_None);
                        (yyval.pyobj) = Py_None;
                    }
-#line 1949 "beancount/parser/grammar.c"
+#line 1952 "beancount/parser/grammar.c"
     break;
 
   case 50:
-#line 449 "beancount/parser/grammar.y"
+#line 448 "beancount/parser/grammar.y"
     {
                        (yyval.pyobj) = (yyvsp[-3].pyobj);
                    }
-#line 1957 "beancount/parser/grammar.c"
+#line 1960 "beancount/parser/grammar.c"
     break;
 
   case 51:
-#line 453 "beancount/parser/grammar.y"
+#line 452 "beancount/parser/grammar.y"
     {
                        BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
                    }
-#line 1966 "beancount/parser/grammar.c"
+#line 1969 "beancount/parser/grammar.c"
     break;
 
   case 52:
-#line 458 "beancount/parser/grammar.y"
+#line 457 "beancount/parser/grammar.y"
     {
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 1975 "beancount/parser/grammar.c"
+#line 1978 "beancount/parser/grammar.c"
     break;
 
   case 53:
-#line 463 "beancount/parser/grammar.y"
+#line 462 "beancount/parser/grammar.y"
     {
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 1984 "beancount/parser/grammar.c"
+#line 1987 "beancount/parser/grammar.c"
     break;
 
   case 54:
-#line 469 "beancount/parser/grammar.y"
+#line 468 "beancount/parser/grammar.y"
     {
                    Py_INCREF(Py_None);
                    (yyval.pyobj) = Py_None;
                }
-#line 1993 "beancount/parser/grammar.c"
+#line 1996 "beancount/parser/grammar.c"
     break;
 
   case 55:
-#line 474 "beancount/parser/grammar.y"
+#line 473 "beancount/parser/grammar.y"
     {
                    BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                }
-#line 2002 "beancount/parser/grammar.c"
+#line 2005 "beancount/parser/grammar.c"
     break;
 
   case 56:
-#line 480 "beancount/parser/grammar.y"
+#line 479 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
               }
-#line 2011 "beancount/parser/grammar.c"
+#line 2014 "beancount/parser/grammar.c"
     break;
 
   case 57:
-#line 485 "beancount/parser/grammar.y"
+#line 484 "beancount/parser/grammar.y"
     {
                   BUILDY(DECREF1((yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
               }
-#line 2020 "beancount/parser/grammar.c"
+#line 2023 "beancount/parser/grammar.c"
     break;
 
   case 58:
-#line 490 "beancount/parser/grammar.y"
+#line 489 "beancount/parser/grammar.y"
     {
                   BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
               }
-#line 2029 "beancount/parser/grammar.c"
+#line 2032 "beancount/parser/grammar.c"
     break;
 
   case 59:
-#line 496 "beancount/parser/grammar.y"
+#line 495 "beancount/parser/grammar.y"
     {
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
          }
-#line 2038 "beancount/parser/grammar.c"
+#line 2041 "beancount/parser/grammar.c"
     break;
 
   case 60:
-#line 502 "beancount/parser/grammar.y"
+#line 501 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
        }
-#line 2047 "beancount/parser/grammar.c"
+#line 2050 "beancount/parser/grammar.c"
     break;
 
   case 61:
-#line 508 "beancount/parser/grammar.y"
+#line 507 "beancount/parser/grammar.y"
     {
              /* Note: key_value is a tuple, Py_BuildValue() won't wrap it up
               * within a tuple, so expand in the method (it receives two
@@ -2055,92 +2058,92 @@ yyreduce:
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
          }
-#line 2059 "beancount/parser/grammar.c"
+#line 2062 "beancount/parser/grammar.c"
     break;
 
   case 62:
-#line 517 "beancount/parser/grammar.y"
+#line 516 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF1((yyvsp[-2].pyobj)),
                    (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
         }
-#line 2068 "beancount/parser/grammar.c"
+#line 2071 "beancount/parser/grammar.c"
     break;
 
   case 63:
-#line 523 "beancount/parser/grammar.y"
+#line 522 "beancount/parser/grammar.y"
     {
          BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                 (yyval.pyobj), "open", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          ;
      }
-#line 2078 "beancount/parser/grammar.c"
+#line 2081 "beancount/parser/grammar.c"
     break;
 
   case 64:
-#line 530 "beancount/parser/grammar.y"
+#line 529 "beancount/parser/grammar.y"
     {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2086 "beancount/parser/grammar.c"
+#line 2089 "beancount/parser/grammar.c"
     break;
 
   case 65:
-#line 534 "beancount/parser/grammar.y"
+#line 533 "beancount/parser/grammar.y"
     {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2095 "beancount/parser/grammar.c"
+#line 2098 "beancount/parser/grammar.c"
     break;
 
   case 66:
-#line 540 "beancount/parser/grammar.y"
+#line 539 "beancount/parser/grammar.y"
     {
           BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "close", "siOOO", FILE_LINE_ARGS, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2104 "beancount/parser/grammar.c"
+#line 2107 "beancount/parser/grammar.c"
     break;
 
   case 67:
-#line 546 "beancount/parser/grammar.y"
+#line 545 "beancount/parser/grammar.y"
     {
               BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "commodity", "siOOO", FILE_LINE_ARGS, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
           }
-#line 2113 "beancount/parser/grammar.c"
+#line 2116 "beancount/parser/grammar.c"
     break;
 
   case 68:
-#line 552 "beancount/parser/grammar.y"
+#line 551 "beancount/parser/grammar.y"
     {
         BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "pad", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
     }
-#line 2122 "beancount/parser/grammar.c"
+#line 2125 "beancount/parser/grammar.c"
     break;
 
   case 69:
-#line 558 "beancount/parser/grammar.y"
+#line 557 "beancount/parser/grammar.y"
     {
             BUILDY(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
                    (yyval.pyobj), "balance", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
         }
-#line 2131 "beancount/parser/grammar.c"
+#line 2134 "beancount/parser/grammar.c"
     break;
 
   case 70:
-#line 564 "beancount/parser/grammar.y"
+#line 563 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
        }
-#line 2140 "beancount/parser/grammar.c"
+#line 2143 "beancount/parser/grammar.c"
     break;
 
   case 71:
-#line 570 "beancount/parser/grammar.y"
+#line 569 "beancount/parser/grammar.y"
     {
                      BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
@@ -2148,269 +2151,269 @@ yyreduce:
                      Py_INCREF(Py_None);
                      ;
                  }
-#line 2152 "beancount/parser/grammar.c"
+#line 2155 "beancount/parser/grammar.c"
     break;
 
   case 72:
-#line 578 "beancount/parser/grammar.y"
+#line 577 "beancount/parser/grammar.y"
     {
                      BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = (yyvsp[-1].pyobj);
                  }
-#line 2162 "beancount/parser/grammar.c"
+#line 2165 "beancount/parser/grammar.c"
     break;
 
   case 73:
-#line 585 "beancount/parser/grammar.y"
+#line 584 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2171 "beancount/parser/grammar.c"
+#line 2174 "beancount/parser/grammar.c"
     break;
 
   case 74:
-#line 590 "beancount/parser/grammar.y"
+#line 589 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2179 "beancount/parser/grammar.c"
+#line 2182 "beancount/parser/grammar.c"
     break;
 
   case 75:
-#line 595 "beancount/parser/grammar.y"
+#line 594 "beancount/parser/grammar.y"
     {
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2188 "beancount/parser/grammar.c"
+#line 2191 "beancount/parser/grammar.c"
     break;
 
   case 76:
-#line 600 "beancount/parser/grammar.y"
+#line 599 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2196 "beancount/parser/grammar.c"
+#line 2199 "beancount/parser/grammar.c"
     break;
 
   case 77:
-#line 605 "beancount/parser/grammar.y"
+#line 604 "beancount/parser/grammar.y"
     {
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2205 "beancount/parser/grammar.c"
+#line 2208 "beancount/parser/grammar.c"
     break;
 
   case 78:
-#line 610 "beancount/parser/grammar.y"
+#line 609 "beancount/parser/grammar.y"
     {
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2214 "beancount/parser/grammar.c"
+#line 2217 "beancount/parser/grammar.c"
     break;
 
   case 79:
-#line 615 "beancount/parser/grammar.y"
+#line 614 "beancount/parser/grammar.y"
     {
                     BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                     ;
                 }
-#line 2224 "beancount/parser/grammar.c"
+#line 2227 "beancount/parser/grammar.c"
     break;
 
   case 80:
-#line 622 "beancount/parser/grammar.y"
+#line 621 "beancount/parser/grammar.y"
     {
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                  }
-#line 2233 "beancount/parser/grammar.c"
+#line 2236 "beancount/parser/grammar.c"
     break;
 
   case 81:
-#line 628 "beancount/parser/grammar.y"
+#line 627 "beancount/parser/grammar.y"
     {
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
           }
-#line 2242 "beancount/parser/grammar.c"
+#line 2245 "beancount/parser/grammar.c"
     break;
 
   case 82:
-#line 633 "beancount/parser/grammar.y"
+#line 632 "beancount/parser/grammar.y"
     {
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
           }
-#line 2251 "beancount/parser/grammar.c"
+#line 2254 "beancount/parser/grammar.c"
     break;
 
   case 83:
-#line 638 "beancount/parser/grammar.y"
+#line 637 "beancount/parser/grammar.y"
     {
               Py_INCREF(Py_None);
               (yyval.pyobj) = Py_None;
           }
-#line 2260 "beancount/parser/grammar.c"
+#line 2263 "beancount/parser/grammar.c"
     break;
 
   case 84:
-#line 644 "beancount/parser/grammar.y"
+#line 643 "beancount/parser/grammar.y"
     {
                    /* We indicate that there was a cost if there */
                    (yyval.pyobj) = PyList_New(0);
                }
-#line 2269 "beancount/parser/grammar.c"
+#line 2272 "beancount/parser/grammar.c"
     break;
 
   case 85:
-#line 649 "beancount/parser/grammar.y"
+#line 648 "beancount/parser/grammar.y"
     {
                    BUILDY(DECREF1((yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
                }
-#line 2278 "beancount/parser/grammar.c"
+#line 2281 "beancount/parser/grammar.c"
     break;
 
   case 86:
-#line 654 "beancount/parser/grammar.y"
+#line 653 "beancount/parser/grammar.y"
     {
                    BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                }
-#line 2287 "beancount/parser/grammar.c"
+#line 2290 "beancount/parser/grammar.c"
     break;
 
   case 87:
-#line 660 "beancount/parser/grammar.y"
+#line 659 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2295 "beancount/parser/grammar.c"
+#line 2298 "beancount/parser/grammar.c"
     break;
 
   case 88:
-#line 664 "beancount/parser/grammar.y"
+#line 663 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2303 "beancount/parser/grammar.c"
+#line 2306 "beancount/parser/grammar.c"
     break;
 
   case 89:
-#line 668 "beancount/parser/grammar.y"
+#line 667 "beancount/parser/grammar.y"
     {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2311 "beancount/parser/grammar.c"
+#line 2314 "beancount/parser/grammar.c"
     break;
 
   case 90:
-#line 672 "beancount/parser/grammar.y"
+#line 671 "beancount/parser/grammar.y"
     {
               BUILDY(,
                      (yyval.pyobj), "cost_merge", "O", Py_None);
           }
-#line 2320 "beancount/parser/grammar.c"
+#line 2323 "beancount/parser/grammar.c"
     break;
 
   case 91:
-#line 679 "beancount/parser/grammar.y"
+#line 678 "beancount/parser/grammar.y"
     {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "price", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2329 "beancount/parser/grammar.c"
+#line 2332 "beancount/parser/grammar.c"
     break;
 
   case 92:
-#line 685 "beancount/parser/grammar.y"
+#line 684 "beancount/parser/grammar.y"
     {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "event", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2338 "beancount/parser/grammar.c"
+#line 2341 "beancount/parser/grammar.c"
     break;
 
   case 93:
-#line 691 "beancount/parser/grammar.y"
+#line 690 "beancount/parser/grammar.y"
     {
              BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "query", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2347 "beancount/parser/grammar.c"
+#line 2350 "beancount/parser/grammar.c"
     break;
 
   case 94:
-#line 697 "beancount/parser/grammar.y"
+#line 696 "beancount/parser/grammar.y"
     {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "note", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2356 "beancount/parser/grammar.c"
+#line 2359 "beancount/parser/grammar.c"
     break;
 
   case 96:
-#line 705 "beancount/parser/grammar.y"
+#line 704 "beancount/parser/grammar.y"
     {
              BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "document", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2365 "beancount/parser/grammar.c"
+#line 2368 "beancount/parser/grammar.c"
     break;
 
   case 97:
-#line 712 "beancount/parser/grammar.y"
+#line 711 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2374 "beancount/parser/grammar.c"
+#line 2377 "beancount/parser/grammar.c"
     break;
 
   case 98:
-#line 717 "beancount/parser/grammar.y"
+#line 716 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2383 "beancount/parser/grammar.c"
+#line 2386 "beancount/parser/grammar.c"
     break;
 
   case 99:
-#line 722 "beancount/parser/grammar.y"
+#line 721 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2392 "beancount/parser/grammar.c"
+#line 2395 "beancount/parser/grammar.c"
     break;
 
   case 100:
-#line 727 "beancount/parser/grammar.y"
+#line 726 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2401 "beancount/parser/grammar.c"
+#line 2404 "beancount/parser/grammar.c"
     break;
 
   case 101:
-#line 732 "beancount/parser/grammar.y"
+#line 731 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2410 "beancount/parser/grammar.c"
+#line 2413 "beancount/parser/grammar.c"
     break;
 
   case 102:
-#line 737 "beancount/parser/grammar.y"
+#line 736 "beancount/parser/grammar.y"
     {
                  /* Obtain beancount.core.account.TYPE */
                  PyObject* module = PyImport_ImportModule("beancount.core.account");
@@ -2419,99 +2422,99 @@ yyreduce:
                  BUILDY(DECREF2((yyvsp[0].pyobj), dtype),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
              }
-#line 2423 "beancount/parser/grammar.c"
+#line 2426 "beancount/parser/grammar.c"
     break;
 
   case 103:
-#line 747 "beancount/parser/grammar.y"
+#line 746 "beancount/parser/grammar.y"
     {
                       Py_INCREF(Py_None);
                       (yyval.pyobj) = Py_None;
                   }
-#line 2432 "beancount/parser/grammar.c"
+#line 2435 "beancount/parser/grammar.c"
     break;
 
   case 104:
-#line 752 "beancount/parser/grammar.y"
+#line 751 "beancount/parser/grammar.y"
     {
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                   }
-#line 2441 "beancount/parser/grammar.c"
+#line 2444 "beancount/parser/grammar.c"
     break;
 
   case 105:
-#line 758 "beancount/parser/grammar.y"
+#line 757 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "custom", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
        }
-#line 2450 "beancount/parser/grammar.c"
+#line 2453 "beancount/parser/grammar.c"
     break;
 
   case 117:
-#line 776 "beancount/parser/grammar.y"
+#line 775 "beancount/parser/grammar.y"
     {
           (yyval.pyobj) = (yyvsp[0].pyobj);
       }
-#line 2458 "beancount/parser/grammar.c"
+#line 2461 "beancount/parser/grammar.c"
     break;
 
   case 118:
-#line 781 "beancount/parser/grammar.y"
+#line 780 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "option", "siOO", FILE_LINE_ARGS, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2467 "beancount/parser/grammar.c"
+#line 2470 "beancount/parser/grammar.c"
     break;
 
   case 119:
-#line 787 "beancount/parser/grammar.y"
+#line 786 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "include", "siO", FILE_LINE_ARGS, (yyvsp[-1].pyobj));
        }
-#line 2476 "beancount/parser/grammar.c"
+#line 2479 "beancount/parser/grammar.c"
     break;
 
   case 120:
-#line 793 "beancount/parser/grammar.y"
+#line 792 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "siOO", FILE_LINE_ARGS, (yyvsp[-1].pyobj), Py_None);
        }
-#line 2485 "beancount/parser/grammar.c"
+#line 2488 "beancount/parser/grammar.c"
     break;
 
   case 121:
-#line 798 "beancount/parser/grammar.y"
+#line 797 "beancount/parser/grammar.y"
     {
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "siOO", FILE_LINE_ARGS, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2494 "beancount/parser/grammar.c"
+#line 2497 "beancount/parser/grammar.c"
     break;
 
   case 130:
-#line 814 "beancount/parser/grammar.y"
+#line 813 "beancount/parser/grammar.y"
     {
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2502 "beancount/parser/grammar.c"
+#line 2505 "beancount/parser/grammar.c"
     break;
 
   case 131:
-#line 818 "beancount/parser/grammar.y"
+#line 817 "beancount/parser/grammar.y"
     {
                  BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
              }
-#line 2511 "beancount/parser/grammar.c"
+#line 2514 "beancount/parser/grammar.c"
     break;
 
   case 132:
-#line 823 "beancount/parser/grammar.y"
+#line 822 "beancount/parser/grammar.y"
     {
                  /*
                   * Ignore the error and continue reducing ({3d95e55b654e}).
@@ -2529,29 +2532,29 @@ yyreduce:
                   */
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2533 "beancount/parser/grammar.c"
+#line 2536 "beancount/parser/grammar.c"
     break;
 
   case 133:
-#line 841 "beancount/parser/grammar.y"
+#line 840 "beancount/parser/grammar.y"
     {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
              }
-#line 2542 "beancount/parser/grammar.c"
+#line 2545 "beancount/parser/grammar.c"
     break;
 
   case 134:
-#line 848 "beancount/parser/grammar.y"
+#line 847 "beancount/parser/grammar.y"
     {
          BUILDY(DECREF1((yyvsp[0].pyobj)),
                 (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2551 "beancount/parser/grammar.c"
+#line 2554 "beancount/parser/grammar.c"
     break;
 
 
-#line 2555 "beancount/parser/grammar.c"
+#line 2558 "beancount/parser/grammar.c"
 
       default: break;
     }
@@ -2602,7 +2605,7 @@ yyerrlab:
     {
       ++yynerrs;
 #if ! YYERROR_VERBOSE
-      yyerror (YY_("syntax error"));
+      yyerror (&yylloc, scanner, YY_("syntax error"));
 #else
 # define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
                                         yyssp, yytoken)
@@ -2629,7 +2632,7 @@ yyerrlab:
                 yymsgp = yymsg;
               }
           }
-        yyerror (yymsgp);
+        yyerror (&yylloc, scanner, yymsgp);
         if (yysyntax_error_status == 2)
           goto yyexhaustedlab;
       }
@@ -2653,7 +2656,7 @@ yyerrlab:
       else
         {
           yydestruct ("Error: discarding",
-                      yytoken, &yylval, &yylloc);
+                      yytoken, &yylval, &yylloc, scanner);
           yychar = YYEMPTY;
         }
     }
@@ -2707,7 +2710,7 @@ yyerrlab1:
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp, yylsp);
+                  yystos[yystate], yyvsp, yylsp, scanner);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -2751,7 +2754,7 @@ yyabortlab:
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
 yyexhaustedlab:
-  yyerror (YY_("memory exhausted"));
+  yyerror (&yylloc, scanner, YY_("memory exhausted"));
   yyresult = 2;
   /* Fall through.  */
 #endif
@@ -2767,7 +2770,7 @@ yyreturn:
          user semantic actions for why this is necessary.  */
       yytoken = YYTRANSLATE (yychar);
       yydestruct ("Cleanup: discarding lookahead",
-                  yytoken, &yylval, &yylloc);
+                  yytoken, &yylval, &yylloc, scanner);
     }
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
@@ -2776,7 +2779,7 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp, yylsp);
+                  yystos[*yyssp], yyvsp, yylsp, scanner);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -2789,7 +2792,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 856 "beancount/parser/grammar.y"
+#line 855 "beancount/parser/grammar.y"
 
 
 /* A function that will convert a token name to a string, used in debugging. */

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.4.  */
+/* A Bison parser, made by GNU Bison 3.4.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -110,7 +110,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 126 "beancount/parser/grammar.y"
+#line 125 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -144,6 +144,6 @@ struct YYLTYPE
 
 
 
-int yyparse (void);
+int yyparse (yyscan_t scanner);
 
 #endif /* !YY_YY_BEANCOUNT_PARSER_GRAMMAR_H_INCLUDED  */

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -110,7 +110,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 125 "beancount/parser/grammar.y"
+#line 124 "beancount/parser/grammar.y"
 
     char character;
     const char* string;

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -80,8 +80,11 @@ typedef struct YYLTYPE {
         }                                                               \
     } while (0)
 
+/* Get a printable version of a token name. */
+const char* token_to_string(int token);
 
-#line 85 "beancount/parser/grammar.h"
+
+#line 88 "beancount/parser/grammar.h"
 
 /* Token type.  */
 #ifndef YYTOKENTYPE
@@ -149,7 +152,7 @@ typedef struct YYLTYPE {
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 148 "beancount/parser/grammar.y"
+#line 147 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -159,7 +162,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 163 "beancount/parser/grammar.h"
+#line 166 "beancount/parser/grammar.h"
 
 };
 typedef union YYSTYPE YYSTYPE;

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -149,7 +149,7 @@ typedef struct YYLTYPE {
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 149 "beancount/parser/grammar.y"
+#line 148 "beancount/parser/grammar.y"
 
     char character;
     const char* string;

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -110,7 +110,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 124 "beancount/parser/grammar.y"
+#line 117 "beancount/parser/grammar.y"
 
     char character;
     const char* string;

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -43,6 +43,45 @@
 #if YYDEBUG
 extern int yydebug;
 #endif
+/* "%code requires" blocks.  */
+#line 12 "beancount/parser/grammar.y"
+
+
+#include <stdio.h>
+#include <assert.h>
+#include "parser.h"
+
+/* Extend default location type with file name information. */
+typedef struct YYLTYPE {
+    int first_line;
+    int first_column;
+    int last_line;
+    int last_column;
+    PyObject* file_name;
+} YYLTYPE;
+
+#define YYLTYPE_IS_DECLARED 1
+
+/* Extend defult location action to copy file name over. */
+#define YYLLOC_DEFAULT(current, rhs, N)                                 \
+    do {                                                                \
+        if (N) {                                                        \
+            (current).first_line   = YYRHSLOC(rhs, 1).first_line;       \
+            (current).first_column = YYRHSLOC(rhs, 1).first_column;     \
+            (current).last_line    = YYRHSLOC(rhs, N).last_line;        \
+            (current).last_column  = YYRHSLOC(rhs, N).last_column;      \
+            (current).file_name    = YYRHSLOC(rhs, N).file_name;        \
+        } else {                                                        \
+            (current).first_line   = (current).last_line =              \
+                YYRHSLOC(rhs, 0).last_line;                             \
+            (current).first_column = (current).last_column =            \
+                YYRHSLOC(rhs, 0).last_column;                           \
+            (current).file_name    = YYRHSLOC(rhs, 0).file_name;        \
+        }                                                               \
+    } while (0)
+
+
+#line 85 "beancount/parser/grammar.h"
 
 /* Token type.  */
 #ifndef YYTOKENTYPE
@@ -110,7 +149,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 117 "beancount/parser/grammar.y"
+#line 149 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -120,7 +159,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 124 "beancount/parser/grammar.h"
+#line 163 "beancount/parser/grammar.h"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -144,6 +183,6 @@ struct YYLTYPE
 
 
 
-int yyparse (yyscan_t scanner, PyObject* parser, PyObject* builder);
+int yyparse (yyscan_t scanner, PyObject* builder);
 
 #endif /* !YY_YY_BEANCOUNT_PARSER_GRAMMAR_H_INCLUDED  */

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -152,7 +152,7 @@ const char* token_to_string(int token);
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 147 "beancount/parser/grammar.y"
+#line 142 "beancount/parser/grammar.y"
 
     char character;
     const char* string;

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -144,6 +144,6 @@ struct YYLTYPE
 
 
 
-int yyparse (yyscan_t scanner);
+int yyparse (yyscan_t scanner, PyObject* parser, PyObject* builder);
 
 #endif /* !YY_YY_BEANCOUNT_PARSER_GRAMMAR_H_INCLUDED  */

--- a/beancount/parser/grammar.py
+++ b/beancount/parser/grammar.py
@@ -136,12 +136,12 @@ class Builder(lexer.LexBuilder):
 
         # A display context builder.
         self.dcontext = display_context.DisplayContext()
-        self._dcupdate = self.dcontext.update
+        self.display_context_update = self.dcontext.update
 
-    def dcupdate(self, number, currency):
+    def _dcupdate(self, number, currency):
         """Update the display context."""
         if isinstance(number, Decimal) and currency and currency is not MISSING:
-            self._dcupdate(number, currency)
+            self.display_context_update(number, currency)
 
     def finalize(self):
         """Finalize the parser, check for final errors and return the triple.
@@ -211,7 +211,7 @@ class Builder(lexer.LexBuilder):
         """See base class."""
         return self.options['long_string_maxlines']
 
-    def store_result(self, entries):
+    def store_result(self, filename, lineno, entries):
         """Start rule stores the final result here.
 
         Args:
@@ -257,7 +257,7 @@ class Builder(lexer.LexBuilder):
         self.errors.append(
             ParserSyntaxError(meta, "Pipe symbol is deprecated.", None))
 
-    def pushtag(self, tag):
+    def pushtag(self, filename, lineno, tag):
         """Push a tag on the current set of tags.
 
         Note that this does not need to be stack ordered.
@@ -267,7 +267,7 @@ class Builder(lexer.LexBuilder):
         """
         self.tags.append(tag)
 
-    def poptag(self, tag):
+    def poptag(self, filename, lineno, tag):
         """Pop a tag off the current set of stacks.
 
         Args:
@@ -276,19 +276,20 @@ class Builder(lexer.LexBuilder):
         try:
             self.tags.remove(tag)
         except ValueError:
-            meta = new_metadata(self.options['filename'], 0)
+            meta = new_metadata(filename, lineno)
             self.errors.append(
                 ParserError(meta, "Attempting to pop absent tag: '{}'".format(tag), None))
 
-    def pushmeta(self, key, value):
+    def pushmeta(self, filename, lineno, key_value):
         """Set a metadata field on the current key-value pairs to be added to transactions.
 
         Args:
           key_value: A KeyValue instance, to be added to the dict of metadata.
         """
+        key, value = key_value
         self.meta[key].append(value)
 
-    def popmeta(self, key):
+    def popmeta(self, filename, lineno, key):
         """Removed a key off the current set of stacks.
 
         Args:
@@ -302,7 +303,7 @@ class Builder(lexer.LexBuilder):
             if not value_list:
                 self.meta.pop(key)
         except IndexError:
-            meta = new_metadata(self.options['filename'], 0)
+            meta = new_metadata(filename, lineno)
             self.errors.append(
                 ParserError(meta,
                             "Attempting to pop absent metadata key: '{}'".format(key),
@@ -410,7 +411,7 @@ class Builder(lexer.LexBuilder):
         """
         self.options['plugin'].append((plugin_name, plugin_config))
 
-    def amount(self, number, currency):
+    def amount(self, filename, lineno, number, currency):
         """Process an amount grammar rule.
 
         Args:
@@ -421,10 +422,10 @@ class Builder(lexer.LexBuilder):
         """
         # Update the mapping that stores the parsed precisions.
         # Note: This is relatively slow, adds about 70ms because of number.as_tuple().
-        self.dcupdate(number, currency)
+        self._dcupdate(number, currency)
         return Amount(number, currency)
 
-    def compound_amount(self, number_per, number_total, currency):
+    def compound_amount(self, filename, lineno, number_per, number_total, currency):
         """Process an amount grammar rule.
 
         Args:
@@ -437,18 +438,18 @@ class Builder(lexer.LexBuilder):
         """
         # Update the mapping that stores the parsed precisions.
         # Note: This is relatively slow, adds about 70ms because of number.as_tuple().
-        self.dcupdate(number_per, currency)
-        self.dcupdate(number_total, currency)
+        self._dcupdate(number_per, currency)
+        self._dcupdate(number_total, currency)
 
         # Note that we are not able to reduce the value to a number per-share
         # here because we only get the number of units in the full lot spec.
         return CompoundAmount(number_per, number_total, currency)
 
-    def cost_merge(self, _):
+    def cost_merge(self, filename, lineno, _):
         """Create a 'merge cost' token."""
         return MERGE_COST
 
-    def cost_spec(self, cost_comp_list, is_total):
+    def cost_spec(self, filename, lineno, cost_comp_list, is_total):
         """Process a cost_spec grammar rule.
 
         Args:
@@ -476,7 +477,7 @@ class Builder(lexer.LexBuilder):
                     compound_cost = comp
                 else:
                     self.errors.append(
-                        ParserError(self.get_lexer_location(),
+                        ParserError(new_metadata(filename, lineno),
                                     "Duplicate cost: '{}'.".format(comp), None))
 
             elif isinstance(comp, date):
@@ -484,18 +485,18 @@ class Builder(lexer.LexBuilder):
                     date_ = comp
                 else:
                     self.errors.append(
-                        ParserError(self.get_lexer_location(),
+                        ParserError(new_metadata(filename, lineno),
                                     "Duplicate date: '{}'.".format(comp), None))
 
             elif comp is MERGE_COST:
                 if merge is None:
                     merge = True
                     self.errors.append(
-                        ParserError(self.get_lexer_location(),
+                        ParserError(new_metadata(filename, lineno),
                                     "Cost merging is not supported yet", None))
                 else:
                     self.errors.append(
-                        ParserError(self.get_lexer_location(),
+                        ParserError(new_metadata(filename, lineno),
                                     "Duplicate merge-cost spec", None))
 
             else:
@@ -505,7 +506,7 @@ class Builder(lexer.LexBuilder):
                     label = comp
                 else:
                     self.errors.append(
-                        ParserError(self.get_lexer_location(),
+                        ParserError(new_metadata(filename, lineno),
                                     "Duplicate label: '{}'.".format(comp), None))
 
         # If there was a cost_comp_list, thus a "{...}" cost basis spec, you must
@@ -519,7 +520,7 @@ class Builder(lexer.LexBuilder):
                 if number_total is not None:
                     self.errors.append(
                         ParserError(
-                            self.get_lexer_location(),
+                            new_metadata(filename, lineno),
                             ("Per-unit cost may not be specified using total cost "
                              "syntax: '{}'; ignoring per-unit cost").format(compound_cost),
                             None))
@@ -535,7 +536,7 @@ class Builder(lexer.LexBuilder):
 
         return CostSpec(number_per, number_total, currency, date_, label, merge)
 
-    def handle_list(self, object_list, new_object):
+    def handle_list(self, filename, lineno, object_list, new_object):
         """Handle a recursive list grammar rule, generically.
 
         Args:
@@ -736,7 +737,7 @@ class Builder(lexer.LexBuilder):
         if not path.isabs(document_filename):
             document_filename = path.abspath(path.join(path.dirname(filename),
                                                        document_filename))
-        tags, links = self.finalize_tags_links(tags_links.tags, tags_links.links)
+        tags, links = self._finalize_tags_links(tags_links.tags, tags_links.links)
         return Document(meta, date, account, document_filename, tags, links)
 
     def custom(self, filename, lineno, date, dir_type, custom_values, kvlist):
@@ -755,7 +756,7 @@ class Builder(lexer.LexBuilder):
         meta = new_metadata(filename, lineno, kvlist)
         return Custom(meta, date, dir_type, custom_values)
 
-    def custom_value(self, value, dtype=None):
+    def custom_value(self, filename, lineno, value, dtype=None):
         """Create a custom value object, along with its type.
 
         Args:
@@ -768,7 +769,7 @@ class Builder(lexer.LexBuilder):
             dtype = type(value)
         return ValueType(value, dtype)
 
-    def key_value(self, key, value):
+    def key_value(self, filename, lineno, key, value):
         """Process a document directive.
 
         Args:
@@ -843,7 +844,7 @@ class Builder(lexer.LexBuilder):
 
         return Posting(account, units, cost, price, chr(flag) if flag else None, meta)
 
-    def tag_link_new(self, _):
+    def tag_link_new(self, filename, lineno, _):
         """Create a new TagsLinks instance.
 
         Returns:
@@ -851,7 +852,7 @@ class Builder(lexer.LexBuilder):
         """
         return TagsLinks(set(), set())
 
-    def tag_link_TAG(self, tags_links, tag):
+    def tag_link_TAG(self, filename, lineno, tags_links, tag):
         """Add a tag to the TagsLinks accumulator.
 
         Args:
@@ -863,7 +864,7 @@ class Builder(lexer.LexBuilder):
         tags_links.tags.add(tag)
         return tags_links
 
-    def tag_link_LINK(self, tags_links, link):
+    def tag_link_LINK(self, filename, lineno, tags_links, link):
         """Add a link to the TagsLinks accumulator.
 
         Args:
@@ -875,7 +876,7 @@ class Builder(lexer.LexBuilder):
         tags_links.links.add(link)
         return tags_links
 
-    def tag_link_STRING(self, tags_links, string):
+    def tag_link_STRING(self, filename, lineno, tags_links, string):
         """Add a string to the TagsLinks accumulator.
 
         Args:
@@ -887,7 +888,7 @@ class Builder(lexer.LexBuilder):
         tags_links.strings.append(string)
         return tags_links
 
-    def unpack_txn_strings(self, txn_strings, meta):
+    def _unpack_txn_strings(self, txn_strings, meta):
         """Unpack a tags_links accumulator to its payee and narration fields.
 
         Args:
@@ -912,7 +913,7 @@ class Builder(lexer.LexBuilder):
             return None
         return payee, narration
 
-    def finalize_tags_links(self, tags, links):
+    def _finalize_tags_links(self, tags, links):
         """Finally amend tags and links and return final objects to be inserted.
 
         Args:
@@ -993,7 +994,7 @@ class Builder(lexer.LexBuilder):
                                     posting_or_kv), None))
 
         # Freeze the tags & links or set to default empty values.
-        tags, links = self.finalize_tags_links(tags, links)
+        tags, links = self._finalize_tags_links(tags, links)
 
         # Initialize the metadata fields from the set of active values.
         if self.meta:
@@ -1005,7 +1006,7 @@ class Builder(lexer.LexBuilder):
             meta.update(explicit_meta)
 
         # Unpack the transaction fields.
-        payee_narration = self.unpack_txn_strings(txn_strings, meta)
+        payee_narration = self._unpack_txn_strings(txn_strings, meta)
         if payee_narration is None:
             return None
         payee, narration = payee_narration

--- a/beancount/parser/grammar.py
+++ b/beancount/parser/grammar.py
@@ -112,7 +112,7 @@ class Builder(lexer.LexBuilder):
     """A builder used by the lexer and grammar parser as callbacks to create
     the data objects corresponding to rules parsed from the input file."""
 
-    def __init__(self, filename):
+    def __init__(self):
         lexer.LexBuilder.__init__(self)
 
         # A stack of the current active tags.
@@ -126,9 +126,6 @@ class Builder(lexer.LexBuilder):
 
         # Accumulated and unprocessed options.
         self.options = copy.deepcopy(options.OPTIONS_DEFAULTS)
-
-        # Set the filename we're processing.
-        self.options['filename'] = filename
 
         # Make the account regexp more restrictive than the default: check
         # types. Warning: This overrides the value in the base class.
@@ -217,6 +214,8 @@ class Builder(lexer.LexBuilder):
         Args:
           entries: A list of entries to store.
         """
+        # Record the name of the processed file.
+        self.options['filename'] = filename
         if entries:
             self.entries = entries
 

--- a/beancount/parser/grammar.py
+++ b/beancount/parser/grammar.py
@@ -235,7 +235,8 @@ class Builder(lexer.LexBuilder):
             assert not isinstance(exc_value, str)
             strings = traceback.format_exception_only(exc_type, exc_value)
             tblist = traceback.extract_tb(exc_traceback)
-            filename, lineno, _, __ = tblist[0]
+            if tblist:
+                filename, lineno, _, __ = tblist[0]
             message = '{} ({}:{})'.format(strings[0], filename, lineno)
         else:
             message = str(exc_value)

--- a/beancount/parser/grammar.y
+++ b/beancount/parser/grammar.y
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include "parser.h"
+#include "grammar.h"
 #include "lexer.h"
 
 extern YY_DECL;
@@ -30,11 +31,7 @@ extern YY_DECL;
         YYERROR;                                                                \
     }
 
-
-/* First line of reported file/line string. This is used as #line. */
-int yy_firstline;
-
-#define FILE_LINE_ARGS  yy_filename, ((yyloc).first_line + yy_firstline)
+#define FILE_LINE_ARGS  yyget_filename(scanner), ((yyloc).first_line + yyget_firstline(scanner))
 
 
 /* Build a grammar error from the exception context. */
@@ -55,7 +52,8 @@ void build_grammar_error_from_exception(yyscan_t scanner)
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "siOOO",
-                                           yy_filename, yyget_lineno(scanner) + yy_firstline,
+                                           yyget_filename(scanner),
+                                           yyget_lineno(scanner) + yyget_firstline(scanner),
                                            pvalue, ptype, ptraceback ?: Py_None);
         if (rv == NULL) {
             /* Note: Leave the internal error trickling up its detail. */
@@ -85,7 +83,8 @@ void yyerror(YYLTYPE *locp, yyscan_t scanner, char const* message)
     else {
         /* Register a syntax error with the builder. */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "sis",
-                                           yy_filename, yyget_lineno(scanner) + yy_firstline,
+                                           yyget_filename(scanner),
+                                           yyget_lineno(scanner) + yyget_firstline(scanner),
                                            message);
         if (rv == NULL) {
             PyErr_SetString(PyExc_RuntimeError,

--- a/beancount/parser/grammar.y
+++ b/beancount/parser/grammar.y
@@ -42,9 +42,9 @@ void build_grammar_error_from_exception(void)
     TRACE_ERROR("Grammar Builder Exception");
 
     /* Get the exception context. */
-    PyObject* ptype;
-    PyObject* pvalue;
-    PyObject* ptraceback;
+    PyObject* ptype = NULL;
+    PyObject* pvalue = NULL;
+    PyObject* ptraceback = NULL;
     PyErr_Fetch(&ptype, &pvalue, &ptraceback);
     PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
 
@@ -55,7 +55,7 @@ void build_grammar_error_from_exception(void)
         /* Build and accumulate a new error object. {27d1d459c5cd} */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "siOOO",
                                            yy_filename, yylineno + yy_firstline,
-                                           pvalue, ptype, ptraceback);
+                                           pvalue, ptype, ptraceback ?: Py_None);
         if (rv == NULL) {
             /* Note: Leave the internal error trickling up its detail. */
             /* PyErr_SetString(PyExc_RuntimeError, */

--- a/beancount/parser/grammar.y
+++ b/beancount/parser/grammar.y
@@ -844,6 +844,13 @@ declarations : declarations directive
 
 file : declarations
      {
+         /* If a Python exception has been raised and not handled, abort. In
+          * case of unrecoverable error, the lexer raises a Python exception and
+          * the yylex() function returns -1, whcih is translated by Bison into
+          * an EOF token, handled here. */
+         if (PyErr_Occurred()) {
+             YYABORT;
+         }
          BUILDY(DECREF1($1),
                 $$, "store_result", "O", $1);
      }

--- a/beancount/parser/grammar.y
+++ b/beancount/parser/grammar.y
@@ -27,15 +27,15 @@ extern YY_DECL;
     target = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);    \
     clean;                                                                      \
     if (target == NULL) {                                                       \
-        build_grammar_error_from_exception(scanner);                            \
+        build_grammar_error_from_exception(scanner, parser, builder);           \
         YYERROR;                                                                \
     }
 
-#define FILE_LINE_ARGS  yyget_filename(scanner), ((yyloc).first_line + yyget_firstline(scanner))
-
+#define FILENAME ((Parser*)parser)->filename
+#define LINENO ((yyloc).first_line + ((Parser*)parser)->line)
 
 /* Build a grammar error from the exception context. */
-void build_grammar_error_from_exception(yyscan_t scanner)
+void build_grammar_error_from_exception(yyscan_t scanner, PyObject* parser, PyObject* builder)
 {
     TRACE_ERROR("Grammar Builder Exception");
 
@@ -51,9 +51,9 @@ void build_grammar_error_from_exception(yyscan_t scanner)
 
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
-        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "siOOO",
-                                           yyget_filename(scanner),
-                                           yyget_lineno(scanner) + yyget_firstline(scanner),
+        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "OiOOO",
+                                           ((Parser*)parser)->filename,
+                                           yyget_lineno(scanner) + ((Parser*)parser)->line,
                                            pvalue, ptype, ptraceback ?: Py_None);
         if (rv == NULL) {
             /* Note: Leave the internal error trickling up its detail. */
@@ -71,10 +71,8 @@ void build_grammar_error_from_exception(yyscan_t scanner)
     Py_XDECREF(ptraceback);
 }
 
-
-
 /* Error-handling function. {ca6aab8b9748} */
-void yyerror(YYLTYPE *locp, yyscan_t scanner, char const* message)
+void yyerror(YYLTYPE *locp, yyscan_t scanner, PyObject* parser, PyObject* builder, char const* message)
 {
     /* Skip lex errors: they have already been registered the lexer itself. */
     if (strstr(message, "LEX_ERROR") != NULL) {
@@ -82,9 +80,9 @@ void yyerror(YYLTYPE *locp, yyscan_t scanner, char const* message)
     }
     else {
         /* Register a syntax error with the builder. */
-        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "sis",
-                                           yyget_filename(scanner),
-                                           yyget_lineno(scanner) + yyget_firstline(scanner),
+        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "Ois",
+                                           ((Parser*)parser)->filename,
+                                           yyget_lineno(scanner) + ((Parser*)parser)->line,
                                            message);
         if (rv == NULL) {
             PyErr_SetString(PyExc_RuntimeError,
@@ -119,6 +117,8 @@ const char* getTokenName(int token);
 %locations
 %define api.pure full
 %param {yyscan_t scanner}
+%param {PyObject* parser}
+%param {PyObject* builder}
 
 /* Collection of value types. */
 %union {
@@ -340,7 +340,7 @@ txn_strings : empty
             | txn_strings PIPE
             {
                 BUILDY(,
-                       $$, "pipe_deprecated_error", "si", FILE_LINE_ARGS);
+                       $$, "pipe_deprecated_error", "Oi", FILENAME, LINENO);
                 $$ = $1;
             }
 
@@ -366,7 +366,7 @@ tags_links : empty
 transaction : DATE txn txn_strings tags_links eol posting_or_kv_list
             {
                 BUILDY(DECREF4($1, $3, $4, $6),
-                       $$, "transaction", "siObOOO", FILE_LINE_ARGS, $1, $2, $3, $4, $6);
+                       $$, "transaction", "OiObOOO", FILENAME, LINENO, $1, $2, $3, $4, $6);
             }
 
 optflag : empty
@@ -391,22 +391,22 @@ price_annotation : incomplete_amount
 posting : INDENT optflag ACCOUNT incomplete_amount cost_spec eol
         {
             BUILDY(DECREF3($3, $4, $5),
-                   $$, "posting", "siOOOOOb", FILE_LINE_ARGS, $3, $4, $5, Py_None, Py_False, $2);
+                   $$, "posting", "OiOOOOOb", FILENAME, LINENO, $3, $4, $5, Py_None, Py_False, $2);
         }
         | INDENT optflag ACCOUNT incomplete_amount cost_spec AT price_annotation eol
         {
             BUILDY(DECREF4($3, $4, $5, $7),
-                   $$, "posting", "siOOOOOb", FILE_LINE_ARGS, $3, $4, $5, $7, Py_False, $2);
+                   $$, "posting", "OiOOOOOb", FILENAME, LINENO, $3, $4, $5, $7, Py_False, $2);
         }
         | INDENT optflag ACCOUNT incomplete_amount cost_spec ATAT price_annotation eol
         {
             BUILDY(DECREF4($3, $4, $5, $7),
-                   $$, "posting", "siOOOOOb", FILE_LINE_ARGS, $3, $4, $5, $7, Py_True, $2);
+                   $$, "posting", "OiOOOOOb", FILENAME, LINENO, $3, $4, $5, $7, Py_True, $2);
         }
         | INDENT optflag ACCOUNT eol
         {
             BUILDY(DECREF1($3),
-                   $$, "posting", "siOOOOOb", FILE_LINE_ARGS, $3, missing_obj, Py_None, Py_None, Py_False, $2);
+                   $$, "posting", "OiOOOOOb", FILENAME, LINENO, $3, missing, Py_None, Py_None, Py_False, $2);
         }
 
 key_value : KEY COLON key_value_value
@@ -520,7 +520,7 @@ popmeta : POPMETA KEY COLON eol
 open : DATE OPEN ACCOUNT currency_list opt_booking eol key_value_list
      {
          BUILDY(DECREF5($1, $3, $4, $5, $7),
-                $$, "open", "siOOOOO", FILE_LINE_ARGS, $1, $3, $4, $5, $7);
+                $$, "open", "OiOOOOO", FILENAME, LINENO, $1, $3, $4, $5, $7);
          ;
      }
 
@@ -537,25 +537,25 @@ opt_booking : STRING
 close : DATE CLOSE ACCOUNT eol key_value_list
       {
           BUILDY(DECREF3($1, $3, $5),
-                 $$, "close", "siOOO", FILE_LINE_ARGS, $1, $3, $5);
+                 $$, "close", "OiOOO", FILENAME, LINENO, $1, $3, $5);
       }
 
 commodity : DATE COMMODITY CURRENCY eol key_value_list
           {
               BUILDY(DECREF3($1, $3, $5),
-                     $$, "commodity", "siOOO", FILE_LINE_ARGS, $1, $3, $5);
+                     $$, "commodity", "OiOOO", FILENAME, LINENO, $1, $3, $5);
           }
 
 pad : DATE PAD ACCOUNT ACCOUNT eol key_value_list
     {
         BUILDY(DECREF4($1, $3, $4, $6),
-               $$, "pad", "siOOOO", FILE_LINE_ARGS, $1, $3, $4, $6);
+               $$, "pad", "OiOOOO", FILENAME, LINENO, $1, $3, $4, $6);
     }
 
 balance : DATE BALANCE ACCOUNT amount_tolerance eol key_value_list
         {
             BUILDY(DECREF5($1, $3, $6, $4.pyobj1, $4.pyobj2),
-                   $$, "balance", "siOOOOO", FILE_LINE_ARGS, $1, $3, $4.pyobj1, $4.pyobj2, $6);
+                   $$, "balance", "OiOOOOO", FILENAME, LINENO, $1, $3, $4.pyobj1, $4.pyobj2, $6);
         }
 
 amount : number_expr CURRENCY
@@ -581,8 +581,8 @@ amount_tolerance : number_expr CURRENCY
 
 maybe_number : empty
              {
-                 Py_INCREF(missing_obj);
-                 $$ = missing_obj;
+                 Py_INCREF(missing);
+                 $$ = missing;
              }
              | number_expr
              {
@@ -591,8 +591,8 @@ maybe_number : empty
 
 maybe_currency : empty
              {
-                 Py_INCREF(missing_obj);
-                 $$ = missing_obj;
+                 Py_INCREF(missing);
+                 $$ = missing;
              }
              | CURRENCY
              {
@@ -676,25 +676,25 @@ cost_comp : compound_amount
 price : DATE PRICE CURRENCY amount eol key_value_list
       {
           BUILDY(DECREF4($1, $3, $4, $6),
-                 $$, "price", "siOOOO", FILE_LINE_ARGS, $1, $3, $4, $6);
+                 $$, "price", "OiOOOO", FILENAME, LINENO, $1, $3, $4, $6);
       }
 
 event : DATE EVENT STRING STRING eol key_value_list
       {
           BUILDY(DECREF4($1, $3, $4, $6),
-                 $$, "event", "siOOOO", FILE_LINE_ARGS, $1, $3, $4, $6);
+                 $$, "event", "OiOOOO", FILENAME, LINENO, $1, $3, $4, $6);
       }
 
 query : DATE QUERY STRING STRING eol key_value_list
          {
              BUILDY(DECREF4($1, $3, $4, $6),
-                    $$, "query", "siOOOO", FILE_LINE_ARGS, $1, $3, $4, $6);
+                    $$, "query", "OiOOOO", FILENAME, LINENO, $1, $3, $4, $6);
          }
 
 note : DATE NOTE ACCOUNT STRING eol key_value_list
       {
           BUILDY(DECREF4($1, $3, $4, $6),
-                 $$, "note", "siOOOO", FILE_LINE_ARGS, $1, $3, $4, $6);
+                 $$, "note", "OiOOOO", FILENAME, LINENO, $1, $3, $4, $6);
       }
 
 filename : STRING
@@ -702,7 +702,7 @@ filename : STRING
 document : DATE DOCUMENT ACCOUNT filename tags_links eol key_value_list
          {
              BUILDY(DECREF5($1, $3, $4, $5, $7),
-                    $$, "document", "siOOOOO", FILE_LINE_ARGS, $1, $3, $4, $5, $7);
+                    $$, "document", "OiOOOOO", FILENAME, LINENO, $1, $3, $4, $5, $7);
          }
 
 
@@ -755,7 +755,7 @@ custom_value_list : empty
 custom : DATE CUSTOM STRING custom_value_list eol key_value_list
        {
            BUILDY(DECREF4($1, $3, $4, $6),
-                  $$, "custom", "siOOOO", FILE_LINE_ARGS, $1, $3, $4, $6);
+                  $$, "custom", "OiOOOO", FILENAME, LINENO, $1, $3, $4, $6);
        }
 
 
@@ -778,24 +778,24 @@ entry : transaction
 option : OPTION STRING STRING eol
        {
            BUILDY(DECREF2($2, $3),
-                  $$, "option", "siOO", FILE_LINE_ARGS, $2, $3);
+                  $$, "option", "OiOO", FILENAME, LINENO, $2, $3);
        }
 
 include : INCLUDE STRING eol
        {
            BUILDY(DECREF1($2),
-                  $$, "include", "siO", FILE_LINE_ARGS, $2);
+                  $$, "include", "OiO", FILENAME, LINENO, $2);
        }
 
 plugin : PLUGIN STRING eol
        {
            BUILDY(DECREF1($2),
-                  $$, "plugin", "siOO", FILE_LINE_ARGS, $2, Py_None);
+                  $$, "plugin", "OiOO", FILENAME, LINENO, $2, Py_None);
        }
        | PLUGIN STRING STRING eol
        {
            BUILDY(DECREF2($2, $3),
-                  $$, "plugin", "siOO", FILE_LINE_ARGS, $2, $3);
+                  $$, "plugin", "OiOO", FILENAME, LINENO, $2, $3);
        }
 
 directive : empty_line

--- a/beancount/parser/grammar.y
+++ b/beancount/parser/grammar.y
@@ -44,6 +44,9 @@ typedef struct YYLTYPE {
         }                                                               \
     } while (0)
 
+/* Get a printable version of a token name. */
+const char* token_to_string(int token);
+
 }
 
 %{
@@ -116,10 +119,6 @@ void yyerror(YYLTYPE *locp, yyscan_t scanner, PyObject* builder, char const* mes
 
     Py_XDECREF(rv);
 }
-
-/* Get a printable version of a token name. */
-const char* getTokenName(int token);
-
 
 /* Macros to clean up memory for temporaries in rule reductions. */
 #define DECREF1(x1)                        Py_DECREF(x1);
@@ -884,59 +883,8 @@ file : declarations
 /* Epilogue */
 %%
 
-/* A function that will convert a token name to a string, used in debugging. */
-const char* getTokenName(int token)
+/* Get a printable version of a token name. */
+const char* token_to_string(int token)
 {
-    switch ( token ) {
-        case LEX_ERROR : return "LEX_ERROR";
-        case INDENT    : return "INDENT";
-        case EOL       : return "EOL";
-        case COMMENT   : return "COMMENT";
-        case SKIPPED   : return "SKIPPED";
-        case PIPE      : return "PIPE";
-        case ATAT      : return "ATAT";
-        case AT        : return "AT";
-        case LCURL     : return "LCURL";
-        case RCURL     : return "RCURL";
-        case EQUAL     : return "EQUAL";
-        case COMMA     : return "COMMA";
-        case TILDE     : return "TILDE";
-        case HASH      : return "HASH";
-        case PLUS      : return "PLUS";
-        case MINUS     : return "MINUS";
-        case ASTERISK  : return "ASTERISK";
-        case SLASH     : return "SLASH";
-        case COLON     : return "COLON";
-        case LPAREN    : return "LPAREN";
-        case RPAREN    : return "RPAREN";
-        case FLAG      : return "FLAG";
-        case TXN       : return "TXN";
-        case BALANCE   : return "BALANCE";
-        case OPEN      : return "OPEN";
-        case CLOSE     : return "CLOSE";
-        case PAD       : return "PAD";
-        case EVENT     : return "EVENT";
-        case QUERY     : return "QUERY";
-        case CUSTOM    : return "CUSTOM";
-        case PRICE     : return "PRICE";
-        case NOTE      : return "NOTE";
-        case DOCUMENT  : return "DOCUMENT";
-        case PUSHTAG   : return "PUSHTAG";
-        case POPTAG    : return "POPTAG";
-        case PUSHMETA  : return "PUSHMETA";
-        case POPMETA   : return "POPMETA";
-        case OPTION    : return "OPTION";
-        case PLUGIN    : return "PLUGIN";
-        case DATE      : return "DATE";
-        case ACCOUNT   : return "ACCOUNT";
-        case CURRENCY  : return "CURRENCY";
-        case STRING    : return "STRING";
-        case NUMBER    : return "NUMBER";
-        case TAG       : return "TAG";
-        case LINK      : return "LINK";
-        case KEY       : return "KEY";
-        case BOOL      : return "BOOL";
-        case NONE      : return "NULL";
-    }
-    return "<NO_STRING_TRANSLATION>";
+    return yytname[YYTRANSLATE(token)];
 }

--- a/beancount/parser/grammar.y
+++ b/beancount/parser/grammar.y
@@ -15,6 +15,7 @@
 #include "parser.h"
 #include "lexer.h"
 
+extern YY_DECL;
 
 /*
  * Call a builder method and detect and handle a Python exception being raised
@@ -25,7 +26,7 @@
     target = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);    \
     clean;                                                                      \
     if (target == NULL) {                                                       \
-        build_grammar_error_from_exception();                                   \
+        build_grammar_error_from_exception(scanner);                            \
         YYERROR;                                                                \
     }
 
@@ -37,7 +38,7 @@ int yy_firstline;
 
 
 /* Build a grammar error from the exception context. */
-void build_grammar_error_from_exception(void)
+void build_grammar_error_from_exception(yyscan_t scanner)
 {
     TRACE_ERROR("Grammar Builder Exception");
 
@@ -54,7 +55,7 @@ void build_grammar_error_from_exception(void)
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "siOOO",
-                                           yy_filename, yylineno + yy_firstline,
+                                           yy_filename, yyget_lineno(scanner) + yy_firstline,
                                            pvalue, ptype, ptraceback ?: Py_None);
         if (rv == NULL) {
             /* Note: Leave the internal error trickling up its detail. */
@@ -75,7 +76,7 @@ void build_grammar_error_from_exception(void)
 
 
 /* Error-handling function. {ca6aab8b9748} */
-void yyerror(char const* message)
+void yyerror(YYLTYPE *locp, yyscan_t scanner, char const* message)
 {
     /* Skip lex errors: they have already been registered the lexer itself. */
     if (strstr(message, "LEX_ERROR") != NULL) {
@@ -84,7 +85,7 @@ void yyerror(char const* message)
     else {
         /* Register a syntax error with the builder. */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "sis",
-                                           yy_filename, yylineno + yy_firstline,
+                                           yy_filename, yyget_lineno(scanner) + yy_firstline,
                                            message);
         if (rv == NULL) {
             PyErr_SetString(PyExc_RuntimeError,
@@ -112,15 +113,13 @@ const char* getTokenName(int token);
 /*--------------------------------------------------------------------------------*/
 /* Bison Declarations */
 
-
 /* Options. */
 %defines
 %error-verbose
 %debug
-%pure-parser
 %locations
-/* %glr-parser */
-
+%define api.pure full
+%param {yyscan_t scanner}
 
 /* Collection of value types. */
 %union {

--- a/beancount/parser/grammar_test.py
+++ b/beancount/parser/grammar_test.py
@@ -293,7 +293,7 @@ class TestUglyBugs(unittest.TestCase):
             ';; End of file',
         ])
 
-        entries, errors, _ = parser.parse_string(input_, yydebug=0)
+        entries, errors, _ = parser.parse_string(input_)
         check_list(self, entries, [data.Transaction])
         check_list(self, errors, [])
 

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -15,10 +15,7 @@ yyscan_t* yylex_free(yyscan_t scanner);
 /* Initialize scanner private data and reset scanner state. */
 void yylex_initialize(yyscan_t scanner, PyObject* file, PyObject* filename, int line, const char* encoding);
 
-PyObject* yyget_filename(yyscan_t scanner);
-int yyget_firstline(yyscan_t scanner);
-
-#line 21 "beancount/parser/lexer.c"
+#line 18 "beancount/parser/lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -971,7 +968,7 @@ static const flex_int32_t yy_rule_can_match_eol[63] =
 /* Top Code. This is included in the FLex generated header file. */
 
 /* Definitions. */
-#line 43 "beancount/parser/lexer.l"
+#line 40 "beancount/parser/lexer.l"
 
 #include <math.h>
 #include <stdlib.h>
@@ -1101,12 +1098,12 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
 
-#line 1104 "beancount/parser/lexer.c"
+#line 1101 "beancount/parser/lexer.c"
 /* A start condition for chomping an invalid token. */
 
 /* Exclusive start condition for parsing escape sequences in string literals. */
 
-#line 1109 "beancount/parser/lexer.c"
+#line 1106 "beancount/parser/lexer.c"
 
 #define INITIAL 0
 #define INVALID 1
@@ -1390,11 +1387,11 @@ YY_DECL
 		}
 
 	{
-#line 193 "beancount/parser/lexer.l"
+#line 190 "beancount/parser/lexer.l"
 
 
 
-#line 197 "beancount/parser/lexer.l"
+#line 194 "beancount/parser/lexer.l"
     /* If a Python exception has been raised, return immediately. This is
      * useful to catch exceptions raised in the YY_INPUT routine or other
      * exceptions not explicitly handled. */
@@ -1404,7 +1401,7 @@ YY_DECL
 
 
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
-#line 1407 "beancount/parser/lexer.c"
+#line 1404 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1472,7 +1469,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 206 "beancount/parser/lexer.l"
+#line 203 "beancount/parser/lexer.l"
 {
     yy_line_tokens = 0;
     yycolumn = 1;
@@ -1485,7 +1482,7 @@ YY_RULE_SETUP
     the grammar. */
 case 2:
 YY_RULE_SETUP
-#line 216 "beancount/parser/lexer.l"
+#line 213 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens == 1 ) {
         /* If the next character completes the line, skip it. */
@@ -1503,79 +1500,79 @@ YY_RULE_SETUP
 /* Characters with special meanings have their own tokens. */
 case 3:
 YY_RULE_SETUP
-#line 231 "beancount/parser/lexer.l"
+#line 228 "beancount/parser/lexer.l"
 { return PIPE; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 232 "beancount/parser/lexer.l"
+#line 229 "beancount/parser/lexer.l"
 { return ATAT; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 233 "beancount/parser/lexer.l"
+#line 230 "beancount/parser/lexer.l"
 { return AT; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 234 "beancount/parser/lexer.l"
+#line 231 "beancount/parser/lexer.l"
 { return LCURLCURL; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 235 "beancount/parser/lexer.l"
+#line 232 "beancount/parser/lexer.l"
 { return RCURLCURL; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 236 "beancount/parser/lexer.l"
+#line 233 "beancount/parser/lexer.l"
 { return LCURL; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 237 "beancount/parser/lexer.l"
+#line 234 "beancount/parser/lexer.l"
 { return RCURL; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 238 "beancount/parser/lexer.l"
+#line 235 "beancount/parser/lexer.l"
 { return COMMA; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 239 "beancount/parser/lexer.l"
+#line 236 "beancount/parser/lexer.l"
 { return TILDE; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 240 "beancount/parser/lexer.l"
+#line 237 "beancount/parser/lexer.l"
 { return PLUS; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 241 "beancount/parser/lexer.l"
+#line 238 "beancount/parser/lexer.l"
 { return MINUS; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 242 "beancount/parser/lexer.l"
+#line 239 "beancount/parser/lexer.l"
 { return SLASH; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 243 "beancount/parser/lexer.l"
+#line 240 "beancount/parser/lexer.l"
 { return LPAREN; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 244 "beancount/parser/lexer.l"
+#line 241 "beancount/parser/lexer.l"
 { return RPAREN; }
 	YY_BREAK
 /* Special handling for characters beginning a line to be ignored.
   * I'd like to improve how this is handled. Needs own lexer, really. */
 case 17:
 YY_RULE_SETUP
-#line 248 "beancount/parser/lexer.l"
+#line 245 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return HASH;
@@ -1589,7 +1586,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 259 "beancount/parser/lexer.l"
+#line 256 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return ASTERISK;
@@ -1603,7 +1600,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 270 "beancount/parser/lexer.l"
+#line 267 "beancount/parser/lexer.l"
 {
   if (yy_line_tokens != 1) {
     return COLON;
@@ -1618,7 +1615,7 @@ YY_RULE_SETUP
 /* Skip commented output (but not the accompanying newline). */
 case 20:
 YY_RULE_SETUP
-#line 282 "beancount/parser/lexer.l"
+#line 279 "beancount/parser/lexer.l"
 {
     /* yy_skip_line(); */
     return COMMENT;
@@ -1634,7 +1631,7 @@ YY_RULE_SETUP
     */
 case 21:
 YY_RULE_SETUP
-#line 295 "beancount/parser/lexer.l"
+#line 292 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         yylval->character = yytext[0];
@@ -1649,103 +1646,103 @@ YY_RULE_SETUP
 /* Keywords. */
 case 22:
 YY_RULE_SETUP
-#line 307 "beancount/parser/lexer.l"
+#line 304 "beancount/parser/lexer.l"
 { return TXN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 308 "beancount/parser/lexer.l"
+#line 305 "beancount/parser/lexer.l"
 { return BALANCE; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 309 "beancount/parser/lexer.l"
+#line 306 "beancount/parser/lexer.l"
 { return OPEN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 310 "beancount/parser/lexer.l"
+#line 307 "beancount/parser/lexer.l"
 { return CLOSE; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 311 "beancount/parser/lexer.l"
+#line 308 "beancount/parser/lexer.l"
 { return COMMODITY; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 312 "beancount/parser/lexer.l"
+#line 309 "beancount/parser/lexer.l"
 { return PAD; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 313 "beancount/parser/lexer.l"
+#line 310 "beancount/parser/lexer.l"
 { return EVENT; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 314 "beancount/parser/lexer.l"
+#line 311 "beancount/parser/lexer.l"
 { return QUERY; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 315 "beancount/parser/lexer.l"
+#line 312 "beancount/parser/lexer.l"
 { return CUSTOM; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 316 "beancount/parser/lexer.l"
+#line 313 "beancount/parser/lexer.l"
 { return PRICE; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 317 "beancount/parser/lexer.l"
+#line 314 "beancount/parser/lexer.l"
 { return NOTE; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 318 "beancount/parser/lexer.l"
+#line 315 "beancount/parser/lexer.l"
 { return DOCUMENT; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 319 "beancount/parser/lexer.l"
+#line 316 "beancount/parser/lexer.l"
 { return PUSHTAG; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 320 "beancount/parser/lexer.l"
+#line 317 "beancount/parser/lexer.l"
 { return POPTAG; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 321 "beancount/parser/lexer.l"
+#line 318 "beancount/parser/lexer.l"
 { return PUSHMETA; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 322 "beancount/parser/lexer.l"
+#line 319 "beancount/parser/lexer.l"
 { return POPMETA; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 323 "beancount/parser/lexer.l"
+#line 320 "beancount/parser/lexer.l"
 { return OPTION; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 324 "beancount/parser/lexer.l"
+#line 321 "beancount/parser/lexer.l"
 { return PLUGIN; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 325 "beancount/parser/lexer.l"
+#line 322 "beancount/parser/lexer.l"
 { return INCLUDE; }
 	YY_BREAK
 /* Boolean values. */
 case 41:
 YY_RULE_SETUP
-#line 328 "beancount/parser/lexer.l"
+#line 325 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_True;
     Py_INCREF(Py_True);
@@ -1754,7 +1751,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 334 "beancount/parser/lexer.l"
+#line 331 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_False;
     Py_INCREF(Py_False);
@@ -1763,7 +1760,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 340 "beancount/parser/lexer.l"
+#line 337 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_None;
     Py_INCREF(Py_None);
@@ -1773,7 +1770,7 @@ YY_RULE_SETUP
 /* Dates. */
 case 44:
 YY_RULE_SETUP
-#line 347 "beancount/parser/lexer.l"
+#line 344 "beancount/parser/lexer.l"
 {
     const char* year_str;
     const char* month_str;
@@ -1798,7 +1795,7 @@ YY_RULE_SETUP
 /* Account names. */
 case 45:
 YY_RULE_SETUP
-#line 369 "beancount/parser/lexer.l"
+#line 366 "beancount/parser/lexer.l"
 {
     BUILD("ACCOUNT", "s", yytext);
     return ACCOUNT;
@@ -1808,7 +1805,7 @@ YY_RULE_SETUP
   * syntax. This is kept in sync with beancount.core.amount.CURRENCY_RE. */
 case 46:
 YY_RULE_SETUP
-#line 376 "beancount/parser/lexer.l"
+#line 373 "beancount/parser/lexer.l"
 {
     BUILD("CURRENCY", "s", yytext);
     return CURRENCY;
@@ -1819,7 +1816,7 @@ YY_RULE_SETUP
     See section "Start Conditions" in the GNU Flex manual. */
 case 47:
 YY_RULE_SETUP
-#line 384 "beancount/parser/lexer.l"
+#line 381 "beancount/parser/lexer.l"
 {
     buffer_beginning(strbuf);
     BEGIN(STRLIT);
@@ -1829,7 +1826,7 @@ YY_RULE_SETUP
 /* Saw closing quote - all done. */
 case 48:
 YY_RULE_SETUP
-#line 392 "beancount/parser/lexer.l"
+#line 389 "beancount/parser/lexer.l"
 {
         BEGIN(INITIAL);
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
@@ -1848,47 +1845,47 @@ YY_RULE_SETUP
 /* Escape sequences. */
 case 49:
 YY_RULE_SETUP
-#line 408 "beancount/parser/lexer.l"
+#line 405 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\n');
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 409 "beancount/parser/lexer.l"
+#line 406 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\t');
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 410 "beancount/parser/lexer.l"
+#line 407 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\r');
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 411 "beancount/parser/lexer.l"
+#line 408 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\b');
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 412 "beancount/parser/lexer.l"
+#line 409 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\f');
 	YY_BREAK
 case 54:
 /* rule 54 can match eol */
 YY_RULE_SETUP
-#line 413 "beancount/parser/lexer.l"
+#line 410 "beancount/parser/lexer.l"
 buffer_push(strbuf, yytext[1]);
 	YY_BREAK
 /* All other characters. */
 case 55:
 /* rule 55 can match eol */
 YY_RULE_SETUP
-#line 416 "beancount/parser/lexer.l"
+#line 413 "beancount/parser/lexer.l"
 buffer_append(strbuf, yytext, yyleng);
 	YY_BREAK
 
 /* Numbers */
 case 56:
 YY_RULE_SETUP
-#line 420 "beancount/parser/lexer.l"
+#line 417 "beancount/parser/lexer.l"
 {
     BUILD("NUMBER", "s", yytext);
     return NUMBER;
@@ -1897,7 +1894,7 @@ YY_RULE_SETUP
 /* Tags */
 case 57:
 YY_RULE_SETUP
-#line 426 "beancount/parser/lexer.l"
+#line 423 "beancount/parser/lexer.l"
 {
     BUILD("TAG", "s", &(yytext[1]));
     return TAG;
@@ -1906,7 +1903,7 @@ YY_RULE_SETUP
 /* Links */
 case 58:
 YY_RULE_SETUP
-#line 432 "beancount/parser/lexer.l"
+#line 429 "beancount/parser/lexer.l"
 {
     BUILD("LINK", "s", &(yytext[1]));
     return LINK;
@@ -1915,7 +1912,7 @@ YY_RULE_SETUP
 /* Key */
 case 59:
 YY_RULE_SETUP
-#line 438 "beancount/parser/lexer.l"
+#line 435 "beancount/parser/lexer.l"
 {
     BUILD("KEY", "s#", yytext, (Py_ssize_t)(yyleng - 1));
     unput(':');
@@ -1925,7 +1922,7 @@ YY_RULE_SETUP
 /* Default rule. {bf253a29a820} */
 case 60:
 YY_RULE_SETUP
-#line 445 "beancount/parser/lexer.l"
+#line 442 "beancount/parser/lexer.l"
 {
     unput(*yytext);
     BEGIN(INVALID);
@@ -1936,7 +1933,7 @@ YY_RULE_SETUP
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(INVALID):
 case YY_STATE_EOF(STRLIT):
-#line 452 "beancount/parser/lexer.l"
+#line 449 "beancount/parser/lexer.l"
 {
   if (yy_eof_times == 0) {
       yy_eof_times = 1;
@@ -1953,7 +1950,7 @@ case YY_STATE_EOF(STRLIT):
     this and more. {bba169a1d35a} */
 case 61:
 YY_RULE_SETUP
-#line 466 "beancount/parser/lexer.l"
+#line 463 "beancount/parser/lexer.l"
 {
     build_lexer_error(yylloc, builder, "Invalid token: '%s'", yytext);
     BEGIN(INITIAL);
@@ -1962,10 +1959,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 473 "beancount/parser/lexer.l"
+#line 470 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1968 "beancount/parser/lexer.c"
+#line 1965 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3168,7 +3165,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 473 "beancount/parser/lexer.l"
+#line 470 "beancount/parser/lexer.l"
 
 
 yyscan_t* yylex_new(void)
@@ -3248,18 +3245,6 @@ void yylex_initialize(yyscan_t scanner, PyObject* file, PyObject* filename, int 
     extra->n_line_tokens = 0;
 
     buffer_beginning(&extra->str);
-}
-
-PyObject* yyget_filename(yyscan_t scanner)
-{
-    yyextra_t* extra = yyget_extra(scanner);
-    return extra->filename;
-}
-
-int yyget_firstline(yyscan_t scanner)
-{
-    yyextra_t* extra = yyget_extra(scanner);
-    return extra->line;
 }
 
 static void buffer_init(struct buffer* b, size_t size)

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -4,13 +4,21 @@
 
 typedef struct _yyextra_t yyextra_t;
 
-/* Initialize scanner private data. */
-void yylex_initialize(yyscan_t yyscanner);
+/* Allocate a new scanner object including private data. This
+ * encapsulates the cumbersome Flex native yylex_init() API. */
+yyscan_t* yylex_new(void);
 
-/* Free scanner private data */
-void yylex_finalize(yyscan_t yyscanner);
+/* Free scanner object including private data. This encapsulates the
+ * cumbersome Flex native yylex_destroy() API. */
+yyscan_t* yylex_free(yyscan_t scanner);
 
-#line 13 "beancount/parser/lexer.c"
+/* Initialize scanner private data and reset scanner state. */
+void yylex_initialize(yyscan_t scanner, PyObject* file, PyObject* filename, int line, const char* encoding);
+
+PyObject* yyget_filename(yyscan_t scanner);
+int yyget_firstline(yyscan_t scanner);
+
+#line 21 "beancount/parser/lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -954,7 +962,7 @@ static const flex_int32_t yy_rule_can_match_eol[63] =
 #define YY_RESTORE_YY_MORE_OFFSET
 #line 1 "beancount/parser/lexer.l"
 /* -*- mode: c -*- */
-/* A flex lexer for Beancount. */
+/* A Flex lexer for Beancount. */
 /* Options */
 /* %option nodefault */
 /* %option debug */
@@ -963,13 +971,11 @@ static const flex_int32_t yy_rule_can_match_eol[63] =
 /* Top Code. This is included in the FLex generated header file. */
 
 /* Definitions. */
-#line 35 "beancount/parser/lexer.l"
+#line 43 "beancount/parser/lexer.l"
 
-/* Includes. */
 #include <math.h>
 #include <stdlib.h>
 
-#include "parser.h"
 #include "grammar.h"
 
 struct buffer {
@@ -979,6 +985,12 @@ struct buffer {
 };
 
 struct _yyextra_t {
+    /* The filename being tokenized. */
+    PyObject* filename;
+    /* Reporting line offset. This is used like the #line cpp macro */
+    int line;
+    /* The encoding to use for converting strings. */
+    const char* encoding;
     /* The number of times EOF has been hit. This is used to
      * synthesize an EOL at the end of the file. */
     int n_eof;
@@ -1019,7 +1031,7 @@ static inline char* buffer_data(const struct buffer* b)
     return b->buf;
 }
 
-static inline void buffer_begin(struct buffer* b)
+static inline void buffer_beginning(struct buffer* b)
 {
     b->ptr = b->buf;
 }
@@ -1027,9 +1039,9 @@ static inline void buffer_begin(struct buffer* b)
 #define strbuf &yyget_extra(yyscanner)->str
 #define yy_eof_times yyget_extra(yyscanner)->n_eof
 #define yy_line_tokens yyget_extra(yyscanner)->n_line_tokens
-#define yy_filename ((Parser*)parser)->filename
-#define yy_firstline ((Parser*)parser)->line
-#define yy_encoding ((Parser*)parser)->encoding
+#define yy_filename yyget_extra(yyscanner)->filename
+#define yy_firstline yyget_extra(yyscanner)->line
+#define yy_encoding yyget_extra(yyscanner)->encoding
 
 /* Build and accumulate an error on the builder object. */
 void build_lexer_error(PyObject* builder, const char* format, ...);
@@ -1058,12 +1070,15 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
         return LEX_ERROR;                                               \
     }
 
-#define YY_USER_ACTION {                                        \
-        yy_line_tokens++;                                       \
-        yylloc->first_line = yylloc->last_line = yylineno;      \
-        yylloc->first_column = yycolumn;                        \
-        yylloc->last_column = yycolumn + yyleng - 1;            \
-        yycolumn += yyleng;                                     \
+#define YY_USER_ACTION                                                  \
+    {                                                                   \
+        yy_line_tokens++;                                               \
+        yylloc->first_line = yylineno + yy_firstline;                   \
+        yylloc->last_line = yylloc->first_line;                         \
+        yylloc->first_column = yycolumn;                                \
+        yylloc->last_column = yycolumn + yyleng - 1;                    \
+        yylloc->file_name = yy_filename;                                \
+        yycolumn += yyleng;                                             \
     }
 
 /* Skip the rest of the input line.  This needs to be implemented as a
@@ -1086,12 +1101,12 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
 
-#line 1089 "beancount/parser/lexer.c"
+#line 1104 "beancount/parser/lexer.c"
 /* A start condition for chomping an invalid token. */
 
 /* Exclusive start condition for parsing escape sequences in string literals. */
 
-#line 1094 "beancount/parser/lexer.c"
+#line 1109 "beancount/parser/lexer.c"
 
 #define INITIAL 0
 #define INVALID 1
@@ -1375,11 +1390,11 @@ YY_DECL
 		}
 
 	{
-#line 178 "beancount/parser/lexer.l"
+#line 193 "beancount/parser/lexer.l"
 
 
 
-#line 182 "beancount/parser/lexer.l"
+#line 197 "beancount/parser/lexer.l"
     /* If a Python exception has been raised, return immediately. This is
      * useful to catch exceptions raised in the YY_INPUT routine or other
      * exceptions not explicitly handled. */
@@ -1389,7 +1404,7 @@ YY_DECL
 
 
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
-#line 1392 "beancount/parser/lexer.c"
+#line 1407 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1457,7 +1472,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 191 "beancount/parser/lexer.l"
+#line 206 "beancount/parser/lexer.l"
 {
     yy_line_tokens = 0;
     yycolumn = 1;
@@ -1470,7 +1485,7 @@ YY_RULE_SETUP
     the grammar. */
 case 2:
 YY_RULE_SETUP
-#line 201 "beancount/parser/lexer.l"
+#line 216 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens == 1 ) {
         /* If the next character completes the line, skip it. */
@@ -1488,79 +1503,79 @@ YY_RULE_SETUP
 /* Characters with special meanings have their own tokens. */
 case 3:
 YY_RULE_SETUP
-#line 216 "beancount/parser/lexer.l"
+#line 231 "beancount/parser/lexer.l"
 { return PIPE; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 217 "beancount/parser/lexer.l"
+#line 232 "beancount/parser/lexer.l"
 { return ATAT; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 218 "beancount/parser/lexer.l"
+#line 233 "beancount/parser/lexer.l"
 { return AT; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 219 "beancount/parser/lexer.l"
+#line 234 "beancount/parser/lexer.l"
 { return LCURLCURL; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 220 "beancount/parser/lexer.l"
+#line 235 "beancount/parser/lexer.l"
 { return RCURLCURL; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 221 "beancount/parser/lexer.l"
+#line 236 "beancount/parser/lexer.l"
 { return LCURL; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 222 "beancount/parser/lexer.l"
+#line 237 "beancount/parser/lexer.l"
 { return RCURL; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 223 "beancount/parser/lexer.l"
+#line 238 "beancount/parser/lexer.l"
 { return COMMA; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 224 "beancount/parser/lexer.l"
+#line 239 "beancount/parser/lexer.l"
 { return TILDE; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 225 "beancount/parser/lexer.l"
+#line 240 "beancount/parser/lexer.l"
 { return PLUS; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 226 "beancount/parser/lexer.l"
+#line 241 "beancount/parser/lexer.l"
 { return MINUS; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 227 "beancount/parser/lexer.l"
+#line 242 "beancount/parser/lexer.l"
 { return SLASH; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 228 "beancount/parser/lexer.l"
+#line 243 "beancount/parser/lexer.l"
 { return LPAREN; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 229 "beancount/parser/lexer.l"
+#line 244 "beancount/parser/lexer.l"
 { return RPAREN; }
 	YY_BREAK
 /* Special handling for characters beginning a line to be ignored.
   * I'd like to improve how this is handled. Needs own lexer, really. */
 case 17:
 YY_RULE_SETUP
-#line 233 "beancount/parser/lexer.l"
+#line 248 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return HASH;
@@ -1574,7 +1589,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 244 "beancount/parser/lexer.l"
+#line 259 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return ASTERISK;
@@ -1588,7 +1603,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 255 "beancount/parser/lexer.l"
+#line 270 "beancount/parser/lexer.l"
 {
   if (yy_line_tokens != 1) {
     return COLON;
@@ -1603,7 +1618,7 @@ YY_RULE_SETUP
 /* Skip commented output (but not the accompanying newline). */
 case 20:
 YY_RULE_SETUP
-#line 267 "beancount/parser/lexer.l"
+#line 282 "beancount/parser/lexer.l"
 {
     /* yy_skip_line(); */
     return COMMENT;
@@ -1619,7 +1634,7 @@ YY_RULE_SETUP
     */
 case 21:
 YY_RULE_SETUP
-#line 280 "beancount/parser/lexer.l"
+#line 295 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         yylval->character = yytext[0];
@@ -1634,103 +1649,103 @@ YY_RULE_SETUP
 /* Keywords. */
 case 22:
 YY_RULE_SETUP
-#line 292 "beancount/parser/lexer.l"
+#line 307 "beancount/parser/lexer.l"
 { return TXN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 293 "beancount/parser/lexer.l"
+#line 308 "beancount/parser/lexer.l"
 { return BALANCE; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 294 "beancount/parser/lexer.l"
+#line 309 "beancount/parser/lexer.l"
 { return OPEN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 295 "beancount/parser/lexer.l"
+#line 310 "beancount/parser/lexer.l"
 { return CLOSE; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 296 "beancount/parser/lexer.l"
+#line 311 "beancount/parser/lexer.l"
 { return COMMODITY; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 297 "beancount/parser/lexer.l"
+#line 312 "beancount/parser/lexer.l"
 { return PAD; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 298 "beancount/parser/lexer.l"
+#line 313 "beancount/parser/lexer.l"
 { return EVENT; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 299 "beancount/parser/lexer.l"
+#line 314 "beancount/parser/lexer.l"
 { return QUERY; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 300 "beancount/parser/lexer.l"
+#line 315 "beancount/parser/lexer.l"
 { return CUSTOM; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 301 "beancount/parser/lexer.l"
+#line 316 "beancount/parser/lexer.l"
 { return PRICE; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 302 "beancount/parser/lexer.l"
+#line 317 "beancount/parser/lexer.l"
 { return NOTE; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 303 "beancount/parser/lexer.l"
+#line 318 "beancount/parser/lexer.l"
 { return DOCUMENT; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 304 "beancount/parser/lexer.l"
+#line 319 "beancount/parser/lexer.l"
 { return PUSHTAG; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 305 "beancount/parser/lexer.l"
+#line 320 "beancount/parser/lexer.l"
 { return POPTAG; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 306 "beancount/parser/lexer.l"
+#line 321 "beancount/parser/lexer.l"
 { return PUSHMETA; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 307 "beancount/parser/lexer.l"
+#line 322 "beancount/parser/lexer.l"
 { return POPMETA; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 308 "beancount/parser/lexer.l"
+#line 323 "beancount/parser/lexer.l"
 { return OPTION; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 309 "beancount/parser/lexer.l"
+#line 324 "beancount/parser/lexer.l"
 { return PLUGIN; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 310 "beancount/parser/lexer.l"
+#line 325 "beancount/parser/lexer.l"
 { return INCLUDE; }
 	YY_BREAK
 /* Boolean values. */
 case 41:
 YY_RULE_SETUP
-#line 313 "beancount/parser/lexer.l"
+#line 328 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_True;
     Py_INCREF(Py_True);
@@ -1739,7 +1754,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 319 "beancount/parser/lexer.l"
+#line 334 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_False;
     Py_INCREF(Py_False);
@@ -1748,7 +1763,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 325 "beancount/parser/lexer.l"
+#line 340 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_None;
     Py_INCREF(Py_None);
@@ -1758,7 +1773,7 @@ YY_RULE_SETUP
 /* Dates. */
 case 44:
 YY_RULE_SETUP
-#line 332 "beancount/parser/lexer.l"
+#line 347 "beancount/parser/lexer.l"
 {
     const char* year_str;
     const char* month_str;
@@ -1783,7 +1798,7 @@ YY_RULE_SETUP
 /* Account names. */
 case 45:
 YY_RULE_SETUP
-#line 354 "beancount/parser/lexer.l"
+#line 369 "beancount/parser/lexer.l"
 {
     BUILD("ACCOUNT", "s", yytext);
     return ACCOUNT;
@@ -1793,7 +1808,7 @@ YY_RULE_SETUP
   * syntax. This is kept in sync with beancount.core.amount.CURRENCY_RE. */
 case 46:
 YY_RULE_SETUP
-#line 361 "beancount/parser/lexer.l"
+#line 376 "beancount/parser/lexer.l"
 {
     BUILD("CURRENCY", "s", yytext);
     return CURRENCY;
@@ -1804,9 +1819,9 @@ YY_RULE_SETUP
     See section "Start Conditions" in the GNU Flex manual. */
 case 47:
 YY_RULE_SETUP
-#line 369 "beancount/parser/lexer.l"
+#line 384 "beancount/parser/lexer.l"
 {
-    buffer_begin(strbuf);
+    buffer_beginning(strbuf);
     BEGIN(STRLIT);
 }
 	YY_BREAK
@@ -1814,7 +1829,7 @@ YY_RULE_SETUP
 /* Saw closing quote - all done. */
 case 48:
 YY_RULE_SETUP
-#line 377 "beancount/parser/lexer.l"
+#line 392 "beancount/parser/lexer.l"
 {
         BEGIN(INITIAL);
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
@@ -1833,47 +1848,47 @@ YY_RULE_SETUP
 /* Escape sequences. */
 case 49:
 YY_RULE_SETUP
-#line 393 "beancount/parser/lexer.l"
+#line 408 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\n');
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 394 "beancount/parser/lexer.l"
+#line 409 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\t');
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 395 "beancount/parser/lexer.l"
+#line 410 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\r');
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 396 "beancount/parser/lexer.l"
+#line 411 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\b');
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 397 "beancount/parser/lexer.l"
+#line 412 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\f');
 	YY_BREAK
 case 54:
 /* rule 54 can match eol */
 YY_RULE_SETUP
-#line 398 "beancount/parser/lexer.l"
+#line 413 "beancount/parser/lexer.l"
 buffer_push(strbuf, yytext[1]);
 	YY_BREAK
 /* All other characters. */
 case 55:
 /* rule 55 can match eol */
 YY_RULE_SETUP
-#line 401 "beancount/parser/lexer.l"
+#line 416 "beancount/parser/lexer.l"
 buffer_append(strbuf, yytext, yyleng);
 	YY_BREAK
 
 /* Numbers */
 case 56:
 YY_RULE_SETUP
-#line 405 "beancount/parser/lexer.l"
+#line 420 "beancount/parser/lexer.l"
 {
     BUILD("NUMBER", "s", yytext);
     return NUMBER;
@@ -1882,7 +1897,7 @@ YY_RULE_SETUP
 /* Tags */
 case 57:
 YY_RULE_SETUP
-#line 411 "beancount/parser/lexer.l"
+#line 426 "beancount/parser/lexer.l"
 {
     BUILD("TAG", "s", &(yytext[1]));
     return TAG;
@@ -1891,7 +1906,7 @@ YY_RULE_SETUP
 /* Links */
 case 58:
 YY_RULE_SETUP
-#line 417 "beancount/parser/lexer.l"
+#line 432 "beancount/parser/lexer.l"
 {
     BUILD("LINK", "s", &(yytext[1]));
     return LINK;
@@ -1900,7 +1915,7 @@ YY_RULE_SETUP
 /* Key */
 case 59:
 YY_RULE_SETUP
-#line 423 "beancount/parser/lexer.l"
+#line 438 "beancount/parser/lexer.l"
 {
     BUILD("KEY", "s#", yytext, (Py_ssize_t)(yyleng - 1));
     unput(':');
@@ -1910,7 +1925,7 @@ YY_RULE_SETUP
 /* Default rule. {bf253a29a820} */
 case 60:
 YY_RULE_SETUP
-#line 430 "beancount/parser/lexer.l"
+#line 445 "beancount/parser/lexer.l"
 {
     unput(*yytext);
     BEGIN(INVALID);
@@ -1921,12 +1936,13 @@ YY_RULE_SETUP
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(INVALID):
 case YY_STATE_EOF(STRLIT):
-#line 437 "beancount/parser/lexer.l"
+#line 452 "beancount/parser/lexer.l"
 {
-  if ( yy_eof_times == 0 ) {
-    yy_eof_times = 1;
-    yylloc->first_line = yylineno;
-    return EOL;
+  if (yy_eof_times == 0) {
+      yy_eof_times = 1;
+      /* Ensure location data is populated. */
+      YY_USER_ACTION;
+      return EOL;
   }
   return 0;
 }
@@ -1937,7 +1953,7 @@ case YY_STATE_EOF(STRLIT):
     this and more. {bba169a1d35a} */
 case 61:
 YY_RULE_SETUP
-#line 450 "beancount/parser/lexer.l"
+#line 466 "beancount/parser/lexer.l"
 {
     build_lexer_error(builder, "Invalid token: '%s'", yytext);
     BEGIN(INITIAL);
@@ -1946,10 +1962,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 457 "beancount/parser/lexer.l"
+#line 473 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1952 "beancount/parser/lexer.c"
+#line 1968 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3152,21 +3168,98 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 457 "beancount/parser/lexer.l"
+#line 473 "beancount/parser/lexer.l"
 
 
-void yylex_initialize(yyscan_t yyscanner)
+yyscan_t* yylex_new(void)
 {
-    yyset_extra(malloc(sizeof(yyextra_t)), yyscanner);
-    yy_eof_times = 0;
-    yy_line_tokens = 0;
-    buffer_init(strbuf, 1024);
+    yyscan_t scanner;
+    yyextra_t* extra;
+
+    extra = malloc(sizeof(*extra));
+    if (!extra)
+        return NULL;
+
+    extra->filename = PyUnicode_FromString("");
+    if (!extra->filename) {
+        free(extra);
+        return NULL;
+    }
+
+    buffer_init(&extra->str, 1024);
+
+    if (yylex_init_extra(extra, &scanner)) {
+        free(extra);
+        return NULL;
+    }
+
+    return scanner;
 }
 
-void yylex_finalize(yyscan_t yyscanner)
+yyscan_t* yylex_free(yyscan_t scanner)
 {
-    buffer_free(strbuf);
-    free(yyget_extra(yyscanner));
+    yyextra_t* extra = yyget_extra(scanner);
+
+    Py_XDECREF(yyget_in(scanner));
+    Py_XDECREF(extra->filename);
+    buffer_free(&extra->str);
+    free(extra);
+    yylex_destroy(scanner);
+
+    return NULL;
+}
+
+/* yyrestart() does not reset the scanner start back to INITIAL and
+ * Flex does not provide a way of doing so outside a scanner
+ * relu. This function does just that accessing Flex internals. */
+static void yybegin(yyscan_t scanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)scanner;
+    BEGIN(INITIAL);
+}
+
+void yylex_initialize(yyscan_t scanner, PyObject* file, PyObject* filename, int line, const char* encoding)
+{
+    yyextra_t* extra = yyget_extra(scanner);
+
+    Py_XDECREF(yyget_in(scanner));
+    yyrestart((void*)file, scanner);
+    Py_INCREF(file);
+    yybegin(scanner);
+
+    /* If a filename has not been specified explicitly, try to get it
+     * from the file object. The io.BaseIO object returned from open()
+     * stores the file path in the 'name' property. */
+    if (!filename || filename == Py_None) {
+        filename = PyObject_GetAttrString(file, "name");
+        if (!filename)
+            PyErr_Clear();
+    }
+
+    if (filename && filename != Py_None) {
+        Py_XDECREF(extra->filename);
+        extra->filename = filename;
+        Py_INCREF(filename);
+    }
+
+    extra->encoding = encoding ? encoding : "utf-8";
+    extra->line = line;
+    extra->n_eof = 0;
+    extra->n_line_tokens = 0;
+
+    buffer_beginning(&extra->str);
+}
+
+PyObject* yyget_filename(yyscan_t scanner)
+{
+    yyextra_t* extra = yyget_extra(scanner);
+    return extra->filename;
+}
+
+int yyget_firstline(yyscan_t scanner)
+{
+    yyextra_t* extra = yyget_extra(scanner);
+    return extra->line;
 }
 
 static void buffer_init(struct buffer* b, size_t size)

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -5,16 +5,12 @@
 typedef struct _yyextra_t yyextra_t;
 
 /* Initialize scanner private data. */
-void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner);
+void yylex_initialize(yyscan_t yyscanner);
 
 /* Free scanner private data */
 void yylex_finalize(yyscan_t yyscanner);
 
-const char* yyget_filename(yyscan_t *scanner);
-
-int yyget_firstline(yyscan_t *scanner);
-
-#line 17 "beancount/parser/lexer.c"
+#line 13 "beancount/parser/lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -967,7 +963,7 @@ static const flex_int32_t yy_rule_can_match_eol[63] =
 /* Top Code. This is included in the FLex generated header file. */
 
 /* Definitions. */
-#line 39 "beancount/parser/lexer.l"
+#line 35 "beancount/parser/lexer.l"
 
 /* Includes. */
 #include <math.h>
@@ -988,12 +984,6 @@ struct _yyextra_t {
     int n_eof;
     /* Number of tokens since the beginning of the line. */
     int n_line_tokens;
-    /* The filename being tokenized. */
-    const char* filename;
-    /* Reporting line offset. This is used like the #line cpp macro */
-    int line;
-    /* The encoding to use for converting strings. */
-    const char* encoding;
     /* Variable size buffer used to accumulate string data. */
     struct buffer str;
 };
@@ -1037,16 +1027,16 @@ static inline void buffer_begin(struct buffer* b)
 #define strbuf &yyget_extra(yyscanner)->str
 #define yy_eof_times yyget_extra(yyscanner)->n_eof
 #define yy_line_tokens yyget_extra(yyscanner)->n_line_tokens
-#define yy_filename yyget_extra(yyscanner)->filename
-#define yy_firstline yyget_extra(yyscanner)->line
-#define yy_encoding yyget_extra(yyscanner)->encoding
+#define yy_filename ((Parser*)parser)->filename
+#define yy_firstline ((Parser*)parser)->line
+#define yy_encoding ((Parser*)parser)->encoding
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(const char* string, size_t length);
+void build_lexer_error(PyObject* builder, const char* string, size_t length);
 
 /* Build and accumulate an error on the builder object using the current
  * exception state. */
-void build_lexer_error_from_exception(void);
+void build_lexer_error_from_exception(PyObject* builder);
 
 int PyFile_Read(PyObject *file, char *buf, size_t max_size);
 
@@ -1058,13 +1048,13 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
     yylval->pyobj = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);     \
     /* Handle a Python exception raised by the handler {3cfb2739349a} */                \
     if (yylval->pyobj == NULL) {                                                        \
-       build_lexer_error_from_exception();                                              \
+       build_lexer_error_from_exception(builder);                                       \
        return LEX_ERROR;                                                                \
     }                                                                                   \
     /* Lexer builder methods should never return None, check for it. */                 \
     else if (yylval->pyobj == Py_None) {                                                \
         Py_DECREF(Py_None);                                                             \
-        build_lexer_error("Unexpected None result from lexer", 34);                     \
+        build_lexer_error(builder, "Unexpected None result from lexer", 34);            \
         return LEX_ERROR;                                                               \
     }
 
@@ -1096,12 +1086,12 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
 
-#line 1099 "beancount/parser/lexer.c"
+#line 1089 "beancount/parser/lexer.c"
 /* A start condition for chomping an invalid token. */
 
 /* Exclusive start condition for parsing escape sequences in string literals. */
 
-#line 1104 "beancount/parser/lexer.c"
+#line 1094 "beancount/parser/lexer.c"
 
 #define INITIAL 0
 #define INVALID 1
@@ -1385,12 +1375,12 @@ YY_DECL
 		}
 
 	{
-#line 188 "beancount/parser/lexer.l"
+#line 178 "beancount/parser/lexer.l"
 
 
-#line 191 "beancount/parser/lexer.l"
+#line 181 "beancount/parser/lexer.l"
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
-#line 1393 "beancount/parser/lexer.c"
+#line 1383 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1458,7 +1448,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 192 "beancount/parser/lexer.l"
+#line 182 "beancount/parser/lexer.l"
 {
     yy_line_tokens = 0;
     yycolumn = 1;
@@ -1471,7 +1461,7 @@ YY_RULE_SETUP
     the grammar. */
 case 2:
 YY_RULE_SETUP
-#line 202 "beancount/parser/lexer.l"
+#line 192 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens == 1 ) {
         /* If the next character completes the line, skip it. */
@@ -1489,79 +1479,79 @@ YY_RULE_SETUP
 /* Characters with special meanings have their own tokens. */
 case 3:
 YY_RULE_SETUP
-#line 217 "beancount/parser/lexer.l"
+#line 207 "beancount/parser/lexer.l"
 { return PIPE; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 218 "beancount/parser/lexer.l"
+#line 208 "beancount/parser/lexer.l"
 { return ATAT; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 219 "beancount/parser/lexer.l"
+#line 209 "beancount/parser/lexer.l"
 { return AT; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 220 "beancount/parser/lexer.l"
+#line 210 "beancount/parser/lexer.l"
 { return LCURLCURL; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 221 "beancount/parser/lexer.l"
+#line 211 "beancount/parser/lexer.l"
 { return RCURLCURL; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 222 "beancount/parser/lexer.l"
+#line 212 "beancount/parser/lexer.l"
 { return LCURL; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 223 "beancount/parser/lexer.l"
+#line 213 "beancount/parser/lexer.l"
 { return RCURL; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 224 "beancount/parser/lexer.l"
+#line 214 "beancount/parser/lexer.l"
 { return COMMA; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 225 "beancount/parser/lexer.l"
+#line 215 "beancount/parser/lexer.l"
 { return TILDE; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 226 "beancount/parser/lexer.l"
+#line 216 "beancount/parser/lexer.l"
 { return PLUS; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 227 "beancount/parser/lexer.l"
+#line 217 "beancount/parser/lexer.l"
 { return MINUS; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 228 "beancount/parser/lexer.l"
+#line 218 "beancount/parser/lexer.l"
 { return SLASH; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 229 "beancount/parser/lexer.l"
+#line 219 "beancount/parser/lexer.l"
 { return LPAREN; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 230 "beancount/parser/lexer.l"
+#line 220 "beancount/parser/lexer.l"
 { return RPAREN; }
 	YY_BREAK
 /* Special handling for characters beginning a line to be ignored.
   * I'd like to improve how this is handled. Needs own lexer, really. */
 case 17:
 YY_RULE_SETUP
-#line 234 "beancount/parser/lexer.l"
+#line 224 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return HASH;
@@ -1575,7 +1565,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 245 "beancount/parser/lexer.l"
+#line 235 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return ASTERISK;
@@ -1589,7 +1579,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 256 "beancount/parser/lexer.l"
+#line 246 "beancount/parser/lexer.l"
 {
   if (yy_line_tokens != 1) {
     return COLON;
@@ -1604,7 +1594,7 @@ YY_RULE_SETUP
 /* Skip commented output (but not the accompanying newline). */
 case 20:
 YY_RULE_SETUP
-#line 268 "beancount/parser/lexer.l"
+#line 258 "beancount/parser/lexer.l"
 {
     /* yy_skip_line(); */
     return COMMENT;
@@ -1620,7 +1610,7 @@ YY_RULE_SETUP
     */
 case 21:
 YY_RULE_SETUP
-#line 281 "beancount/parser/lexer.l"
+#line 271 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         yylval->character = yytext[0];
@@ -1635,103 +1625,103 @@ YY_RULE_SETUP
 /* Keywords. */
 case 22:
 YY_RULE_SETUP
-#line 293 "beancount/parser/lexer.l"
+#line 283 "beancount/parser/lexer.l"
 { return TXN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 294 "beancount/parser/lexer.l"
+#line 284 "beancount/parser/lexer.l"
 { return BALANCE; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 295 "beancount/parser/lexer.l"
+#line 285 "beancount/parser/lexer.l"
 { return OPEN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 296 "beancount/parser/lexer.l"
+#line 286 "beancount/parser/lexer.l"
 { return CLOSE; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 297 "beancount/parser/lexer.l"
+#line 287 "beancount/parser/lexer.l"
 { return COMMODITY; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 298 "beancount/parser/lexer.l"
+#line 288 "beancount/parser/lexer.l"
 { return PAD; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 299 "beancount/parser/lexer.l"
+#line 289 "beancount/parser/lexer.l"
 { return EVENT; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 300 "beancount/parser/lexer.l"
+#line 290 "beancount/parser/lexer.l"
 { return QUERY; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 301 "beancount/parser/lexer.l"
+#line 291 "beancount/parser/lexer.l"
 { return CUSTOM; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 302 "beancount/parser/lexer.l"
+#line 292 "beancount/parser/lexer.l"
 { return PRICE; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 303 "beancount/parser/lexer.l"
+#line 293 "beancount/parser/lexer.l"
 { return NOTE; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 304 "beancount/parser/lexer.l"
+#line 294 "beancount/parser/lexer.l"
 { return DOCUMENT; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 305 "beancount/parser/lexer.l"
+#line 295 "beancount/parser/lexer.l"
 { return PUSHTAG; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 306 "beancount/parser/lexer.l"
+#line 296 "beancount/parser/lexer.l"
 { return POPTAG; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 307 "beancount/parser/lexer.l"
+#line 297 "beancount/parser/lexer.l"
 { return PUSHMETA; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 308 "beancount/parser/lexer.l"
+#line 298 "beancount/parser/lexer.l"
 { return POPMETA; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 309 "beancount/parser/lexer.l"
+#line 299 "beancount/parser/lexer.l"
 { return OPTION; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 310 "beancount/parser/lexer.l"
+#line 300 "beancount/parser/lexer.l"
 { return PLUGIN; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 311 "beancount/parser/lexer.l"
+#line 301 "beancount/parser/lexer.l"
 { return INCLUDE; }
 	YY_BREAK
 /* Boolean values. */
 case 41:
 YY_RULE_SETUP
-#line 314 "beancount/parser/lexer.l"
+#line 304 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_True;
     Py_INCREF(Py_True);
@@ -1740,7 +1730,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 320 "beancount/parser/lexer.l"
+#line 310 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_False;
     Py_INCREF(Py_False);
@@ -1749,7 +1739,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 326 "beancount/parser/lexer.l"
+#line 316 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_None;
     Py_INCREF(Py_None);
@@ -1759,7 +1749,7 @@ YY_RULE_SETUP
 /* Dates. */
 case 44:
 YY_RULE_SETUP
-#line 333 "beancount/parser/lexer.l"
+#line 323 "beancount/parser/lexer.l"
 {
     const char* year_str;
     const char* month_str;
@@ -1784,7 +1774,7 @@ YY_RULE_SETUP
 /* Account names. */
 case 45:
 YY_RULE_SETUP
-#line 355 "beancount/parser/lexer.l"
+#line 345 "beancount/parser/lexer.l"
 {
     BUILD_LEX("ACCOUNT", "s", yytext);
     return ACCOUNT;
@@ -1794,7 +1784,7 @@ YY_RULE_SETUP
   * syntax. This is kept in sync with beancount.core.amount.CURRENCY_RE. */
 case 46:
 YY_RULE_SETUP
-#line 362 "beancount/parser/lexer.l"
+#line 352 "beancount/parser/lexer.l"
 {
     BUILD_LEX("CURRENCY", "s", yytext);
     return CURRENCY;
@@ -1805,7 +1795,7 @@ YY_RULE_SETUP
     See section "Start Conditions" in the GNU Flex manual. */
 case 47:
 YY_RULE_SETUP
-#line 370 "beancount/parser/lexer.l"
+#line 360 "beancount/parser/lexer.l"
 {
     buffer_begin(strbuf);
     BEGIN(STRLIT);
@@ -1815,13 +1805,13 @@ YY_RULE_SETUP
 /* Saw closing quote - all done. */
 case 48:
 YY_RULE_SETUP
-#line 378 "beancount/parser/lexer.l"
+#line 368 "beancount/parser/lexer.l"
 {
         BEGIN(INITIAL);
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
                                          yy_encoding, "ignore");
         if (!str) {
-            build_lexer_error_from_exception();
+            build_lexer_error_from_exception(builder);
             yylval->pyobj = Py_None;
             Py_INCREF(Py_None);
             return LEX_ERROR;
@@ -1834,47 +1824,47 @@ YY_RULE_SETUP
 /* Escape sequences. */
 case 49:
 YY_RULE_SETUP
-#line 394 "beancount/parser/lexer.l"
+#line 384 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\n');
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 395 "beancount/parser/lexer.l"
+#line 385 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\t');
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 396 "beancount/parser/lexer.l"
+#line 386 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\r');
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 397 "beancount/parser/lexer.l"
+#line 387 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\b');
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 398 "beancount/parser/lexer.l"
+#line 388 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\f');
 	YY_BREAK
 case 54:
 /* rule 54 can match eol */
 YY_RULE_SETUP
-#line 399 "beancount/parser/lexer.l"
+#line 389 "beancount/parser/lexer.l"
 buffer_push(strbuf, yytext[1]);
 	YY_BREAK
 /* All other characters. */
 case 55:
 /* rule 55 can match eol */
 YY_RULE_SETUP
-#line 402 "beancount/parser/lexer.l"
+#line 392 "beancount/parser/lexer.l"
 buffer_append(strbuf, yytext, yyleng);
 	YY_BREAK
 
 /* Numbers */
 case 56:
 YY_RULE_SETUP
-#line 406 "beancount/parser/lexer.l"
+#line 396 "beancount/parser/lexer.l"
 {
     BUILD_LEX("NUMBER", "s", yytext);
     return NUMBER;
@@ -1883,7 +1873,7 @@ YY_RULE_SETUP
 /* Tags */
 case 57:
 YY_RULE_SETUP
-#line 412 "beancount/parser/lexer.l"
+#line 402 "beancount/parser/lexer.l"
 {
     BUILD_LEX("TAG", "s", &(yytext[1]));
     return TAG;
@@ -1892,7 +1882,7 @@ YY_RULE_SETUP
 /* Links */
 case 58:
 YY_RULE_SETUP
-#line 418 "beancount/parser/lexer.l"
+#line 408 "beancount/parser/lexer.l"
 {
     BUILD_LEX("LINK", "s", &(yytext[1]));
     return LINK;
@@ -1901,7 +1891,7 @@ YY_RULE_SETUP
 /* Key */
 case 59:
 YY_RULE_SETUP
-#line 424 "beancount/parser/lexer.l"
+#line 414 "beancount/parser/lexer.l"
 {
     BUILD_LEX("KEY", "s#", yytext, (Py_ssize_t)(yyleng-1));
     unput(':');
@@ -1911,7 +1901,7 @@ YY_RULE_SETUP
 /* Default rule. {bf253a29a820} */
 case 60:
 YY_RULE_SETUP
-#line 431 "beancount/parser/lexer.l"
+#line 421 "beancount/parser/lexer.l"
 {
     unput(*yytext);
     BEGIN(INVALID);
@@ -1922,7 +1912,7 @@ YY_RULE_SETUP
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(INVALID):
 case YY_STATE_EOF(STRLIT):
-#line 438 "beancount/parser/lexer.l"
+#line 428 "beancount/parser/lexer.l"
 {
   if ( yy_eof_times == 0 ) {
     yy_eof_times = 1;
@@ -1938,21 +1928,21 @@ case YY_STATE_EOF(STRLIT):
     this and more. {bba169a1d35a} */
 case 61:
 YY_RULE_SETUP
-#line 451 "beancount/parser/lexer.l"
+#line 441 "beancount/parser/lexer.l"
 {
     char buffer[256];
     size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
-    build_lexer_error(buffer, length);
+    build_lexer_error(builder, buffer, length);
     BEGIN(INITIAL);
     return LEX_ERROR;
 }
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 460 "beancount/parser/lexer.l"
+#line 450 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1955 "beancount/parser/lexer.c"
+#line 1945 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3155,18 +3145,14 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 460 "beancount/parser/lexer.l"
+#line 450 "beancount/parser/lexer.l"
 
 
-void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner)
+void yylex_initialize(yyscan_t yyscanner)
 {
     yyset_extra(malloc(sizeof(yyextra_t)), yyscanner);
-
     yy_eof_times = 0;
     yy_line_tokens = 0;
-    yy_filename = filename ?: "";
-    yy_firstline = firstline;
-    yy_encoding = encoding ?: "utf-8";
     buffer_init(strbuf, 1024);
 }
 
@@ -3174,16 +3160,6 @@ void yylex_finalize(yyscan_t yyscanner)
 {
     buffer_free(strbuf);
     free(yyget_extra(yyscanner));
-}
-
-const char* yyget_filename(yyscan_t *scanner)
-{
-    return yyget_extra(scanner)->filename;
-}
-
-int yyget_firstline(yyscan_t *scanner)
-{
-    return yyget_extra(scanner)->line;
 }
 
 static void buffer_init(struct buffer* b, size_t size)
@@ -3229,7 +3205,7 @@ int strtonl(const char* buf, size_t nchars)
 }
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(const char* string, size_t length)
+void build_lexer_error(PyObject* builder, const char* string, size_t length)
 {
     TRACE_ERROR("Invalid Token");
 
@@ -3243,7 +3219,7 @@ void build_lexer_error(const char* string, size_t length)
     Py_XDECREF(rv);
 }
 
-void build_lexer_error_from_exception()
+void build_lexer_error_from_exception(PyObject* builder)
 {
     TRACE_ERROR("Lexer Builder Exception");
 

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -1,4 +1,4 @@
-#line 2 "beancount/parser/lexer.c"
+#line 1 "beancount/parser/lexer.c"
 
 /* Includes. */
 #include <math.h>
@@ -13,6 +13,11 @@ void build_lexer_error(const char* string, size_t length);
 /* Build and accumulate an error on the builder object using the current
  * exception state. */
 void build_lexer_error_from_exception(void);
+
+int PyFile_Read(PyObject *file, char *buf, size_t max_size);
+
+#define YY_INPUT(buf, result, max_size)                         \
+    result = PyFile_Read((PyObject *)yyin, buf, max_size);
 
 /* Callback call site with error handling. */
 #define BUILD_LEX(method_name, format, ...)                                             \
@@ -71,7 +76,7 @@ int strtonl(const char* buf, size_t nchars);
 	}                                       \
         *strbuf_ptr++ = value;
 
-#line 75 "beancount/parser/lexer.c"
+#line 79 "beancount/parser/lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1055,7 +1060,7 @@ char *yytext;
 
 /*--------------------------------------------------------------------------------------*/
 /* Rules */
-#line 1059 "beancount/parser/lexer.c"
+#line 1063 "beancount/parser/lexer.c"
 
 #define INITIAL 0
 #define INVALID 1
@@ -1292,13 +1297,13 @@ YY_DECL
 		}
 
 	{
-#line 128 "beancount/parser/lexer.l"
-
-
-
 #line 132 "beancount/parser/lexer.l"
+
+
+
+#line 136 "beancount/parser/lexer.l"
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
-#line 1302 "beancount/parser/lexer.c"
+#line 1306 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1364,7 +1369,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 133 "beancount/parser/lexer.l"
+#line 137 "beancount/parser/lexer.l"
 {
     yy_line_tokens = 0;
     yycolumn = 1;
@@ -1377,7 +1382,7 @@ YY_RULE_SETUP
     the grammar. */
 case 2:
 YY_RULE_SETUP
-#line 143 "beancount/parser/lexer.l"
+#line 147 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens == 1 ) {
         /* If the next character completes the line, skip it. */
@@ -1395,79 +1400,79 @@ YY_RULE_SETUP
 /* Characters with special meanings have their own tokens. */
 case 3:
 YY_RULE_SETUP
-#line 158 "beancount/parser/lexer.l"
+#line 162 "beancount/parser/lexer.l"
 { return PIPE; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 159 "beancount/parser/lexer.l"
+#line 163 "beancount/parser/lexer.l"
 { return ATAT; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 160 "beancount/parser/lexer.l"
+#line 164 "beancount/parser/lexer.l"
 { return AT; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 161 "beancount/parser/lexer.l"
+#line 165 "beancount/parser/lexer.l"
 { return LCURLCURL; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 162 "beancount/parser/lexer.l"
+#line 166 "beancount/parser/lexer.l"
 { return RCURLCURL; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 163 "beancount/parser/lexer.l"
+#line 167 "beancount/parser/lexer.l"
 { return LCURL; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 164 "beancount/parser/lexer.l"
+#line 168 "beancount/parser/lexer.l"
 { return RCURL; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 165 "beancount/parser/lexer.l"
+#line 169 "beancount/parser/lexer.l"
 { return COMMA; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 166 "beancount/parser/lexer.l"
+#line 170 "beancount/parser/lexer.l"
 { return TILDE; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 167 "beancount/parser/lexer.l"
+#line 171 "beancount/parser/lexer.l"
 { return PLUS; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 168 "beancount/parser/lexer.l"
+#line 172 "beancount/parser/lexer.l"
 { return MINUS; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 169 "beancount/parser/lexer.l"
+#line 173 "beancount/parser/lexer.l"
 { return SLASH; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 170 "beancount/parser/lexer.l"
+#line 174 "beancount/parser/lexer.l"
 { return LPAREN; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 171 "beancount/parser/lexer.l"
+#line 175 "beancount/parser/lexer.l"
 { return RPAREN; }
 	YY_BREAK
 /* Special handling for characters beginning a line to be ignored.
   * I'd like to improve how this is handled. Needs own lexer, really. */
 case 17:
 YY_RULE_SETUP
-#line 175 "beancount/parser/lexer.l"
+#line 179 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return HASH;
@@ -1481,7 +1486,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 186 "beancount/parser/lexer.l"
+#line 190 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return ASTERISK;
@@ -1495,7 +1500,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 197 "beancount/parser/lexer.l"
+#line 201 "beancount/parser/lexer.l"
 {
   if (yy_line_tokens != 1) {
     return COLON;
@@ -1510,7 +1515,7 @@ YY_RULE_SETUP
 /* Skip commented output (but not the accompanying newline). */
 case 20:
 YY_RULE_SETUP
-#line 209 "beancount/parser/lexer.l"
+#line 213 "beancount/parser/lexer.l"
 {
     /* yy_skip_line(); */
     return COMMENT;
@@ -1526,7 +1531,7 @@ YY_RULE_SETUP
     */
 case 21:
 YY_RULE_SETUP
-#line 222 "beancount/parser/lexer.l"
+#line 226 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         yylval->character = yytext[0];
@@ -1541,103 +1546,103 @@ YY_RULE_SETUP
 /* Keywords. */
 case 22:
 YY_RULE_SETUP
-#line 234 "beancount/parser/lexer.l"
+#line 238 "beancount/parser/lexer.l"
 { return TXN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 235 "beancount/parser/lexer.l"
+#line 239 "beancount/parser/lexer.l"
 { return BALANCE; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 236 "beancount/parser/lexer.l"
+#line 240 "beancount/parser/lexer.l"
 { return OPEN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 237 "beancount/parser/lexer.l"
+#line 241 "beancount/parser/lexer.l"
 { return CLOSE; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 238 "beancount/parser/lexer.l"
+#line 242 "beancount/parser/lexer.l"
 { return COMMODITY; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 239 "beancount/parser/lexer.l"
+#line 243 "beancount/parser/lexer.l"
 { return PAD; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 240 "beancount/parser/lexer.l"
+#line 244 "beancount/parser/lexer.l"
 { return EVENT; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 241 "beancount/parser/lexer.l"
+#line 245 "beancount/parser/lexer.l"
 { return QUERY; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 242 "beancount/parser/lexer.l"
+#line 246 "beancount/parser/lexer.l"
 { return CUSTOM; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 243 "beancount/parser/lexer.l"
+#line 247 "beancount/parser/lexer.l"
 { return PRICE; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 244 "beancount/parser/lexer.l"
+#line 248 "beancount/parser/lexer.l"
 { return NOTE; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 245 "beancount/parser/lexer.l"
+#line 249 "beancount/parser/lexer.l"
 { return DOCUMENT; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 246 "beancount/parser/lexer.l"
+#line 250 "beancount/parser/lexer.l"
 { return PUSHTAG; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 247 "beancount/parser/lexer.l"
+#line 251 "beancount/parser/lexer.l"
 { return POPTAG; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 248 "beancount/parser/lexer.l"
+#line 252 "beancount/parser/lexer.l"
 { return PUSHMETA; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 249 "beancount/parser/lexer.l"
+#line 253 "beancount/parser/lexer.l"
 { return POPMETA; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 250 "beancount/parser/lexer.l"
+#line 254 "beancount/parser/lexer.l"
 { return OPTION; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 251 "beancount/parser/lexer.l"
+#line 255 "beancount/parser/lexer.l"
 { return PLUGIN; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 252 "beancount/parser/lexer.l"
+#line 256 "beancount/parser/lexer.l"
 { return INCLUDE; }
 	YY_BREAK
 /* Boolean values. */
 case 41:
 YY_RULE_SETUP
-#line 255 "beancount/parser/lexer.l"
+#line 259 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_True;
     Py_INCREF(Py_True);
@@ -1646,7 +1651,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 261 "beancount/parser/lexer.l"
+#line 265 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_False;
     Py_INCREF(Py_False);
@@ -1655,7 +1660,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 267 "beancount/parser/lexer.l"
+#line 271 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_None;
     Py_INCREF(Py_None);
@@ -1665,7 +1670,7 @@ YY_RULE_SETUP
 /* Dates. */
 case 44:
 YY_RULE_SETUP
-#line 274 "beancount/parser/lexer.l"
+#line 278 "beancount/parser/lexer.l"
 {
     const char* year_str;
     const char* month_str;
@@ -1690,7 +1695,7 @@ YY_RULE_SETUP
 /* Account names. */
 case 45:
 YY_RULE_SETUP
-#line 296 "beancount/parser/lexer.l"
+#line 300 "beancount/parser/lexer.l"
 {
     BUILD_LEX("ACCOUNT", "s", yytext);
     return ACCOUNT;
@@ -1700,7 +1705,7 @@ YY_RULE_SETUP
   * syntax. This is kept in sync with beancount.core.amount.CURRENCY_RE. */
 case 46:
 YY_RULE_SETUP
-#line 303 "beancount/parser/lexer.l"
+#line 307 "beancount/parser/lexer.l"
 {
     BUILD_LEX("CURRENCY", "s", yytext);
     return CURRENCY;
@@ -1711,7 +1716,7 @@ YY_RULE_SETUP
     See section "Start Conditions" in the GNU Flex manual. */
 case 47:
 YY_RULE_SETUP
-#line 311 "beancount/parser/lexer.l"
+#line 315 "beancount/parser/lexer.l"
 {
     strbuf_ptr = strbuf;
     BEGIN(STRLIT);
@@ -1721,7 +1726,7 @@ YY_RULE_SETUP
 /* Saw closing quote - all done. */
 case 48:
 YY_RULE_SETUP
-#line 319 "beancount/parser/lexer.l"
+#line 323 "beancount/parser/lexer.l"
 {
         BEGIN(INITIAL);
         *strbuf_ptr = '\0';
@@ -1742,40 +1747,40 @@ YY_RULE_SETUP
 /* Escape sequences. */
 case 49:
 YY_RULE_SETUP
-#line 337 "beancount/parser/lexer.l"
+#line 341 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR('\n');
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 338 "beancount/parser/lexer.l"
+#line 342 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR('\t');
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 339 "beancount/parser/lexer.l"
+#line 343 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR('\r');
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 340 "beancount/parser/lexer.l"
+#line 344 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR('\b');
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 341 "beancount/parser/lexer.l"
+#line 345 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR('\f');
 	YY_BREAK
 case 54:
 /* rule 54 can match eol */
 YY_RULE_SETUP
-#line 342 "beancount/parser/lexer.l"
+#line 346 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR(yytext[1]);
 	YY_BREAK
 /* All other characters. */
 case 55:
 /* rule 55 can match eol */
 YY_RULE_SETUP
-#line 345 "beancount/parser/lexer.l"
+#line 349 "beancount/parser/lexer.l"
 {
         if ( yyleng > (strbuf_end - strbuf_ptr) ) {
             strbuf_realloc(yyleng);
@@ -1790,7 +1795,7 @@ YY_RULE_SETUP
 /* Numbers */
 case 56:
 YY_RULE_SETUP
-#line 357 "beancount/parser/lexer.l"
+#line 361 "beancount/parser/lexer.l"
 {
     BUILD_LEX("NUMBER", "s", yytext);
     return NUMBER;
@@ -1799,7 +1804,7 @@ YY_RULE_SETUP
 /* Tags */
 case 57:
 YY_RULE_SETUP
-#line 363 "beancount/parser/lexer.l"
+#line 367 "beancount/parser/lexer.l"
 {
     BUILD_LEX("TAG", "s", &(yytext[1]));
     return TAG;
@@ -1808,7 +1813,7 @@ YY_RULE_SETUP
 /* Links */
 case 58:
 YY_RULE_SETUP
-#line 369 "beancount/parser/lexer.l"
+#line 373 "beancount/parser/lexer.l"
 {
     BUILD_LEX("LINK", "s", &(yytext[1]));
     return LINK;
@@ -1817,7 +1822,7 @@ YY_RULE_SETUP
 /* Key */
 case 59:
 YY_RULE_SETUP
-#line 375 "beancount/parser/lexer.l"
+#line 379 "beancount/parser/lexer.l"
 {
     BUILD_LEX("KEY", "s#", yytext, (Py_ssize_t)(yyleng-1));
     unput(':');
@@ -1827,7 +1832,7 @@ YY_RULE_SETUP
 /* Default rule. {bf253a29a820} */
 case 60:
 YY_RULE_SETUP
-#line 382 "beancount/parser/lexer.l"
+#line 386 "beancount/parser/lexer.l"
 {
     unput(*yytext);
     BEGIN(INVALID);
@@ -1838,7 +1843,7 @@ YY_RULE_SETUP
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(INVALID):
 case YY_STATE_EOF(STRLIT):
-#line 389 "beancount/parser/lexer.l"
+#line 393 "beancount/parser/lexer.l"
 {
   if ( yy_eof_times == 0 ) {
     yy_eof_times = 1;
@@ -1854,7 +1859,7 @@ case YY_STATE_EOF(STRLIT):
     this and more. {bba169a1d35a} */
 case 61:
 YY_RULE_SETUP
-#line 402 "beancount/parser/lexer.l"
+#line 406 "beancount/parser/lexer.l"
 {
     char buffer[256];
     size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
@@ -1865,10 +1870,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 411 "beancount/parser/lexer.l"
+#line 415 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1872 "beancount/parser/lexer.c"
+#line 1876 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -2884,7 +2889,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 411 "beancount/parser/lexer.l"
+#line 415 "beancount/parser/lexer.l"
 
 /*--------------------------------------------------------------------------------------*/
 /* User Code */
@@ -2919,7 +2924,7 @@ void yylex_initialize(const char* filename, const char* encoding)
 {
     assert(filename != NULL);
     yy_eof_times = 0;
-    yy_filename = filename;
+    yy_filename = filename ?: "";
     yy_line_tokens = 0;
     yycolumn = 1;
     if ( encoding == 0 ) {
@@ -3050,5 +3055,29 @@ void build_lexer_error_from_exception()
         PyErr_SetString(PyExc_RuntimeError,
                         "Internal error: No exception");
     }
+}
+
+int PyFile_Read(PyObject *file, char *buf, size_t max_size)
+{
+     PyObject* dest = NULL;
+     PyObject* read = NULL;
+     int ret = 0;
+
+     dest = PyMemoryView_FromMemory(buf, max_size, PyBUF_WRITE);
+     if (!dest)
+          goto error;
+
+     read = PyObject_CallMethod(file, "readinto", "(O)", dest);
+     if (!read)
+          goto error;
+
+     ret = PyLong_AsSize_t(read);
+     if (PyErr_Occurred())
+          ret = 0;
+
+error:
+     Py_XDECREF(dest);
+     Py_XDECREF(read);
+     return ret;
 }
 

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -42,7 +42,6 @@ void yylex_finalize(void);
 /* Global declarations; defined below. */
 extern int yy_eof_times;
 extern const char* yy_filename;
-extern int yycolumn;
 extern const char* yy_encoding;
 
 /* String buffer statics. */
@@ -63,9 +62,23 @@ extern int yy_line_tokens; /* Number of tokens since the bol. */
     yycolumn += yyleng;                                 \
   }
 
-/* Skip the rest of the input line. */
-int yy_skip_line(void);
-
+/* Skip the rest of the input line.  This needs to be implemented as a
+ * macro because input() and unput() are thmeselves macros tha use
+ * variable definitions internal to the yylex() function. */
+#define yy_skip_line()                          \
+    do {                                        \
+        for (;;) {                              \
+            int c = input(yyscanner);           \
+            if (c == EOF || c == -1) {          \
+                break;                          \
+            }                                   \
+            if (c == '\n') {                    \
+                unput(c);                       \
+                break;                          \
+            }                                   \
+        }                                       \
+    } while (0)
+       
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
 
@@ -75,8 +88,8 @@ int strtonl(const char* buf, size_t nchars);
             strbuf_realloc(1);                  \
 	}                                       \
         *strbuf_ptr++ = value;
-
-#line 79 "beancount/parser/lexer.c"
+ 
+#line 92 "beancount/parser/lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -211,21 +224,38 @@ typedef unsigned int flex_uint32_t;
  */
 #define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
+/* An opaque pointer. */
+#ifndef YY_TYPEDEF_YY_SCANNER_T
+#define YY_TYPEDEF_YY_SCANNER_T
+typedef void* yyscan_t;
+#endif
+
+/* For convenience, these vars (plus the bison vars far below)
+   are macros in the reentrant scanner. */
+#define yyin yyg->yyin_r
+#define yyout yyg->yyout_r
+#define yyextra yyg->yyextra_r
+#define yyleng yyg->yyleng_r
+#define yytext yyg->yytext_r
+#define yylineno (YY_CURRENT_BUFFER_LVALUE->yy_bs_lineno)
+#define yycolumn (YY_CURRENT_BUFFER_LVALUE->yy_bs_column)
+#define yy_flex_debug yyg->yy_flex_debug_r
+
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
-#define BEGIN (yy_start) = 1 + 2 *
+#define BEGIN yyg->yy_start = 1 + 2 *
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
-#define YY_START (((yy_start) - 1) / 2)
+#define YY_START ((yyg->yy_start - 1) / 2)
 #define YYSTATE YY_START
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart( yyin  )
+#define YY_NEW_FILE yyrestart( yyin , yyscanner )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -254,10 +284,6 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #define YY_TYPEDEF_YY_SIZE_T
 typedef size_t yy_size_t;
 #endif
-
-extern int yyleng;
-
-extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
@@ -292,13 +318,13 @@ extern FILE *yyin, *yyout;
 		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		*yy_cp = (yy_hold_char); \
+		*yy_cp = yyg->yy_hold_char; \
 		YY_RESTORE_YY_MORE_OFFSET \
-		(yy_c_buf_p) = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
+		yyg->yy_c_buf_p = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-#define unput(c) yyunput( c, (yytext_ptr)  )
+#define unput(c) yyunput( c, yyg->yytext_ptr , yyscanner )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
@@ -365,77 +391,57 @@ struct yy_buffer_state
 	};
 #endif /* !YY_STRUCT_YY_BUFFER_STATE */
 
-/* Stack of input buffers. */
-static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
-static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
-
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
  * "scanner state".
  *
  * Returns the top of the stack, or NULL.
  */
-#define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
-                          ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
+#define YY_CURRENT_BUFFER ( yyg->yy_buffer_stack \
+                          ? yyg->yy_buffer_stack[yyg->yy_buffer_stack_top] \
                           : NULL)
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
-#define YY_CURRENT_BUFFER_LVALUE (yy_buffer_stack)[(yy_buffer_stack_top)]
+#define YY_CURRENT_BUFFER_LVALUE yyg->yy_buffer_stack[yyg->yy_buffer_stack_top]
 
-/* yy_hold_char holds the character lost when yytext is formed. */
-static char yy_hold_char;
-static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-int yyleng;
+void yyrestart ( FILE *input_file , yyscan_t yyscanner );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
+void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+void yypop_buffer_state ( yyscan_t yyscanner );
 
-/* Points to current character in buffer. */
-static char *yy_c_buf_p = NULL;
-static int yy_init = 0;		/* whether we need to initialize */
-static int yy_start = 0;	/* start state number */
+static void yyensure_buffer_stack ( yyscan_t yyscanner );
+static void yy_load_buffer_state ( yyscan_t yyscanner );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER , yyscanner)
 
-/* Flag which is used to allow yywrap()'s to do buffer switches
- * instead of setting up a fresh yyin.  A bit of a hack ...
- */
-static int yy_did_buffer_switch_on_eof;
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
-void yyrestart ( FILE *input_file  );
-void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
-void yy_delete_buffer ( YY_BUFFER_STATE b  );
-void yy_flush_buffer ( YY_BUFFER_STATE b  );
-void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state ( void );
-
-static void yyensure_buffer_stack ( void );
-static void yy_load_buffer_state ( void );
-static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
-#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
-
-YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
-
-void *yyalloc ( yy_size_t  );
-void *yyrealloc ( void *, yy_size_t  );
-void yyfree ( void *  );
+void *yyalloc ( yy_size_t , yyscan_t yyscanner );
+void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
+void yyfree ( void * , yyscan_t yyscanner );
 
 #define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        yyensure_buffer_stack (); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer( yyin, YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        yyensure_buffer_stack (); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer( yyin, YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
@@ -443,37 +449,28 @@ void yyfree ( void *  );
 
 /* Begin user sect3 */
 
-#define yywrap() (/*CONSTCOND*/1)
+#define yywrap(yyscanner) (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
 typedef flex_uint8_t YY_CHAR;
 
-FILE *yyin = NULL, *yyout = NULL;
-
 typedef int yy_state_type;
 
-extern int yylineno;
-int yylineno = 1;
+#define yytext_ptr yytext_r
 
-extern char *yytext;
-#ifdef yytext_ptr
-#undef yytext_ptr
-#endif
-#define yytext_ptr yytext
-
-static yy_state_type yy_get_previous_state ( void );
-static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
-static int yy_get_next_buffer ( void );
-static void yynoreturn yy_fatal_error ( const char* msg  );
+static yy_state_type yy_get_previous_state ( yyscan_t yyscanner );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  , yyscan_t yyscanner);
+static int yy_get_next_buffer ( yyscan_t yyscanner );
+static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
-	(yytext_ptr) = yy_bp; \
+	yyg->yytext_ptr = yy_bp; \
 	yyleng = (int) (yy_cp - yy_bp); \
-	(yy_hold_char) = *yy_cp; \
+	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
-	(yy_c_buf_p) = yy_cp;
+	yyg->yy_c_buf_p = yy_cp;
 #define YY_NUM_RULES 62
 #define YY_END_OF_BUFFER 63
 /* This struct is not used in this scanner,
@@ -1027,12 +1024,6 @@ static const flex_int32_t yy_rule_can_match_eol[63] =
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 
     0, 0, 0,     };
 
-static yy_state_type yy_last_accepting_state;
-static char *yy_last_accepting_cpos;
-
-extern int yy_flex_debug;
-int yy_flex_debug = 0;
-
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
  */
@@ -1040,7 +1031,6 @@ int yy_flex_debug = 0;
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-char *yytext;
 #line 1 "beancount/parser/lexer.l"
 /* -*- mode: c -*- */
 /* A flex lexer for Beancount. */
@@ -1048,7 +1038,6 @@ char *yytext;
 /* Definitions */
 /* Options */
 /* %option nodefault */
-/* %option reentrant */
 /* %option debug */
 /* %option stack */
 /* %option 8bit */
@@ -1060,7 +1049,7 @@ char *yytext;
 
 /*--------------------------------------------------------------------------------------*/
 /* Rules */
-#line 1063 "beancount/parser/lexer.c"
+#line 1052 "beancount/parser/lexer.c"
 
 #define INITIAL 0
 #define INVALID 1
@@ -1078,44 +1067,96 @@ char *yytext;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals ( void );
+/* Holds the entire state of the reentrant scanner. */
+struct yyguts_t
+    {
+
+    /* User-defined. Not touched by flex. */
+    YY_EXTRA_TYPE yyextra_r;
+
+    /* The rest are the same as the globals declared in the non-reentrant scanner. */
+    FILE *yyin_r, *yyout_r;
+    size_t yy_buffer_stack_top; /**< index of top of stack. */
+    size_t yy_buffer_stack_max; /**< capacity of stack. */
+    YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
+    char yy_hold_char;
+    int yy_n_chars;
+    int yyleng_r;
+    char *yy_c_buf_p;
+    int yy_init;
+    int yy_start;
+    int yy_did_buffer_switch_on_eof;
+    int yy_start_stack_ptr;
+    int yy_start_stack_depth;
+    int *yy_start_stack;
+    yy_state_type yy_last_accepting_state;
+    char* yy_last_accepting_cpos;
+
+    int yylineno_r;
+    int yy_flex_debug_r;
+
+    char *yytext_r;
+    int yy_more_flag;
+    int yy_more_len;
+
+    YYSTYPE * yylval_r;
+
+    YYLTYPE * yylloc_r;
+
+    }; /* end struct yyguts_t */
+
+static int yy_init_globals ( yyscan_t yyscanner );
+
+    /* This must go here because YYSTYPE and YYLTYPE are included
+     * from bison output in section 1.*/
+    #    define yylval yyg->yylval_r
+    
+    #    define yylloc yyg->yylloc_r
+    
+int yylex_init (yyscan_t* scanner);
+
+int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy ( void );
+int yylex_destroy ( yyscan_t yyscanner );
 
-int yyget_debug ( void );
+int yyget_debug ( yyscan_t yyscanner );
 
-void yyset_debug ( int debug_flag  );
+void yyset_debug ( int debug_flag , yyscan_t yyscanner );
 
-YY_EXTRA_TYPE yyget_extra ( void );
+YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
 
-void yyset_extra ( YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
 
-FILE *yyget_in ( void );
+FILE *yyget_in ( yyscan_t yyscanner );
 
-void yyset_in  ( FILE * _in_str  );
+void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
 
-FILE *yyget_out ( void );
+FILE *yyget_out ( yyscan_t yyscanner );
 
-void yyset_out  ( FILE * _out_str  );
+void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			int yyget_leng ( void );
+			int yyget_leng ( yyscan_t yyscanner );
 
-char *yyget_text ( void );
+char *yyget_text ( yyscan_t yyscanner );
 
-int yyget_lineno ( void );
+int yyget_lineno ( yyscan_t yyscanner );
 
-void yyset_lineno ( int _line_number  );
+void yyset_lineno ( int _line_number , yyscan_t yyscanner );
 
-YYSTYPE * yyget_lval ( void );
+int yyget_column  ( yyscan_t yyscanner );
 
-void yyset_lval ( YYSTYPE * yylval_param  );
+void yyset_column ( int _column_no , yyscan_t yyscanner );
 
-       YYLTYPE *yyget_lloc ( void );
+YYSTYPE * yyget_lval ( yyscan_t yyscanner );
+
+void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
+
+       YYLTYPE *yyget_lloc ( yyscan_t yyscanner );
     
-        void yyset_lloc ( YYLTYPE * yylloc_param  );
+        void yyset_lloc ( YYLTYPE * yylloc_param , yyscan_t yyscanner );
     
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -1123,31 +1164,31 @@ void yyset_lval ( YYSTYPE * yylval_param  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap ( void );
+extern "C" int yywrap ( yyscan_t yyscanner );
 #else
-extern int yywrap ( void );
+extern int yywrap ( yyscan_t yyscanner );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
     
-    static void yyunput ( int c, char *buf_ptr  );
+    static void yyunput ( int c, char *buf_ptr  , yyscan_t yyscanner);
     
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy ( char *, const char *, int );
+static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen ( const char * );
+static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
-static int yyinput ( void );
+static int yyinput ( yyscan_t yyscanner );
 #else
-static int input ( void );
+static int input ( yyscan_t yyscanner );
 #endif
 
 #endif
@@ -1221,7 +1262,7 @@ static int input ( void );
 
 /* Report a fatal error. */
 #ifndef YY_FATAL_ERROR
-#define YY_FATAL_ERROR(msg) yy_fatal_error( msg )
+#define YY_FATAL_ERROR(msg) yy_fatal_error( msg , yyscanner)
 #endif
 
 /* end tables serialization structures and prototypes */
@@ -1233,10 +1274,10 @@ static int input ( void );
 #define YY_DECL_IS_OURS 1
 
 extern int yylex \
-               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param );
+               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner);
 
 #define YY_DECL int yylex \
-               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param )
+               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner)
 #endif /* !YY_DECL */
 
 /* Code executed at the beginning of each rule, after yytext and yyleng
@@ -1261,25 +1302,22 @@ YY_DECL
 	yy_state_type yy_current_state;
 	char *yy_cp, *yy_bp;
 	int yy_act;
-    
-        YYSTYPE * yylval;
-    
-        YYLTYPE * yylloc;
-    
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
     yylval = yylval_param;
 
     yylloc = yylloc_param;
 
-	if ( !(yy_init) )
+	if ( !yyg->yy_init )
 		{
-		(yy_init) = 1;
+		yyg->yy_init = 1;
 
 #ifdef YY_USER_INIT
 		YY_USER_INIT;
 #endif
 
-		if ( ! (yy_start) )
-			(yy_start) = 1;	/* first start state */
+		if ( ! yyg->yy_start )
+			yyg->yy_start = 1;	/* first start state */
 
 		if ( ! yyin )
 			yyin = stdin;
@@ -1288,44 +1326,44 @@ YY_DECL
 			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			yyensure_buffer_stack ();
+			yyensure_buffer_stack (yyscanner);
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer( yyin, YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 		}
 
-		yy_load_buffer_state(  );
+		yy_load_buffer_state( yyscanner );
 		}
 
 	{
-#line 132 "beancount/parser/lexer.l"
+#line 138 "beancount/parser/lexer.l"
 
 
 
-#line 136 "beancount/parser/lexer.l"
+#line 142 "beancount/parser/lexer.l"
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
-#line 1306 "beancount/parser/lexer.c"
+#line 1344 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
-		yy_cp = (yy_c_buf_p);
+		yy_cp = yyg->yy_c_buf_p;
 
 		/* Support of yytext. */
-		*yy_cp = (yy_hold_char);
+		*yy_cp = yyg->yy_hold_char;
 
 		/* yy_bp points to the position in yy_ch_buf of the start of
 		 * the current run.
 		 */
 		yy_bp = yy_cp;
 
-		yy_current_state = (yy_start);
+		yy_current_state = yyg->yy_start;
 yy_match:
 		do
 			{
 			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
 			if ( yy_accept[yy_current_state] )
 				{
-				(yy_last_accepting_state) = yy_current_state;
-				(yy_last_accepting_cpos) = yy_cp;
+				yyg->yy_last_accepting_state = yy_current_state;
+				yyg->yy_last_accepting_cpos = yy_cp;
 				}
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
@@ -1337,8 +1375,8 @@ yy_match:
 			++yy_cp;
 			}
 		while ( yy_current_state != 347 );
-		yy_cp = (yy_last_accepting_cpos);
-		yy_current_state = (yy_last_accepting_state);
+		yy_cp = yyg->yy_last_accepting_cpos;
+		yy_current_state = yyg->yy_last_accepting_state;
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -1351,7 +1389,9 @@ yy_find_action:
 			for ( yyl = 0; yyl < yyleng; ++yyl )
 				if ( yytext[yyl] == '\n' )
 					
-    yylineno++;
+    do{ yylineno++;
+        yycolumn=0;
+    }while(0)
 ;
 			}
 
@@ -1361,15 +1401,15 @@ do_action:	/* This label is used only to access EOF actions. */
 	{ /* beginning of action switch */
 			case 0: /* must back up */
 			/* undo the effects of YY_DO_BEFORE_ACTION */
-			*yy_cp = (yy_hold_char);
-			yy_cp = (yy_last_accepting_cpos);
-			yy_current_state = (yy_last_accepting_state);
+			*yy_cp = yyg->yy_hold_char;
+			yy_cp = yyg->yy_last_accepting_cpos;
+			yy_current_state = yyg->yy_last_accepting_state;
 			goto yy_find_action;
 
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 137 "beancount/parser/lexer.l"
+#line 143 "beancount/parser/lexer.l"
 {
     yy_line_tokens = 0;
     yycolumn = 1;
@@ -1382,13 +1422,13 @@ YY_RULE_SETUP
     the grammar. */
 case 2:
 YY_RULE_SETUP
-#line 147 "beancount/parser/lexer.l"
+#line 153 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens == 1 ) {
         /* If the next character completes the line, skip it. */
-        if ( yy_hold_char == '\n' ||
-             yy_hold_char == '\r' ||
-             yy_hold_char == '\0' ) {
+        if ( yyg->yy_hold_char == '\n' ||
+             yyg->yy_hold_char == '\r' ||
+             yyg->yy_hold_char == '\0' ) {
             return SKIPPED;
         }
         else {
@@ -1400,79 +1440,79 @@ YY_RULE_SETUP
 /* Characters with special meanings have their own tokens. */
 case 3:
 YY_RULE_SETUP
-#line 162 "beancount/parser/lexer.l"
+#line 168 "beancount/parser/lexer.l"
 { return PIPE; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 163 "beancount/parser/lexer.l"
+#line 169 "beancount/parser/lexer.l"
 { return ATAT; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 164 "beancount/parser/lexer.l"
+#line 170 "beancount/parser/lexer.l"
 { return AT; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 165 "beancount/parser/lexer.l"
+#line 171 "beancount/parser/lexer.l"
 { return LCURLCURL; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 166 "beancount/parser/lexer.l"
+#line 172 "beancount/parser/lexer.l"
 { return RCURLCURL; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 167 "beancount/parser/lexer.l"
+#line 173 "beancount/parser/lexer.l"
 { return LCURL; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 168 "beancount/parser/lexer.l"
+#line 174 "beancount/parser/lexer.l"
 { return RCURL; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 169 "beancount/parser/lexer.l"
+#line 175 "beancount/parser/lexer.l"
 { return COMMA; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 170 "beancount/parser/lexer.l"
+#line 176 "beancount/parser/lexer.l"
 { return TILDE; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 171 "beancount/parser/lexer.l"
+#line 177 "beancount/parser/lexer.l"
 { return PLUS; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 172 "beancount/parser/lexer.l"
+#line 178 "beancount/parser/lexer.l"
 { return MINUS; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 173 "beancount/parser/lexer.l"
+#line 179 "beancount/parser/lexer.l"
 { return SLASH; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 174 "beancount/parser/lexer.l"
+#line 180 "beancount/parser/lexer.l"
 { return LPAREN; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 175 "beancount/parser/lexer.l"
+#line 181 "beancount/parser/lexer.l"
 { return RPAREN; }
 	YY_BREAK
 /* Special handling for characters beginning a line to be ignored.
   * I'd like to improve how this is handled. Needs own lexer, really. */
 case 17:
 YY_RULE_SETUP
-#line 179 "beancount/parser/lexer.l"
+#line 185 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return HASH;
@@ -1486,7 +1526,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 190 "beancount/parser/lexer.l"
+#line 196 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return ASTERISK;
@@ -1500,7 +1540,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 201 "beancount/parser/lexer.l"
+#line 207 "beancount/parser/lexer.l"
 {
   if (yy_line_tokens != 1) {
     return COLON;
@@ -1515,7 +1555,7 @@ YY_RULE_SETUP
 /* Skip commented output (but not the accompanying newline). */
 case 20:
 YY_RULE_SETUP
-#line 213 "beancount/parser/lexer.l"
+#line 219 "beancount/parser/lexer.l"
 {
     /* yy_skip_line(); */
     return COMMENT;
@@ -1531,7 +1571,7 @@ YY_RULE_SETUP
     */
 case 21:
 YY_RULE_SETUP
-#line 226 "beancount/parser/lexer.l"
+#line 232 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         yylval->character = yytext[0];
@@ -1546,103 +1586,103 @@ YY_RULE_SETUP
 /* Keywords. */
 case 22:
 YY_RULE_SETUP
-#line 238 "beancount/parser/lexer.l"
+#line 244 "beancount/parser/lexer.l"
 { return TXN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 239 "beancount/parser/lexer.l"
+#line 245 "beancount/parser/lexer.l"
 { return BALANCE; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 240 "beancount/parser/lexer.l"
+#line 246 "beancount/parser/lexer.l"
 { return OPEN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 241 "beancount/parser/lexer.l"
+#line 247 "beancount/parser/lexer.l"
 { return CLOSE; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 242 "beancount/parser/lexer.l"
+#line 248 "beancount/parser/lexer.l"
 { return COMMODITY; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 243 "beancount/parser/lexer.l"
+#line 249 "beancount/parser/lexer.l"
 { return PAD; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 244 "beancount/parser/lexer.l"
+#line 250 "beancount/parser/lexer.l"
 { return EVENT; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 245 "beancount/parser/lexer.l"
+#line 251 "beancount/parser/lexer.l"
 { return QUERY; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 246 "beancount/parser/lexer.l"
+#line 252 "beancount/parser/lexer.l"
 { return CUSTOM; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 247 "beancount/parser/lexer.l"
+#line 253 "beancount/parser/lexer.l"
 { return PRICE; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 248 "beancount/parser/lexer.l"
+#line 254 "beancount/parser/lexer.l"
 { return NOTE; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 249 "beancount/parser/lexer.l"
+#line 255 "beancount/parser/lexer.l"
 { return DOCUMENT; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 250 "beancount/parser/lexer.l"
+#line 256 "beancount/parser/lexer.l"
 { return PUSHTAG; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 251 "beancount/parser/lexer.l"
+#line 257 "beancount/parser/lexer.l"
 { return POPTAG; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 252 "beancount/parser/lexer.l"
+#line 258 "beancount/parser/lexer.l"
 { return PUSHMETA; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 253 "beancount/parser/lexer.l"
+#line 259 "beancount/parser/lexer.l"
 { return POPMETA; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 254 "beancount/parser/lexer.l"
+#line 260 "beancount/parser/lexer.l"
 { return OPTION; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 255 "beancount/parser/lexer.l"
+#line 261 "beancount/parser/lexer.l"
 { return PLUGIN; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 256 "beancount/parser/lexer.l"
+#line 262 "beancount/parser/lexer.l"
 { return INCLUDE; }
 	YY_BREAK
 /* Boolean values. */
 case 41:
 YY_RULE_SETUP
-#line 259 "beancount/parser/lexer.l"
+#line 265 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_True;
     Py_INCREF(Py_True);
@@ -1651,7 +1691,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 265 "beancount/parser/lexer.l"
+#line 271 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_False;
     Py_INCREF(Py_False);
@@ -1660,7 +1700,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 271 "beancount/parser/lexer.l"
+#line 277 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_None;
     Py_INCREF(Py_None);
@@ -1670,7 +1710,7 @@ YY_RULE_SETUP
 /* Dates. */
 case 44:
 YY_RULE_SETUP
-#line 278 "beancount/parser/lexer.l"
+#line 284 "beancount/parser/lexer.l"
 {
     const char* year_str;
     const char* month_str;
@@ -1695,7 +1735,7 @@ YY_RULE_SETUP
 /* Account names. */
 case 45:
 YY_RULE_SETUP
-#line 300 "beancount/parser/lexer.l"
+#line 306 "beancount/parser/lexer.l"
 {
     BUILD_LEX("ACCOUNT", "s", yytext);
     return ACCOUNT;
@@ -1705,7 +1745,7 @@ YY_RULE_SETUP
   * syntax. This is kept in sync with beancount.core.amount.CURRENCY_RE. */
 case 46:
 YY_RULE_SETUP
-#line 307 "beancount/parser/lexer.l"
+#line 313 "beancount/parser/lexer.l"
 {
     BUILD_LEX("CURRENCY", "s", yytext);
     return CURRENCY;
@@ -1716,7 +1756,7 @@ YY_RULE_SETUP
     See section "Start Conditions" in the GNU Flex manual. */
 case 47:
 YY_RULE_SETUP
-#line 315 "beancount/parser/lexer.l"
+#line 321 "beancount/parser/lexer.l"
 {
     strbuf_ptr = strbuf;
     BEGIN(STRLIT);
@@ -1726,7 +1766,7 @@ YY_RULE_SETUP
 /* Saw closing quote - all done. */
 case 48:
 YY_RULE_SETUP
-#line 323 "beancount/parser/lexer.l"
+#line 329 "beancount/parser/lexer.l"
 {
         BEGIN(INITIAL);
         *strbuf_ptr = '\0';
@@ -1747,40 +1787,40 @@ YY_RULE_SETUP
 /* Escape sequences. */
 case 49:
 YY_RULE_SETUP
-#line 341 "beancount/parser/lexer.l"
+#line 347 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR('\n');
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 342 "beancount/parser/lexer.l"
+#line 348 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR('\t');
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 343 "beancount/parser/lexer.l"
+#line 349 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR('\r');
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 344 "beancount/parser/lexer.l"
+#line 350 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR('\b');
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 345 "beancount/parser/lexer.l"
+#line 351 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR('\f');
 	YY_BREAK
 case 54:
 /* rule 54 can match eol */
 YY_RULE_SETUP
-#line 346 "beancount/parser/lexer.l"
+#line 352 "beancount/parser/lexer.l"
 SAFE_COPY_CHAR(yytext[1]);
 	YY_BREAK
 /* All other characters. */
 case 55:
 /* rule 55 can match eol */
 YY_RULE_SETUP
-#line 349 "beancount/parser/lexer.l"
+#line 355 "beancount/parser/lexer.l"
 {
         if ( yyleng > (strbuf_end - strbuf_ptr) ) {
             strbuf_realloc(yyleng);
@@ -1795,7 +1835,7 @@ YY_RULE_SETUP
 /* Numbers */
 case 56:
 YY_RULE_SETUP
-#line 361 "beancount/parser/lexer.l"
+#line 367 "beancount/parser/lexer.l"
 {
     BUILD_LEX("NUMBER", "s", yytext);
     return NUMBER;
@@ -1804,7 +1844,7 @@ YY_RULE_SETUP
 /* Tags */
 case 57:
 YY_RULE_SETUP
-#line 367 "beancount/parser/lexer.l"
+#line 373 "beancount/parser/lexer.l"
 {
     BUILD_LEX("TAG", "s", &(yytext[1]));
     return TAG;
@@ -1813,7 +1853,7 @@ YY_RULE_SETUP
 /* Links */
 case 58:
 YY_RULE_SETUP
-#line 373 "beancount/parser/lexer.l"
+#line 379 "beancount/parser/lexer.l"
 {
     BUILD_LEX("LINK", "s", &(yytext[1]));
     return LINK;
@@ -1822,7 +1862,7 @@ YY_RULE_SETUP
 /* Key */
 case 59:
 YY_RULE_SETUP
-#line 379 "beancount/parser/lexer.l"
+#line 385 "beancount/parser/lexer.l"
 {
     BUILD_LEX("KEY", "s#", yytext, (Py_ssize_t)(yyleng-1));
     unput(':');
@@ -1832,7 +1872,7 @@ YY_RULE_SETUP
 /* Default rule. {bf253a29a820} */
 case 60:
 YY_RULE_SETUP
-#line 386 "beancount/parser/lexer.l"
+#line 392 "beancount/parser/lexer.l"
 {
     unput(*yytext);
     BEGIN(INVALID);
@@ -1843,7 +1883,7 @@ YY_RULE_SETUP
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(INVALID):
 case YY_STATE_EOF(STRLIT):
-#line 393 "beancount/parser/lexer.l"
+#line 399 "beancount/parser/lexer.l"
 {
   if ( yy_eof_times == 0 ) {
     yy_eof_times = 1;
@@ -1859,7 +1899,7 @@ case YY_STATE_EOF(STRLIT):
     this and more. {bba169a1d35a} */
 case 61:
 YY_RULE_SETUP
-#line 406 "beancount/parser/lexer.l"
+#line 412 "beancount/parser/lexer.l"
 {
     char buffer[256];
     size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
@@ -1870,18 +1910,18 @@ YY_RULE_SETUP
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 415 "beancount/parser/lexer.l"
+#line 421 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1876 "beancount/parser/lexer.c"
+#line 1916 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
 		/* Amount of text matched not including the EOB char. */
-		int yy_amount_of_matched_text = (int) (yy_cp - (yytext_ptr)) - 1;
+		int yy_amount_of_matched_text = (int) (yy_cp - yyg->yytext_ptr) - 1;
 
 		/* Undo the effects of YY_DO_BEFORE_ACTION. */
-		*yy_cp = (yy_hold_char);
+		*yy_cp = yyg->yy_hold_char;
 		YY_RESTORE_YY_MORE_OFFSET
 
 		if ( YY_CURRENT_BUFFER_LVALUE->yy_buffer_status == YY_BUFFER_NEW )
@@ -1895,7 +1935,7 @@ ECHO;
 			 * this is the first action (other than possibly a
 			 * back-up) that will match for the new input source.
 			 */
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
+			yyg->yy_n_chars = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
 			YY_CURRENT_BUFFER_LVALUE->yy_input_file = yyin;
 			YY_CURRENT_BUFFER_LVALUE->yy_buffer_status = YY_BUFFER_NORMAL;
 			}
@@ -1907,13 +1947,13 @@ ECHO;
 		 * end-of-buffer state).  Contrast this with the test
 		 * in input().
 		 */
-		if ( (yy_c_buf_p) <= &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars)] )
+		if ( yyg->yy_c_buf_p <= &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars] )
 			{ /* This was really a NUL. */
 			yy_state_type yy_next_state;
 
-			(yy_c_buf_p) = (yytext_ptr) + yy_amount_of_matched_text;
+			yyg->yy_c_buf_p = yyg->yytext_ptr + yy_amount_of_matched_text;
 
-			yy_current_state = yy_get_previous_state(  );
+			yy_current_state = yy_get_previous_state( yyscanner );
 
 			/* Okay, we're now positioned to make the NUL
 			 * transition.  We couldn't have
@@ -1924,33 +1964,33 @@ ECHO;
 			 * will run more slowly).
 			 */
 
-			yy_next_state = yy_try_NUL_trans( yy_current_state );
+			yy_next_state = yy_try_NUL_trans( yy_current_state , yyscanner);
 
-			yy_bp = (yytext_ptr) + YY_MORE_ADJ;
+			yy_bp = yyg->yytext_ptr + YY_MORE_ADJ;
 
 			if ( yy_next_state )
 				{
 				/* Consume the NUL. */
-				yy_cp = ++(yy_c_buf_p);
+				yy_cp = ++yyg->yy_c_buf_p;
 				yy_current_state = yy_next_state;
 				goto yy_match;
 				}
 
 			else
 				{
-				yy_cp = (yy_last_accepting_cpos);
-				yy_current_state = (yy_last_accepting_state);
+				yy_cp = yyg->yy_last_accepting_cpos;
+				yy_current_state = yyg->yy_last_accepting_state;
 				goto yy_find_action;
 				}
 			}
 
-		else switch ( yy_get_next_buffer(  ) )
+		else switch ( yy_get_next_buffer( yyscanner ) )
 			{
 			case EOB_ACT_END_OF_FILE:
 				{
-				(yy_did_buffer_switch_on_eof) = 0;
+				yyg->yy_did_buffer_switch_on_eof = 0;
 
-				if ( yywrap(  ) )
+				if ( yywrap( yyscanner ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1961,7 +2001,7 @@ ECHO;
 					 * YY_NULL, it'll still work - another
 					 * YY_NULL will get returned.
 					 */
-					(yy_c_buf_p) = (yytext_ptr) + YY_MORE_ADJ;
+					yyg->yy_c_buf_p = yyg->yytext_ptr + YY_MORE_ADJ;
 
 					yy_act = YY_STATE_EOF(YY_START);
 					goto do_action;
@@ -1969,30 +2009,30 @@ ECHO;
 
 				else
 					{
-					if ( ! (yy_did_buffer_switch_on_eof) )
+					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
 					}
 				break;
 				}
 
 			case EOB_ACT_CONTINUE_SCAN:
-				(yy_c_buf_p) =
-					(yytext_ptr) + yy_amount_of_matched_text;
+				yyg->yy_c_buf_p =
+					yyg->yytext_ptr + yy_amount_of_matched_text;
 
-				yy_current_state = yy_get_previous_state(  );
+				yy_current_state = yy_get_previous_state( yyscanner );
 
-				yy_cp = (yy_c_buf_p);
-				yy_bp = (yytext_ptr) + YY_MORE_ADJ;
+				yy_cp = yyg->yy_c_buf_p;
+				yy_bp = yyg->yytext_ptr + YY_MORE_ADJ;
 				goto yy_match;
 
 			case EOB_ACT_LAST_MATCH:
-				(yy_c_buf_p) =
-				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars)];
+				yyg->yy_c_buf_p =
+				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars];
 
-				yy_current_state = yy_get_previous_state(  );
+				yy_current_state = yy_get_previous_state( yyscanner );
 
-				yy_cp = (yy_c_buf_p);
-				yy_bp = (yytext_ptr) + YY_MORE_ADJ;
+				yy_cp = yyg->yy_c_buf_p;
+				yy_bp = yyg->yytext_ptr + YY_MORE_ADJ;
 				goto yy_find_action;
 			}
 		break;
@@ -2013,20 +2053,21 @@ ECHO;
  *	EOB_ACT_CONTINUE_SCAN - continue scanning from current position
  *	EOB_ACT_END_OF_FILE - end of file
  */
-static int yy_get_next_buffer (void)
+static int yy_get_next_buffer (yyscan_t yyscanner)
 {
-    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	char *source = (yytext_ptr);
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = yyg->yytext_ptr;
 	int number_to_move, i;
 	int ret_val;
 
-	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
+	if ( yyg->yy_c_buf_p > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars + 1] )
 		YY_FATAL_ERROR(
 		"fatal flex scanner internal error--end of buffer missed" );
 
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_fill_buffer == 0 )
 		{ /* Don't try to fill the buffer, so this is an EOF. */
-		if ( (yy_c_buf_p) - (yytext_ptr) - YY_MORE_ADJ == 1 )
+		if ( yyg->yy_c_buf_p - yyg->yytext_ptr - YY_MORE_ADJ == 1 )
 			{
 			/* We matched a single character, the EOB, so
 			 * treat this as a final EOF.
@@ -2046,7 +2087,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
+	number_to_move = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -2055,7 +2096,7 @@ static int yy_get_next_buffer (void)
 		/* don't do the read, it's not guaranteed to return an EOF,
 		 * just force an EOF
 		 */
-		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars) = 0;
+		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = yyg->yy_n_chars = 0;
 
 	else
 		{
@@ -2069,7 +2110,7 @@ static int yy_get_next_buffer (void)
 			YY_BUFFER_STATE b = YY_CURRENT_BUFFER_LVALUE;
 
 			int yy_c_buf_p_offset =
-				(int) ((yy_c_buf_p) - b->yy_ch_buf);
+				(int) (yyg->yy_c_buf_p - b->yy_ch_buf);
 
 			if ( b->yy_is_our_buffer )
 				{
@@ -2083,7 +2124,7 @@ static int yy_get_next_buffer (void)
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
 					yyrealloc( (void *) b->yy_ch_buf,
-							 (yy_size_t) (b->yy_buf_size + 2)  );
+							 (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 				}
 			else
 				/* Can't grow it, we don't own it. */
@@ -2093,7 +2134,7 @@ static int yy_get_next_buffer (void)
 				YY_FATAL_ERROR(
 				"fatal error - scanner input buffer overflow" );
 
-			(yy_c_buf_p) = &b->yy_ch_buf[yy_c_buf_p_offset];
+			yyg->yy_c_buf_p = &b->yy_ch_buf[yy_c_buf_p_offset];
 
 			num_to_read = YY_CURRENT_BUFFER_LVALUE->yy_buf_size -
 						number_to_move - 1;
@@ -2105,17 +2146,17 @@ static int yy_get_next_buffer (void)
 
 		/* Read in more data. */
 		YY_INPUT( (&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move]),
-			(yy_n_chars), num_to_read );
+			yyg->yy_n_chars, num_to_read );
 
-		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars);
+		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = yyg->yy_n_chars;
 		}
 
-	if ( (yy_n_chars) == 0 )
+	if ( yyg->yy_n_chars == 0 )
 		{
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart( yyin  );
+			yyrestart( yyin  , yyscanner);
 			}
 
 		else
@@ -2129,42 +2170,43 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
-			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
 		/* "- 2" to take care of EOB's */
 		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
-	(yy_n_chars) += number_to_move;
-	YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars)] = YY_END_OF_BUFFER_CHAR;
-	YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] = YY_END_OF_BUFFER_CHAR;
+	yyg->yy_n_chars += number_to_move;
+	YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars] = YY_END_OF_BUFFER_CHAR;
+	YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars + 1] = YY_END_OF_BUFFER_CHAR;
 
-	(yytext_ptr) = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[0];
+	yyg->yytext_ptr = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[0];
 
 	return ret_val;
 }
 
 /* yy_get_previous_state - get the state just before the EOB char was reached */
 
-    static yy_state_type yy_get_previous_state (void)
+    static yy_state_type yy_get_previous_state (yyscan_t yyscanner)
 {
 	yy_state_type yy_current_state;
 	char *yy_cp;
-    
-	yy_current_state = (yy_start);
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
+	yy_current_state = yyg->yy_start;
+
+	for ( yy_cp = yyg->yytext_ptr + YY_MORE_ADJ; yy_cp < yyg->yy_c_buf_p; ++yy_cp )
 		{
 		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
-			(yy_last_accepting_state) = yy_current_state;
-			(yy_last_accepting_cpos) = yy_cp;
+			yyg->yy_last_accepting_state = yy_current_state;
+			yyg->yy_last_accepting_cpos = yy_cp;
 			}
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
@@ -2183,16 +2225,17 @@ static int yy_get_next_buffer (void)
  * synopsis
  *	next_state = yy_try_NUL_trans( current_state );
  */
-    static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
+    static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state , yyscan_t yyscanner)
 {
 	int yy_is_jam;
-    	char *yy_cp = (yy_c_buf_p);
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner; /* This var may be unused depending upon options. */
+	char *yy_cp = yyg->yy_c_buf_p;
 
 	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
-		(yy_last_accepting_state) = yy_current_state;
-		(yy_last_accepting_cpos) = yy_cp;
+		yyg->yy_last_accepting_state = yy_current_state;
+		yyg->yy_last_accepting_cpos = yy_cp;
 		}
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
@@ -2203,24 +2246,26 @@ static int yy_get_next_buffer (void)
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 347);
 
-		return yy_is_jam ? 0 : yy_current_state;
+	(void)yyg;
+	return yy_is_jam ? 0 : yy_current_state;
 }
 
 #ifndef YY_NO_UNPUT
 
-    static void yyunput (int c, char * yy_bp )
+    static void yyunput (int c, char * yy_bp , yyscan_t yyscanner)
 {
 	char *yy_cp;
-    
-    yy_cp = (yy_c_buf_p);
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+    yy_cp = yyg->yy_c_buf_p;
 
 	/* undo effects of setting up yytext */
-	*yy_cp = (yy_hold_char);
+	*yy_cp = yyg->yy_hold_char;
 
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		int number_to_move = (yy_n_chars) + 2;
+		int number_to_move = yyg->yy_n_chars + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -2232,7 +2277,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			yyg->yy_n_chars = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -2244,41 +2289,42 @@ static int yy_get_next_buffer (void)
         --yylineno;
     }
 
-	(yytext_ptr) = yy_bp;
-	(yy_hold_char) = *yy_cp;
-	(yy_c_buf_p) = yy_cp;
+	yyg->yytext_ptr = yy_bp;
+	yyg->yy_hold_char = *yy_cp;
+	yyg->yy_c_buf_p = yy_cp;
 }
 
 #endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
-    static int yyinput (void)
+    static int yyinput (yyscan_t yyscanner)
 #else
-    static int input  (void)
+    static int input  (yyscan_t yyscanner)
 #endif
 
 {
 	int c;
-    
-	*(yy_c_buf_p) = (yy_hold_char);
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	if ( *(yy_c_buf_p) == YY_END_OF_BUFFER_CHAR )
+	*yyg->yy_c_buf_p = yyg->yy_hold_char;
+
+	if ( *yyg->yy_c_buf_p == YY_END_OF_BUFFER_CHAR )
 		{
 		/* yy_c_buf_p now points to the character we want to return.
 		 * If this occurs *before* the EOB characters, then it's a
 		 * valid NUL; if not, then we've hit the end of the buffer.
 		 */
-		if ( (yy_c_buf_p) < &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars)] )
+		if ( yyg->yy_c_buf_p < &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars] )
 			/* This was really a NUL. */
-			*(yy_c_buf_p) = '\0';
+			*yyg->yy_c_buf_p = '\0';
 
 		else
 			{ /* need more input */
-			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
-			++(yy_c_buf_p);
+			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
+			++yyg->yy_c_buf_p;
 
-			switch ( yy_get_next_buffer(  ) )
+			switch ( yy_get_next_buffer( yyscanner ) )
 				{
 				case EOB_ACT_LAST_MATCH:
 					/* This happens because yy_g_n_b()
@@ -2292,38 +2338,40 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart( yyin );
+					yyrestart( yyin , yyscanner);
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap(  ) )
+					if ( yywrap( yyscanner ) )
 						return 0;
 
-					if ( ! (yy_did_buffer_switch_on_eof) )
+					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
 #ifdef __cplusplus
-					return yyinput();
+					return yyinput(yyscanner);
 #else
-					return input();
+					return input(yyscanner);
 #endif
 					}
 
 				case EOB_ACT_CONTINUE_SCAN:
-					(yy_c_buf_p) = (yytext_ptr) + offset;
+					yyg->yy_c_buf_p = yyg->yytext_ptr + offset;
 					break;
 				}
 			}
 		}
 
-	c = *(unsigned char *) (yy_c_buf_p);	/* cast for 8-bit char's */
-	*(yy_c_buf_p) = '\0';	/* preserve yytext */
-	(yy_hold_char) = *++(yy_c_buf_p);
+	c = *(unsigned char *) yyg->yy_c_buf_p;	/* cast for 8-bit char's */
+	*yyg->yy_c_buf_p = '\0';	/* preserve yytext */
+	yyg->yy_hold_char = *++yyg->yy_c_buf_p;
 
 	if ( c == '\n' )
 		
-    yylineno++;
+    do{ yylineno++;
+        yycolumn=0;
+    }while(0)
 ;
 
 	return c;
@@ -2332,76 +2380,79 @@ static int yy_get_next_buffer (void)
 
 /** Immediately switch to a different input stream.
  * @param input_file A readable stream.
- * 
+ * @param yyscanner The scanner object.
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void yyrestart  (FILE * input_file )
+    void yyrestart  (FILE * input_file , yyscan_t yyscanner)
 {
-    
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
 	if ( ! YY_CURRENT_BUFFER ){
-        yyensure_buffer_stack ();
+        yyensure_buffer_stack (yyscanner);
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer( yyin, YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 	}
 
-	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
-	yy_load_buffer_state(  );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file , yyscanner);
+	yy_load_buffer_state( yyscanner );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
- * 
+ * @param yyscanner The scanner object.
  */
-    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
 {
-    
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
 	/* TODO. We should be able to replace this entire function body
 	 * with
 	 *		yypop_buffer_state();
 	 *		yypush_buffer_state(new_buffer);
      */
-	yyensure_buffer_stack ();
+	yyensure_buffer_stack (yyscanner);
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
-		*(yy_c_buf_p) = (yy_hold_char);
-		YY_CURRENT_BUFFER_LVALUE->yy_buf_pos = (yy_c_buf_p);
-		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars);
+		*yyg->yy_c_buf_p = yyg->yy_hold_char;
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_pos = yyg->yy_c_buf_p;
+		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = yyg->yy_n_chars;
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state(  );
+	yy_load_buffer_state( yyscanner );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
 	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
-	(yy_did_buffer_switch_on_eof) = 1;
+	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
-static void yy_load_buffer_state  (void)
+static void yy_load_buffer_state  (yyscan_t yyscanner)
 {
-    	(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
-	(yytext_ptr) = (yy_c_buf_p) = YY_CURRENT_BUFFER_LVALUE->yy_buf_pos;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	yyg->yy_n_chars = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
+	yyg->yytext_ptr = yyg->yy_c_buf_p = YY_CURRENT_BUFFER_LVALUE->yy_buf_pos;
 	yyin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
-	(yy_hold_char) = *(yy_c_buf_p);
+	yyg->yy_hold_char = *yyg->yy_c_buf_p;
 }
 
 /** Allocate and initialize an input buffer state.
  * @param file A readable stream.
  * @param size The character buffer size in bytes. When in doubt, use @c YY_BUF_SIZE.
- * 
+ * @param yyscanner The scanner object.
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size )
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
@@ -2410,24 +2461,25 @@ static void yy_load_buffer_state  (void)
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer( b, file );
+	yy_init_buffer( b, file , yyscanner);
 
 	return b;
 }
 
 /** Destroy the buffer.
  * @param b a buffer created with yy_create_buffer()
- * 
+ * @param yyscanner The scanner object.
  */
-    void yy_delete_buffer (YY_BUFFER_STATE  b )
+    void yy_delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
-    
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
 	if ( ! b )
 		return;
 
@@ -2435,21 +2487,22 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree( (void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf , yyscanner );
 
-	yyfree( (void *) b  );
+	yyfree( (void *) b , yyscanner );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a yyrestart() or at EOF.
  */
-    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
 
 {
 	int oerrno = errno;
-    
-	yy_flush_buffer( b );
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+	yy_flush_buffer( b , yyscanner);
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -2470,11 +2523,12 @@ static void yy_load_buffer_state  (void)
 
 /** Discard all buffered characters. On the next scan, YY_INPUT will be called.
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
- * 
+ * @param yyscanner The scanner object.
  */
-    void yy_flush_buffer (YY_BUFFER_STATE  b )
+    void yy_flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
-    	if ( ! b )
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	if ( ! b )
 		return;
 
 	b->yy_n_chars = 0;
@@ -2492,114 +2546,117 @@ static void yy_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state(  );
+		yy_load_buffer_state( yyscanner );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
  *  the current state. This function will allocate the stack
  *  if necessary.
  *  @param new_buffer The new state.
- *  
+ *  @param yyscanner The scanner object.
  */
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
 {
-    	if (new_buffer == NULL)
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	if (new_buffer == NULL)
 		return;
 
-	yyensure_buffer_stack();
+	yyensure_buffer_stack(yyscanner);
 
 	/* This block is copied from yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
-		*(yy_c_buf_p) = (yy_hold_char);
-		YY_CURRENT_BUFFER_LVALUE->yy_buf_pos = (yy_c_buf_p);
-		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars);
+		*yyg->yy_c_buf_p = yyg->yy_hold_char;
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_pos = yyg->yy_c_buf_p;
+		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = yyg->yy_n_chars;
 		}
 
 	/* Only push if top exists. Otherwise, replace top. */
 	if (YY_CURRENT_BUFFER)
-		(yy_buffer_stack_top)++;
+		yyg->yy_buffer_stack_top++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state(  );
-	(yy_did_buffer_switch_on_eof) = 1;
+	yy_load_buffer_state( yyscanner );
+	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
 /** Removes and deletes the top of the stack, if present.
  *  The next element becomes the new top.
- *  
+ *  @param yyscanner The scanner object.
  */
-void yypop_buffer_state (void)
+void yypop_buffer_state (yyscan_t yyscanner)
 {
-    	if (!YY_CURRENT_BUFFER)
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	if (!YY_CURRENT_BUFFER)
 		return;
 
-	yy_delete_buffer(YY_CURRENT_BUFFER );
+	yy_delete_buffer(YY_CURRENT_BUFFER , yyscanner);
 	YY_CURRENT_BUFFER_LVALUE = NULL;
-	if ((yy_buffer_stack_top) > 0)
-		--(yy_buffer_stack_top);
+	if (yyg->yy_buffer_stack_top > 0)
+		--yyg->yy_buffer_stack_top;
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state(  );
-		(yy_did_buffer_switch_on_eof) = 1;
+		yy_load_buffer_state( yyscanner );
+		yyg->yy_did_buffer_switch_on_eof = 1;
 	}
 }
 
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void yyensure_buffer_stack (void)
+static void yyensure_buffer_stack (yyscan_t yyscanner)
 {
 	yy_size_t num_to_alloc;
-    
-	if (!(yy_buffer_stack)) {
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+	if (!yyg->yy_buffer_stack) {
 
 		/* First allocation is just for 2 elements, since we don't know if this
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
       num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
-								);
-		if ( ! (yy_buffer_stack) )
+								, yyscanner);
+		if ( ! yyg->yy_buffer_stack )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
-		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
+		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
 
-		(yy_buffer_stack_max) = num_to_alloc;
-		(yy_buffer_stack_top) = 0;
+		yyg->yy_buffer_stack_max = num_to_alloc;
+		yyg->yy_buffer_stack_top = 0;
 		return;
 	}
 
-	if ((yy_buffer_stack_top) >= ((yy_buffer_stack_max)) - 1){
+	if (yyg->yy_buffer_stack_top >= (yyg->yy_buffer_stack_max) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
 		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
-		num_to_alloc = (yy_buffer_stack_max) + grow_size;
-		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
-								((yy_buffer_stack),
+		num_to_alloc = yyg->yy_buffer_stack_max + grow_size;
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyrealloc
+								(yyg->yy_buffer_stack,
 								num_to_alloc * sizeof(struct yy_buffer_state*)
-								);
-		if ( ! (yy_buffer_stack) )
+								, yyscanner);
+		if ( ! yyg->yy_buffer_stack )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
-		memset((yy_buffer_stack) + (yy_buffer_stack_max), 0, grow_size * sizeof(struct yy_buffer_state*));
-		(yy_buffer_stack_max) = num_to_alloc;
+		memset(yyg->yy_buffer_stack + yyg->yy_buffer_stack_max, 0, grow_size * sizeof(struct yy_buffer_state*));
+		yyg->yy_buffer_stack_max = num_to_alloc;
 	}
 }
 
 /** Setup the input buffer state to scan directly from a user-specified character buffer.
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
- * 
+ * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
@@ -2609,7 +2666,7 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 		/* They forgot to leave room for the EOB's. */
 		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
@@ -2623,7 +2680,7 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer( b  );
+	yy_switch_to_buffer( b , yyscanner );
 
 	return b;
 }
@@ -2631,25 +2688,25 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 /** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
- * 
+ * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (const char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
 {
     
-	return yy_scan_bytes( yystr, (int) strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) , yyscanner);
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
- * 
+ * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
@@ -2658,7 +2715,7 @@ YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = (yy_size_t) (_yybytes_len + 2);
-	buf = (char *) yyalloc( n  );
+	buf = (char *) yyalloc( n , yyscanner );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -2667,7 +2724,7 @@ YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer( buf, n );
+	b = yy_scan_buffer( buf, n , yyscanner);
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -2683,9 +2740,11 @@ YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yynoreturn yy_fatal_error (const char* msg )
+static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 {
-			fprintf( stderr, "%s\n", msg );
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+	fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2698,109 +2757,261 @@ static void yynoreturn yy_fatal_error (const char* msg )
 		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		yytext[yyleng] = (yy_hold_char); \
-		(yy_c_buf_p) = yytext + yyless_macro_arg; \
-		(yy_hold_char) = *(yy_c_buf_p); \
-		*(yy_c_buf_p) = '\0'; \
+		yytext[yyleng] = yyg->yy_hold_char; \
+		yyg->yy_c_buf_p = yytext + yyless_macro_arg; \
+		yyg->yy_hold_char = *yyg->yy_c_buf_p; \
+		*yyg->yy_c_buf_p = '\0'; \
 		yyleng = yyless_macro_arg; \
 		} \
 	while ( 0 )
 
 /* Accessor  methods (get/set functions) to struct members. */
 
-/** Get the current line number.
- * 
+/** Get the user-defined data for this scanner.
+ * @param yyscanner The scanner object.
  */
-int yyget_lineno  (void)
+YY_EXTRA_TYPE yyget_extra  (yyscan_t yyscanner)
 {
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yyextra;
+}
+
+/** Get the current line number.
+ * @param yyscanner The scanner object.
+ */
+int yyget_lineno  (yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+        if (! YY_CURRENT_BUFFER)
+            return 0;
     
     return yylineno;
 }
 
-/** Get the input stream.
- * 
+/** Get the current column number.
+ * @param yyscanner The scanner object.
  */
-FILE *yyget_in  (void)
+int yyget_column  (yyscan_t yyscanner)
 {
-        return yyin;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+        if (! YY_CURRENT_BUFFER)
+            return 0;
+    
+    return yycolumn;
+}
+
+/** Get the input stream.
+ * @param yyscanner The scanner object.
+ */
+FILE *yyget_in  (yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yyin;
 }
 
 /** Get the output stream.
- * 
+ * @param yyscanner The scanner object.
  */
-FILE *yyget_out  (void)
+FILE *yyget_out  (yyscan_t yyscanner)
 {
-        return yyout;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yyout;
 }
 
 /** Get the length of the current token.
- * 
+ * @param yyscanner The scanner object.
  */
-int yyget_leng  (void)
+int yyget_leng  (yyscan_t yyscanner)
 {
-        return yyleng;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yyleng;
 }
 
 /** Get the current token.
- * 
+ * @param yyscanner The scanner object.
  */
 
-char *yyget_text  (void)
+char *yyget_text  (yyscan_t yyscanner)
 {
-        return yytext;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yytext;
+}
+
+/** Set the user-defined data. This data is never touched by the scanner.
+ * @param user_defined The data to be associated with this scanner.
+ * @param yyscanner The scanner object.
+ */
+void yyset_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    yyextra = user_defined ;
 }
 
 /** Set the current line number.
  * @param _line_number line number
- * 
+ * @param yyscanner The scanner object.
  */
-void yyset_lineno (int  _line_number )
+void yyset_lineno (int  _line_number , yyscan_t yyscanner)
 {
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+        /* lineno is only valid if an input buffer exists. */
+        if (! YY_CURRENT_BUFFER )
+           YY_FATAL_ERROR( "yyset_lineno called with no buffer" );
     
     yylineno = _line_number;
+}
+
+/** Set the current column.
+ * @param _column_no column number
+ * @param yyscanner The scanner object.
+ */
+void yyset_column (int  _column_no , yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+        /* column is only valid if an input buffer exists. */
+        if (! YY_CURRENT_BUFFER )
+           YY_FATAL_ERROR( "yyset_column called with no buffer" );
+    
+    yycolumn = _column_no;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
  * @param _in_str A readable stream.
- * 
+ * @param yyscanner The scanner object.
  * @see yy_switch_to_buffer
  */
-void yyset_in (FILE *  _in_str )
+void yyset_in (FILE *  _in_str , yyscan_t yyscanner)
 {
-        yyin = _in_str ;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    yyin = _in_str ;
 }
 
-void yyset_out (FILE *  _out_str )
+void yyset_out (FILE *  _out_str , yyscan_t yyscanner)
 {
-        yyout = _out_str ;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    yyout = _out_str ;
 }
 
-int yyget_debug  (void)
+int yyget_debug  (yyscan_t yyscanner)
 {
-        return yy_flex_debug;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yy_flex_debug;
 }
 
-void yyset_debug (int  _bdebug )
+void yyset_debug (int  _bdebug , yyscan_t yyscanner)
 {
-        yy_flex_debug = _bdebug ;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    yy_flex_debug = _bdebug ;
 }
 
-static int yy_init_globals (void)
+/* Accessor methods for yylval and yylloc */
+
+YYSTYPE * yyget_lval  (yyscan_t yyscanner)
 {
-        /* Initialization is the same as for the non-reentrant scanner.
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yylval;
+}
+
+void yyset_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    yylval = yylval_param;
+}
+
+YYLTYPE *yyget_lloc  (yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yylloc;
+}
+    
+void yyset_lloc (YYLTYPE *  yylloc_param , yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    yylloc = yylloc_param;
+}
+    
+/* User-visible API */
+
+/* yylex_init is special because it creates the scanner itself, so it is
+ * the ONLY reentrant function that doesn't take the scanner as the last argument.
+ * That's why we explicitly handle the declaration, instead of using our macros.
+ */
+int yylex_init(yyscan_t* ptr_yy_globals)
+{
+    if (ptr_yy_globals == NULL){
+        errno = EINVAL;
+        return 1;
+    }
+
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), NULL );
+
+    if (*ptr_yy_globals == NULL){
+        errno = ENOMEM;
+        return 1;
+    }
+
+    /* By setting to 0xAA, we expose bugs in yy_init_globals. Leave at 0x00 for releases. */
+    memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
+
+    return yy_init_globals ( *ptr_yy_globals );
+}
+
+/* yylex_init_extra has the same functionality as yylex_init, but follows the
+ * convention of taking the scanner as the last argument. Note however, that
+ * this is a *pointer* to a scanner, as it will be allocated by this call (and
+ * is the reason, too, why this function also must handle its own declaration).
+ * The user defined value in the first argument will be available to yyalloc in
+ * the yyextra field.
+ */
+int yylex_init_extra( YY_EXTRA_TYPE yy_user_defined, yyscan_t* ptr_yy_globals )
+{
+    struct yyguts_t dummy_yyguts;
+
+    yyset_extra (yy_user_defined, &dummy_yyguts);
+
+    if (ptr_yy_globals == NULL){
+        errno = EINVAL;
+        return 1;
+    }
+
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
+
+    if (*ptr_yy_globals == NULL){
+        errno = ENOMEM;
+        return 1;
+    }
+
+    /* By setting to 0xAA, we expose bugs in
+    yy_init_globals. Leave at 0x00 for releases. */
+    memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
+
+    yyset_extra (yy_user_defined, *ptr_yy_globals);
+
+    return yy_init_globals ( *ptr_yy_globals );
+}
+
+static int yy_init_globals (yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    /* Initialization is the same as for the non-reentrant scanner.
      * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    /* We do not touch yylineno unless the option is enabled. */
-    yylineno =  1;
-    
-    (yy_buffer_stack) = NULL;
-    (yy_buffer_stack_top) = 0;
-    (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = NULL;
-    (yy_init) = 0;
-    (yy_start) = 0;
+    yyg->yy_buffer_stack = NULL;
+    yyg->yy_buffer_stack_top = 0;
+    yyg->yy_buffer_stack_max = 0;
+    yyg->yy_c_buf_p = NULL;
+    yyg->yy_init = 0;
+    yyg->yy_start = 0;
+
+    yyg->yy_start_stack_ptr = 0;
+    yyg->yy_start_stack_depth = 0;
+    yyg->yy_start_stack =  NULL;
 
 /* Defined in main.c */
 #ifdef YY_STDINIT
@@ -2818,24 +3029,32 @@ static int yy_init_globals (void)
 }
 
 /* yylex_destroy is for both reentrant and non-reentrant scanners. */
-int yylex_destroy  (void)
+int yylex_destroy  (yyscan_t yyscanner)
 {
-    
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer( YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER , yyscanner );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		yypop_buffer_state();
+		yypop_buffer_state(yyscanner);
 	}
 
 	/* Destroy the stack itself. */
-	yyfree((yy_buffer_stack) );
-	(yy_buffer_stack) = NULL;
+	yyfree(yyg->yy_buffer_stack , yyscanner);
+	yyg->yy_buffer_stack = NULL;
+
+    /* Destroy the start condition stack. */
+        yyfree( yyg->yy_start_stack , yyscanner );
+        yyg->yy_start_stack = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
      * yylex() is called, initialization will occur. */
-    yy_init_globals( );
+    yy_init_globals( yyscanner);
 
+    /* Destroy the main struct (reentrant only). */
+    yyfree ( yyscanner , yyscanner );
+    yyscanner = NULL;
     return 0;
 }
 
@@ -2844,9 +3063,11 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, const char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n , yyscan_t yyscanner)
 {
-		
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+
 	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
@@ -2854,7 +3075,7 @@ static void yy_flex_strncpy (char* s1, const char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (const char * s )
+static int yy_flex_strlen (const char * s , yyscan_t yyscanner)
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -2864,14 +3085,18 @@ static int yy_flex_strlen (const char * s )
 }
 #endif
 
-void *yyalloc (yy_size_t  size )
+void *yyalloc (yy_size_t  size , yyscan_t yyscanner)
 {
-			return malloc(size);
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+	return malloc(size);
 }
 
-void *yyrealloc  (void * ptr, yy_size_t  size )
+void *yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 {
-		
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -2882,14 +3107,16 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	return realloc(ptr, size);
 }
 
-void yyfree (void * ptr )
+void yyfree (void * ptr , yyscan_t yyscanner)
 {
-			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-#line 415 "beancount/parser/lexer.l"
+#line 421 "beancount/parser/lexer.l"
 
 /*--------------------------------------------------------------------------------------*/
 /* User Code */
@@ -2907,9 +3134,6 @@ const char* yy_filename = 0;
 /* Number of tokens since the beginning of the line. */
 int yy_line_tokens = 0;
 
-/* The current column we're tokenizing at. */
-int yycolumn = 1;
-
 /* The encoding to use for converting strings. */
 const char* yy_encoding = NULL;
 
@@ -2926,7 +3150,6 @@ void yylex_initialize(const char* filename, const char* encoding)
     yy_eof_times = 0;
     yy_filename = filename ?: "";
     yy_line_tokens = 0;
-    yycolumn = 1;
     if ( encoding == 0 ) {
         yy_encoding = "utf8";
     }
@@ -2939,9 +3162,6 @@ void yylex_initialize(const char* filename, const char* encoding)
     strbuf = realloc(strbuf, strbuf_size + 1);
     strbuf_end = strbuf + strbuf_size - 1;
     strbuf_ptr = NULL;
-
-    /* Note: If we used a reentrant parser, this routine should eventually call
-     * yylex_init(). */
 }
 
 /* Finalize the globals before running the lexer. */
@@ -2954,9 +3174,6 @@ void yylex_finalize(void)
         free(strbuf);
         strbuf = NULL;
     }
-
-    /* Call the yylex finalization routine. */
-    yylex_destroy();
 }
 
 
@@ -2972,29 +3189,6 @@ void strbuf_realloc(size_t num_new_chars)
     strbuf = realloc(strbuf, strbuf_size + 1);
     strbuf_ptr = strbuf + cur_size;
     strbuf_end = strbuf + strbuf_size - 1;
-}
-
-
-
-
-#define LEXEOF 0
-
-int yy_skip_line()
-{
-    int num_chars = 0;
-    for ( ;; ) {
-        int c = input();
-        num_chars++;
-        if ( c == LEXEOF || c == -1 ) {
-            break;
-        }
-        if ( c == '\n' ) {
-            unput(c);
-            num_chars--;
-            break;
-        }
-    }
-    return num_chars;
 }
 
 /* Convert an integer string to a number. */

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -1378,9 +1378,18 @@ YY_DECL
 #line 178 "beancount/parser/lexer.l"
 
 
-#line 181 "beancount/parser/lexer.l"
+
+#line 182 "beancount/parser/lexer.l"
+    /* If a Python exception has been raised, return immediately. This is
+     * useful to catch exceptions raised in the YY_INPUT routine or other
+     * exceptions not explicitly handled. */
+    if (PyErr_Occurred()) {
+        return -1;
+    }
+
+
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
-#line 1383 "beancount/parser/lexer.c"
+#line 1392 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1448,7 +1457,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 182 "beancount/parser/lexer.l"
+#line 191 "beancount/parser/lexer.l"
 {
     yy_line_tokens = 0;
     yycolumn = 1;
@@ -1461,7 +1470,7 @@ YY_RULE_SETUP
     the grammar. */
 case 2:
 YY_RULE_SETUP
-#line 192 "beancount/parser/lexer.l"
+#line 201 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens == 1 ) {
         /* If the next character completes the line, skip it. */
@@ -1479,79 +1488,79 @@ YY_RULE_SETUP
 /* Characters with special meanings have their own tokens. */
 case 3:
 YY_RULE_SETUP
-#line 207 "beancount/parser/lexer.l"
+#line 216 "beancount/parser/lexer.l"
 { return PIPE; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 208 "beancount/parser/lexer.l"
+#line 217 "beancount/parser/lexer.l"
 { return ATAT; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 209 "beancount/parser/lexer.l"
+#line 218 "beancount/parser/lexer.l"
 { return AT; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 210 "beancount/parser/lexer.l"
+#line 219 "beancount/parser/lexer.l"
 { return LCURLCURL; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 211 "beancount/parser/lexer.l"
+#line 220 "beancount/parser/lexer.l"
 { return RCURLCURL; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 212 "beancount/parser/lexer.l"
+#line 221 "beancount/parser/lexer.l"
 { return LCURL; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 213 "beancount/parser/lexer.l"
+#line 222 "beancount/parser/lexer.l"
 { return RCURL; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 214 "beancount/parser/lexer.l"
+#line 223 "beancount/parser/lexer.l"
 { return COMMA; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 215 "beancount/parser/lexer.l"
+#line 224 "beancount/parser/lexer.l"
 { return TILDE; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 216 "beancount/parser/lexer.l"
+#line 225 "beancount/parser/lexer.l"
 { return PLUS; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 217 "beancount/parser/lexer.l"
+#line 226 "beancount/parser/lexer.l"
 { return MINUS; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 218 "beancount/parser/lexer.l"
+#line 227 "beancount/parser/lexer.l"
 { return SLASH; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 219 "beancount/parser/lexer.l"
+#line 228 "beancount/parser/lexer.l"
 { return LPAREN; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 220 "beancount/parser/lexer.l"
+#line 229 "beancount/parser/lexer.l"
 { return RPAREN; }
 	YY_BREAK
 /* Special handling for characters beginning a line to be ignored.
   * I'd like to improve how this is handled. Needs own lexer, really. */
 case 17:
 YY_RULE_SETUP
-#line 224 "beancount/parser/lexer.l"
+#line 233 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return HASH;
@@ -1565,7 +1574,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 235 "beancount/parser/lexer.l"
+#line 244 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         return ASTERISK;
@@ -1579,7 +1588,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 246 "beancount/parser/lexer.l"
+#line 255 "beancount/parser/lexer.l"
 {
   if (yy_line_tokens != 1) {
     return COLON;
@@ -1594,7 +1603,7 @@ YY_RULE_SETUP
 /* Skip commented output (but not the accompanying newline). */
 case 20:
 YY_RULE_SETUP
-#line 258 "beancount/parser/lexer.l"
+#line 267 "beancount/parser/lexer.l"
 {
     /* yy_skip_line(); */
     return COMMENT;
@@ -1610,7 +1619,7 @@ YY_RULE_SETUP
     */
 case 21:
 YY_RULE_SETUP
-#line 271 "beancount/parser/lexer.l"
+#line 280 "beancount/parser/lexer.l"
 {
     if ( yy_line_tokens != 1 ) {
         yylval->character = yytext[0];
@@ -1625,103 +1634,103 @@ YY_RULE_SETUP
 /* Keywords. */
 case 22:
 YY_RULE_SETUP
-#line 283 "beancount/parser/lexer.l"
+#line 292 "beancount/parser/lexer.l"
 { return TXN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 284 "beancount/parser/lexer.l"
+#line 293 "beancount/parser/lexer.l"
 { return BALANCE; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 285 "beancount/parser/lexer.l"
+#line 294 "beancount/parser/lexer.l"
 { return OPEN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 286 "beancount/parser/lexer.l"
+#line 295 "beancount/parser/lexer.l"
 { return CLOSE; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 287 "beancount/parser/lexer.l"
+#line 296 "beancount/parser/lexer.l"
 { return COMMODITY; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 288 "beancount/parser/lexer.l"
+#line 297 "beancount/parser/lexer.l"
 { return PAD; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 289 "beancount/parser/lexer.l"
+#line 298 "beancount/parser/lexer.l"
 { return EVENT; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 290 "beancount/parser/lexer.l"
+#line 299 "beancount/parser/lexer.l"
 { return QUERY; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 291 "beancount/parser/lexer.l"
+#line 300 "beancount/parser/lexer.l"
 { return CUSTOM; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 292 "beancount/parser/lexer.l"
+#line 301 "beancount/parser/lexer.l"
 { return PRICE; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 293 "beancount/parser/lexer.l"
+#line 302 "beancount/parser/lexer.l"
 { return NOTE; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 294 "beancount/parser/lexer.l"
+#line 303 "beancount/parser/lexer.l"
 { return DOCUMENT; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 295 "beancount/parser/lexer.l"
+#line 304 "beancount/parser/lexer.l"
 { return PUSHTAG; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 296 "beancount/parser/lexer.l"
+#line 305 "beancount/parser/lexer.l"
 { return POPTAG; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 297 "beancount/parser/lexer.l"
+#line 306 "beancount/parser/lexer.l"
 { return PUSHMETA; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 298 "beancount/parser/lexer.l"
+#line 307 "beancount/parser/lexer.l"
 { return POPMETA; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 299 "beancount/parser/lexer.l"
+#line 308 "beancount/parser/lexer.l"
 { return OPTION; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 300 "beancount/parser/lexer.l"
+#line 309 "beancount/parser/lexer.l"
 { return PLUGIN; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 301 "beancount/parser/lexer.l"
+#line 310 "beancount/parser/lexer.l"
 { return INCLUDE; }
 	YY_BREAK
 /* Boolean values. */
 case 41:
 YY_RULE_SETUP
-#line 304 "beancount/parser/lexer.l"
+#line 313 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_True;
     Py_INCREF(Py_True);
@@ -1730,7 +1739,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 310 "beancount/parser/lexer.l"
+#line 319 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_False;
     Py_INCREF(Py_False);
@@ -1739,7 +1748,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 316 "beancount/parser/lexer.l"
+#line 325 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_None;
     Py_INCREF(Py_None);
@@ -1749,7 +1758,7 @@ YY_RULE_SETUP
 /* Dates. */
 case 44:
 YY_RULE_SETUP
-#line 323 "beancount/parser/lexer.l"
+#line 332 "beancount/parser/lexer.l"
 {
     const char* year_str;
     const char* month_str;
@@ -1774,7 +1783,7 @@ YY_RULE_SETUP
 /* Account names. */
 case 45:
 YY_RULE_SETUP
-#line 345 "beancount/parser/lexer.l"
+#line 354 "beancount/parser/lexer.l"
 {
     BUILD_LEX("ACCOUNT", "s", yytext);
     return ACCOUNT;
@@ -1784,7 +1793,7 @@ YY_RULE_SETUP
   * syntax. This is kept in sync with beancount.core.amount.CURRENCY_RE. */
 case 46:
 YY_RULE_SETUP
-#line 352 "beancount/parser/lexer.l"
+#line 361 "beancount/parser/lexer.l"
 {
     BUILD_LEX("CURRENCY", "s", yytext);
     return CURRENCY;
@@ -1795,7 +1804,7 @@ YY_RULE_SETUP
     See section "Start Conditions" in the GNU Flex manual. */
 case 47:
 YY_RULE_SETUP
-#line 360 "beancount/parser/lexer.l"
+#line 369 "beancount/parser/lexer.l"
 {
     buffer_begin(strbuf);
     BEGIN(STRLIT);
@@ -1805,7 +1814,7 @@ YY_RULE_SETUP
 /* Saw closing quote - all done. */
 case 48:
 YY_RULE_SETUP
-#line 368 "beancount/parser/lexer.l"
+#line 377 "beancount/parser/lexer.l"
 {
         BEGIN(INITIAL);
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
@@ -1824,47 +1833,47 @@ YY_RULE_SETUP
 /* Escape sequences. */
 case 49:
 YY_RULE_SETUP
-#line 384 "beancount/parser/lexer.l"
+#line 393 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\n');
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 385 "beancount/parser/lexer.l"
+#line 394 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\t');
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 386 "beancount/parser/lexer.l"
+#line 395 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\r');
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 387 "beancount/parser/lexer.l"
+#line 396 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\b');
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 388 "beancount/parser/lexer.l"
+#line 397 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\f');
 	YY_BREAK
 case 54:
 /* rule 54 can match eol */
 YY_RULE_SETUP
-#line 389 "beancount/parser/lexer.l"
+#line 398 "beancount/parser/lexer.l"
 buffer_push(strbuf, yytext[1]);
 	YY_BREAK
 /* All other characters. */
 case 55:
 /* rule 55 can match eol */
 YY_RULE_SETUP
-#line 392 "beancount/parser/lexer.l"
+#line 401 "beancount/parser/lexer.l"
 buffer_append(strbuf, yytext, yyleng);
 	YY_BREAK
 
 /* Numbers */
 case 56:
 YY_RULE_SETUP
-#line 396 "beancount/parser/lexer.l"
+#line 405 "beancount/parser/lexer.l"
 {
     BUILD_LEX("NUMBER", "s", yytext);
     return NUMBER;
@@ -1873,7 +1882,7 @@ YY_RULE_SETUP
 /* Tags */
 case 57:
 YY_RULE_SETUP
-#line 402 "beancount/parser/lexer.l"
+#line 411 "beancount/parser/lexer.l"
 {
     BUILD_LEX("TAG", "s", &(yytext[1]));
     return TAG;
@@ -1882,7 +1891,7 @@ YY_RULE_SETUP
 /* Links */
 case 58:
 YY_RULE_SETUP
-#line 408 "beancount/parser/lexer.l"
+#line 417 "beancount/parser/lexer.l"
 {
     BUILD_LEX("LINK", "s", &(yytext[1]));
     return LINK;
@@ -1891,7 +1900,7 @@ YY_RULE_SETUP
 /* Key */
 case 59:
 YY_RULE_SETUP
-#line 414 "beancount/parser/lexer.l"
+#line 423 "beancount/parser/lexer.l"
 {
     BUILD_LEX("KEY", "s#", yytext, (Py_ssize_t)(yyleng-1));
     unput(':');
@@ -1901,7 +1910,7 @@ YY_RULE_SETUP
 /* Default rule. {bf253a29a820} */
 case 60:
 YY_RULE_SETUP
-#line 421 "beancount/parser/lexer.l"
+#line 430 "beancount/parser/lexer.l"
 {
     unput(*yytext);
     BEGIN(INVALID);
@@ -1912,7 +1921,7 @@ YY_RULE_SETUP
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(INVALID):
 case YY_STATE_EOF(STRLIT):
-#line 428 "beancount/parser/lexer.l"
+#line 437 "beancount/parser/lexer.l"
 {
   if ( yy_eof_times == 0 ) {
     yy_eof_times = 1;
@@ -1928,7 +1937,7 @@ case YY_STATE_EOF(STRLIT):
     this and more. {bba169a1d35a} */
 case 61:
 YY_RULE_SETUP
-#line 441 "beancount/parser/lexer.l"
+#line 450 "beancount/parser/lexer.l"
 {
     char buffer[256];
     size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
@@ -1939,10 +1948,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 450 "beancount/parser/lexer.l"
+#line 459 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1945 "beancount/parser/lexer.c"
+#line 1954 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3145,7 +3154,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 450 "beancount/parser/lexer.l"
+#line 459 "beancount/parser/lexer.l"
 
 
 void yylex_initialize(yyscan_t yyscanner)

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -2,7 +2,7 @@
 #define yyHEADER_H 1
 #define yyIN_HEADER 1
 
-#line 6 "beancount/parser/lexer.h"
+#line 5 "beancount/parser/lexer.h"
 
 /* Includes. */
 #include <math.h>
@@ -17,6 +17,11 @@ void build_lexer_error(const char* string, size_t length);
 /* Build and accumulate an error on the builder object using the current
  * exception state. */
 void build_lexer_error_from_exception(void);
+
+int PyFile_Read(PyObject *file, char *buf, size_t max_size);
+
+#define YY_INPUT(buf, result, max_size)                         \
+    result = PyFile_Read((PyObject *)yyin, buf, max_size);
 
 /* Callback call site with error handling. */
 #define BUILD_LEX(method_name, format, ...)                                             \
@@ -75,7 +80,7 @@ int strtonl(const char* buf, size_t nchars);
 	}                                       \
         *strbuf_ptr++ = value;
 
-#line 79 "beancount/parser/lexer.h"
+#line 83 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -576,9 +581,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 411 "beancount/parser/lexer.l"
+#line 415 "beancount/parser/lexer.l"
 
 
-#line 583 "beancount/parser/lexer.h"
+#line 587 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -9,16 +9,12 @@
 typedef struct _yyextra_t yyextra_t;
 
 /* Initialize scanner private data. */
-void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner);
+void yylex_initialize(yyscan_t yyscanner);
 
 /* Free scanner private data */
 void yylex_finalize(yyscan_t yyscanner);
 
-const char* yyget_filename(yyscan_t *scanner);
-
-int yyget_firstline(yyscan_t *scanner);
-
-#line 21 "beancount/parser/lexer.h"
+#line 17 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -532,9 +528,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 460 "beancount/parser/lexer.l"
+#line 450 "beancount/parser/lexer.l"
 
 
-#line 538 "beancount/parser/lexer.h"
+#line 534 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -8,13 +8,21 @@
 
 typedef struct _yyextra_t yyextra_t;
 
-/* Initialize scanner private data. */
-void yylex_initialize(yyscan_t yyscanner);
+/* Allocate a new scanner object including private data. This
+ * encapsulates the cumbersome Flex native yylex_init() API. */
+yyscan_t* yylex_new(void);
 
-/* Free scanner private data */
-void yylex_finalize(yyscan_t yyscanner);
+/* Free scanner object including private data. This encapsulates the
+ * cumbersome Flex native yylex_destroy() API. */
+yyscan_t* yylex_free(yyscan_t scanner);
 
-#line 17 "beancount/parser/lexer.h"
+/* Initialize scanner private data and reset scanner state. */
+void yylex_initialize(yyscan_t scanner, PyObject* file, PyObject* filename, int line, const char* encoding);
+
+PyObject* yyget_filename(yyscan_t scanner);
+int yyget_firstline(yyscan_t scanner);
+
+#line 25 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -528,9 +536,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 457 "beancount/parser/lexer.l"
+#line 473 "beancount/parser/lexer.l"
 
 
-#line 534 "beancount/parser/lexer.h"
+#line 542 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -528,7 +528,7 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 459 "beancount/parser/lexer.l"
+#line 457 "beancount/parser/lexer.l"
 
 
 #line 534 "beancount/parser/lexer.h"

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -4,96 +4,21 @@
 
 #line 5 "beancount/parser/lexer.h"
 
-/* Includes. */
-#include <math.h>
-#include <stdlib.h>
-
 #include "parser.h"
-#include "grammar.h"
 
-/* Build and accumulate an error on the builder object. */
-void build_lexer_error(const char* string, size_t length);
+typedef struct _yyextra_t yyextra_t;
 
-/* Build and accumulate an error on the builder object using the current
- * exception state. */
-void build_lexer_error_from_exception(void);
+/* Initialize scanner private data. */
+void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner);
 
-int PyFile_Read(PyObject *file, char *buf, size_t max_size);
+/* Free scanner private data */
+void yylex_finalize(yyscan_t yyscanner);
 
-#define YY_INPUT(buf, result, max_size)                         \
-    result = PyFile_Read((PyObject *)yyin, buf, max_size);
+const char* yyget_filename(yyscan_t *scanner);
 
-/* Callback call site with error handling. */
-#define BUILD_LEX(method_name, format, ...)                                             \
-    yylval->pyobj = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);     \
-    /* Handle a Python exception raised by the handler {3cfb2739349a} */                \
-    if (yylval->pyobj == NULL) {                                                        \
-       build_lexer_error_from_exception();                                              \
-       return LEX_ERROR;                                                                \
-    }                                                                                   \
-    /* Lexer builder methods should never return None, check for it. */                 \
-    else if (yylval->pyobj == Py_None) {                                                \
-        Py_DECREF(Py_None);                                                             \
-        build_lexer_error("Unexpected None result from lexer", 34);                     \
-        return LEX_ERROR;                                                               \
-    }
+int yyget_firstline(yyscan_t *scanner);
 
-/* Initialization/finalization methods. These are separate from the yylex_init()
- * and yylex_destroy() and they call them. */
-void yylex_initialize(const char* filename, const char* encoding);
-void yylex_finalize(void);
-
-/* Global declarations; defined below. */
-extern int yy_eof_times;
-extern const char* yy_filename;
-extern const char* yy_encoding;
-
-/* String buffer statics. */
-extern size_t strbuf_size; /* Current buffer size (not including final nul). */
-extern char* strbuf;       /* Current buffer head. */
-extern char* strbuf_end;   /* Current buffer sentinel (points to the final nul). */
-extern char* strbuf_ptr;   /* Current insertion point in buffer. */
-void strbuf_realloc(size_t num_new_chars);
-
-/* Handle detecting the beginning of line. */
-extern int yy_line_tokens; /* Number of tokens since the bol. */
-
-#define YY_USER_ACTION  {                               \
-    yy_line_tokens++;                                   \
-    yylloc->first_line = yylloc->last_line = yylineno;  \
-    yylloc->first_column = yycolumn;                    \
-    yylloc->last_column = yycolumn+yyleng-1;            \
-    yycolumn += yyleng;                                 \
-  }
-
-/* Skip the rest of the input line.  This needs to be implemented as a
- * macro because input() and unput() are thmeselves macros tha use
- * variable definitions internal to the yylex() function. */
-#define yy_skip_line()                          \
-    do {                                        \
-        for (;;) {                              \
-            int c = input(yyscanner);           \
-            if (c == EOF || c == -1) {          \
-                break;                          \
-            }                                   \
-            if (c == '\n') {                    \
-                unput(c);                       \
-                break;                          \
-            }                                   \
-        }                                       \
-    } while (0)
-       
-/* Utility functions. */
-int strtonl(const char* buf, size_t nchars);
-
-/* Append characters to the static string buffer and verify. */
-#define SAFE_COPY_CHAR(value)                    \
-	if (strbuf_ptr >= strbuf_end) {         \
-            strbuf_realloc(1);                  \
-	}                                       \
-        *strbuf_ptr++ = value;
- 
-#line 96 "beancount/parser/lexer.h"
+#line 21 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -349,9 +274,7 @@ void yyfree ( void * , yyscan_t yyscanner );
 #include <unistd.h>
 #endif
 
-#ifndef YY_EXTRA_TYPE
-#define YY_EXTRA_TYPE void *
-#endif
+#define YY_EXTRA_TYPE yyextra_t*
 
 int yylex_init (yyscan_t* scanner);
 
@@ -609,9 +532,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 421 "beancount/parser/lexer.l"
+#line 460 "beancount/parser/lexer.l"
 
 
-#line 615 "beancount/parser/lexer.h"
+#line 538 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -19,10 +19,7 @@ yyscan_t* yylex_free(yyscan_t scanner);
 /* Initialize scanner private data and reset scanner state. */
 void yylex_initialize(yyscan_t scanner, PyObject* file, PyObject* filename, int line, const char* encoding);
 
-PyObject* yyget_filename(yyscan_t scanner);
-int yyget_firstline(yyscan_t scanner);
-
-#line 25 "beancount/parser/lexer.h"
+#line 22 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -536,9 +533,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 473 "beancount/parser/lexer.l"
+#line 470 "beancount/parser/lexer.l"
 
 
-#line 542 "beancount/parser/lexer.h"
+#line 539 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -528,7 +528,7 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 450 "beancount/parser/lexer.l"
+#line 459 "beancount/parser/lexer.l"
 
 
 #line 534 "beancount/parser/lexer.h"

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -46,7 +46,6 @@ void yylex_finalize(void);
 /* Global declarations; defined below. */
 extern int yy_eof_times;
 extern const char* yy_filename;
-extern int yycolumn;
 extern const char* yy_encoding;
 
 /* String buffer statics. */
@@ -67,9 +66,23 @@ extern int yy_line_tokens; /* Number of tokens since the bol. */
     yycolumn += yyleng;                                 \
   }
 
-/* Skip the rest of the input line. */
-int yy_skip_line(void);
-
+/* Skip the rest of the input line.  This needs to be implemented as a
+ * macro because input() and unput() are thmeselves macros tha use
+ * variable definitions internal to the yylex() function. */
+#define yy_skip_line()                          \
+    do {                                        \
+        for (;;) {                              \
+            int c = input(yyscanner);           \
+            if (c == EOF || c == -1) {          \
+                break;                          \
+            }                                   \
+            if (c == '\n') {                    \
+                unput(c);                       \
+                break;                          \
+            }                                   \
+        }                                       \
+    } while (0)
+       
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
 
@@ -79,8 +92,8 @@ int strtonl(const char* buf, size_t nchars);
             strbuf_realloc(1);                  \
 	}                                       \
         *strbuf_ptr++ = value;
-
-#line 83 "beancount/parser/lexer.h"
+ 
+#line 96 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -207,6 +220,23 @@ typedef unsigned int flex_uint32_t;
 #define yynoreturn
 #endif
 
+/* An opaque pointer. */
+#ifndef YY_TYPEDEF_YY_SCANNER_T
+#define YY_TYPEDEF_YY_SCANNER_T
+typedef void* yyscan_t;
+#endif
+
+/* For convenience, these vars (plus the bison vars far below)
+   are macros in the reentrant scanner. */
+#define yyin yyg->yyin_r
+#define yyout yyg->yyout_r
+#define yyextra yyg->yyextra_r
+#define yyleng yyg->yyleng_r
+#define yytext yyg->yytext_r
+#define yylineno (YY_CURRENT_BUFFER_LVALUE->yy_bs_lineno)
+#define yycolumn (YY_CURRENT_BUFFER_LVALUE->yy_bs_column)
+#define yy_flex_debug yyg->yy_flex_debug_r
+
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
 #ifdef __ia64__
@@ -229,10 +259,6 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #define YY_TYPEDEF_YY_SIZE_T
 typedef size_t yy_size_t;
 #endif
-
-extern int yyleng;
-
-extern FILE *yyin, *yyout;
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
@@ -285,34 +311,28 @@ struct yy_buffer_state
 	};
 #endif /* !YY_STRUCT_YY_BUFFER_STATE */
 
-void yyrestart ( FILE *input_file  );
-void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
-void yy_delete_buffer ( YY_BUFFER_STATE b  );
-void yy_flush_buffer ( YY_BUFFER_STATE b  );
-void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state ( void );
+void yyrestart ( FILE *input_file , yyscan_t yyscanner );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
+void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+void yypop_buffer_state ( yyscan_t yyscanner );
 
-YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
-void *yyalloc ( yy_size_t  );
-void *yyrealloc ( void *, yy_size_t  );
-void yyfree ( void *  );
+void *yyalloc ( yy_size_t , yyscan_t yyscanner );
+void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
+void yyfree ( void * , yyscan_t yyscanner );
 
 /* Begin user sect3 */
 
-#define yywrap() (/*CONSTCOND*/1)
+#define yywrap(yyscanner) (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
 
-extern int yylineno;
-
-extern char *yytext;
-#ifdef yytext_ptr
-#undef yytext_ptr
-#endif
-#define yytext_ptr yytext
+#define yytext_ptr yytext_r
 
 #ifdef YY_HEADER_EXPORT_START_CONDITIONS
 #define INITIAL 0
@@ -333,42 +353,50 @@ extern char *yytext;
 #define YY_EXTRA_TYPE void *
 #endif
 
+int yylex_init (yyscan_t* scanner);
+
+int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
+
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy ( void );
+int yylex_destroy ( yyscan_t yyscanner );
 
-int yyget_debug ( void );
+int yyget_debug ( yyscan_t yyscanner );
 
-void yyset_debug ( int debug_flag  );
+void yyset_debug ( int debug_flag , yyscan_t yyscanner );
 
-YY_EXTRA_TYPE yyget_extra ( void );
+YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
 
-void yyset_extra ( YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
 
-FILE *yyget_in ( void );
+FILE *yyget_in ( yyscan_t yyscanner );
 
-void yyset_in  ( FILE * _in_str  );
+void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
 
-FILE *yyget_out ( void );
+FILE *yyget_out ( yyscan_t yyscanner );
 
-void yyset_out  ( FILE * _out_str  );
+void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			int yyget_leng ( void );
+			int yyget_leng ( yyscan_t yyscanner );
 
-char *yyget_text ( void );
+char *yyget_text ( yyscan_t yyscanner );
 
-int yyget_lineno ( void );
+int yyget_lineno ( yyscan_t yyscanner );
 
-void yyset_lineno ( int _line_number  );
+void yyset_lineno ( int _line_number , yyscan_t yyscanner );
 
-YYSTYPE * yyget_lval ( void );
+int yyget_column  ( yyscan_t yyscanner );
 
-void yyset_lval ( YYSTYPE * yylval_param  );
+void yyset_column ( int _column_no , yyscan_t yyscanner );
 
-       YYLTYPE *yyget_lloc ( void );
+YYSTYPE * yyget_lval ( yyscan_t yyscanner );
+
+void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
+
+       YYLTYPE *yyget_lloc ( yyscan_t yyscanner );
     
-        void yyset_lloc ( YYLTYPE * yylloc_param  );
+        void yyset_lloc ( YYLTYPE * yylloc_param , yyscan_t yyscanner );
     
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -376,18 +404,18 @@ void yyset_lval ( YYSTYPE * yylval_param  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap ( void );
+extern "C" int yywrap ( yyscan_t yyscanner );
 #else
-extern int yywrap ( void );
+extern int yywrap ( yyscan_t yyscanner );
 #endif
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy ( char *, const char *, int );
+static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen ( const char * );
+static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
@@ -416,10 +444,10 @@ static int yy_flex_strlen ( const char * );
 #define YY_DECL_IS_OURS 1
 
 extern int yylex \
-               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param );
+               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner);
 
 #define YY_DECL int yylex \
-               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param )
+               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner)
 #endif /* !YY_DECL */
 
 /* yy_get_previous_state - get the state just before the EOB char was reached */
@@ -581,9 +609,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 415 "beancount/parser/lexer.l"
+#line 421 "beancount/parser/lexer.l"
 
 
-#line 587 "beancount/parser/lexer.h"
+#line 615 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -1,9 +1,6 @@
 /* -*- mode: c -*- */
 /* A flex lexer for Beancount. */
 
-/*--------------------------------------------------------------------------------------*/
-/* Definitions */
-
 /* Options */
 %option noyywrap
 %option yylineno
@@ -12,14 +9,33 @@
 %option bison-bridge
 %option bison-locations
 %option reentrant
+%option extra-type="yyextra_t*"
 /* %option nodefault */
 /* %option debug */
 /* %option stack */
 /* %option 8bit */
 
-
-/* Top Code. */
+/* Top Code. This is included in the FLex generated header file. */
 %top{
+
+#include "parser.h"
+
+typedef struct _yyextra_t yyextra_t;
+
+/* Initialize scanner private data. */
+void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner);
+
+/* Free scanner private data */
+void yylex_finalize(yyscan_t yyscanner);
+
+const char* yyget_filename(yyscan_t *scanner);
+
+int yyget_firstline(yyscan_t *scanner);
+
+}
+
+/* Definitions. */
+%{
 
 /* Includes. */
 #include <math.h>
@@ -28,6 +44,70 @@
 #include "parser.h"
 #include "grammar.h"
 
+struct buffer {
+    char* buf;
+    char* ptr;
+    char* end;
+};
+
+struct _yyextra_t {
+    /* The number of times EOF has been hit. This is used to
+     * synthesize an EOL at the end of the file. */
+    int n_eof;
+    /* Number of tokens since the beginning of the line. */
+    int n_line_tokens;
+    /* The filename being tokenized. */
+    const char* filename;
+    /* Reporting line offset. This is used like the #line cpp macro */
+    int line;
+    /* The encoding to use for converting strings. */
+    const char* encoding;
+    /* Variable size buffer used to accumulate string data. */
+    struct buffer str;
+};
+
+static void buffer_init(struct buffer* b, size_t size);
+static void buffer_free(struct buffer* b);
+static void buffer_realloc(struct buffer* b, size_t num_new_chars);
+
+static inline void buffer_push(struct buffer* b, char value)
+{
+    if (b->ptr > b->end)
+        buffer_realloc(b, 1);
+    *b->ptr++ = value;
+}
+
+static inline void buffer_append(struct buffer* b, const char* data, ssize_t len)
+{
+    if (len > (b->end - b->ptr))
+        buffer_realloc(b, len);
+
+    memcpy(b->ptr, data, len);
+
+    b->ptr += len;
+}
+
+static inline size_t buffer_strlen(const struct buffer* b)
+{
+    return b->ptr - b->buf;
+}
+
+static inline char* buffer_data(const struct buffer* b)
+{
+    return b->buf;
+}
+
+static inline void buffer_begin(struct buffer* b)
+{
+    b->ptr = b->buf;
+}
+
+#define strbuf &yyget_extra(yyscanner)->str
+#define yy_eof_times yyget_extra(yyscanner)->n_eof
+#define yy_line_tokens yyget_extra(yyscanner)->n_line_tokens
+#define yy_filename yyget_extra(yyscanner)->filename
+#define yy_firstline yyget_extra(yyscanner)->line
+#define yy_encoding yyget_extra(yyscanner)->encoding
 
 /* Build and accumulate an error on the builder object. */
 void build_lexer_error(const char* string, size_t length);
@@ -40,7 +120,6 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
 
 #define YY_INPUT(buf, result, max_size)                         \
     result = PyFile_Read((PyObject *)yyin, buf, max_size);
-
 
 /* Callback call site with error handling. */
 #define BUILD_LEX(method_name, format, ...)                                             \
@@ -57,33 +136,13 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
         return LEX_ERROR;                                                               \
     }
 
-/* Initialization/finalization methods. These are separate from the yylex_init()
- * and yylex_destroy() and they call them. */
-void yylex_initialize(const char* filename, const char* encoding);
-void yylex_finalize(void);
-
-/* Global declarations; defined below. */
-extern int yy_eof_times;
-extern const char* yy_filename;
-extern const char* yy_encoding;
-
-/* String buffer statics. */
-extern size_t strbuf_size; /* Current buffer size (not including final nul). */
-extern char* strbuf;       /* Current buffer head. */
-extern char* strbuf_end;   /* Current buffer sentinel (points to the final nul). */
-extern char* strbuf_ptr;   /* Current insertion point in buffer. */
-void strbuf_realloc(size_t num_new_chars);
-
-/* Handle detecting the beginning of line. */
-extern int yy_line_tokens; /* Number of tokens since the bol. */
-
-#define YY_USER_ACTION  {                               \
-    yy_line_tokens++;                                   \
-    yylloc->first_line = yylloc->last_line = yylineno;  \
-    yylloc->first_column = yycolumn;                    \
-    yylloc->last_column = yycolumn+yyleng-1;            \
-    yycolumn += yyleng;                                 \
-  }
+#define YY_USER_ACTION {                                        \
+        yy_line_tokens++;                                       \
+        yylloc->first_line = yylloc->last_line = yylineno;      \
+        yylloc->first_column = yycolumn;                        \
+        yylloc->last_column = yycolumn+yyleng-1;                \
+        yycolumn += yyleng;                                     \
+    }
 
 /* Skip the rest of the input line.  This needs to be implemented as a
  * macro because input() and unput() are thmeselves macros tha use
@@ -101,18 +160,11 @@ extern int yy_line_tokens; /* Number of tokens since the bol. */
             }                                   \
         }                                       \
     } while (0)
-       
+
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
 
-/* Append characters to the static string buffer and verify. */
-#define SAFE_COPY_CHAR(value)                    \
-	if (strbuf_ptr >= strbuf_end) {         \
-            strbuf_realloc(1);                  \
-	}                                       \
-        *strbuf_ptr++ = value;
- 
-}
+%}
 
 /* A start condition for chomping an invalid token. */
 %x INVALID
@@ -133,10 +185,7 @@ ACCOUNTTYPE     ([A-Z]|{UTF-8-ONLY})([A-Za-z0-9\-]|{UTF-8-ONLY})*
 ACCOUNTNAME     ([A-Z0-9]|{UTF-8-ONLY})([A-Za-z0-9\-]|{UTF-8-ONLY})*
 
 
-/*--------------------------------------------------------------------------------------*/
-/* Rules */
-%%
-
+%% /* Rules */
 
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
 \n		{
@@ -318,7 +367,7 @@ NULL		{
  /* Note that we use an exclusive start condition.
     See section "Start Conditions" in the GNU Flex manual. */
 \"	{
-    strbuf_ptr = strbuf;
+    buffer_begin(strbuf);
     BEGIN(STRLIT);
 }
 
@@ -327,39 +376,29 @@ NULL		{
     /* Saw closing quote - all done. */
     \"        {
         BEGIN(INITIAL);
-        *strbuf_ptr = '\0';
-        PyObject* unicode_str = PyUnicode_Decode(strbuf, strbuf_ptr - strbuf,
-                                                 yy_encoding, "ignore");
-        if ( unicode_str == NULL ) {
+        PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
+                                         yy_encoding, "ignore");
+        if (!str) {
             build_lexer_error_from_exception();
             yylval->pyobj = Py_None;
             Py_INCREF(Py_None);
             return LEX_ERROR;
         }
-        BUILD_LEX("STRING", "O", unicode_str);
-        Py_DECREF(unicode_str);
-        strbuf_ptr = NULL;
+        BUILD_LEX("STRING", "O", str);
+        Py_DECREF(str);
         return STRING;
     }
 
     /* Escape sequences. */
-    \\n       SAFE_COPY_CHAR('\n');
-    \\t       SAFE_COPY_CHAR('\t');
-    \\r       SAFE_COPY_CHAR('\r');
-    \\b       SAFE_COPY_CHAR('\b');
-    \\f       SAFE_COPY_CHAR('\f');
-    \\(.|\n)  SAFE_COPY_CHAR(yytext[1]);
+    \\n       buffer_push(strbuf, '\n');
+    \\t       buffer_push(strbuf, '\t');
+    \\r       buffer_push(strbuf, '\r');
+    \\b       buffer_push(strbuf, '\b');
+    \\f       buffer_push(strbuf, '\f');
+    \\(.|\n)  buffer_push(strbuf, yytext[1]);
 
     /* All other characters. */
-    [^\\\"]+        {
-        if ( yyleng > (strbuf_end - strbuf_ptr) ) {
-            strbuf_realloc(yyleng);
-        }
-        ssize_t i;
-        for (i = 0; i < yyleng; ++i) {
-            *strbuf_ptr++ = yytext[i];
-        }
-    }
+    [^\\\"]+  buffer_append(strbuf, yytext, yyleng);
 }
 
  /* Numbers */
@@ -417,78 +456,64 @@ NULL		{
 }
 
 
-%%
-/*--------------------------------------------------------------------------------------*/
-/* User Code */
+%% /* User Code */
 
-
-/* Note: All these globals should be moved to an yylex_extra */
-
-/* The number of times EOF has been hit. This is used to synthesize an EOL at
- * the end of the file. */
-int yy_eof_times = 0;
-
-/* The filename being tokenized. */
-const char* yy_filename = 0;
-
-/* Number of tokens since the beginning of the line. */
-int yy_line_tokens = 0;
-
-/* The encoding to use for converting strings. */
-const char* yy_encoding = NULL;
-
-/* A buffer for parsing string literals. It is reused and its size is dynamically allocated. */
-size_t strbuf_size = 0;
-char* strbuf = NULL;
-char* strbuf_end;
-char* strbuf_ptr;
-
-/* Initialize the globals before running the lexer. */
-void yylex_initialize(const char* filename, const char* encoding)
+void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner)
 {
-    assert(filename != NULL);
+    yyset_extra(malloc(sizeof(yyextra_t)), yyscanner);
+
     yy_eof_times = 0;
-    yy_filename = filename ?: "";
     yy_line_tokens = 0;
-    if ( encoding == 0 ) {
-        yy_encoding = "utf8";
-    }
-    else {
-        yy_encoding = encoding;
-    }
-
-    /* Start with a decent small buffer. */
-    strbuf_size = 1024;
-    strbuf = realloc(strbuf, strbuf_size + 1);
-    strbuf_end = strbuf + strbuf_size - 1;
-    strbuf_ptr = NULL;
+    yy_filename = filename ?: "";
+    yy_firstline = firstline;
+    yy_encoding = encoding ?: "utf-8";
+    buffer_init(strbuf, 1024);
 }
 
-/* Finalize the globals before running the lexer. */
-void yylex_finalize(void)
+void yylex_finalize(yyscan_t yyscanner)
 {
-    yy_filename = NULL;
-
-    /* Finalize our reading buffer. */
-    if ( strbuf != NULL ) {
-        free(strbuf);
-        strbuf = NULL;
-    }
+    buffer_free(strbuf);
+    free(yyget_extra(yyscanner));
 }
 
-
-/* Reallocate the buffer to accommodate some new characters. */
-void strbuf_realloc(size_t num_new_chars)
+const char* yyget_filename(yyscan_t *scanner)
 {
-    assert(strbuf_ptr != NULL);
-    size_t cur_size = strbuf_ptr - strbuf;
+    return yyget_extra(scanner)->filename;
+}
+
+int yyget_firstline(yyscan_t *scanner)
+{
+    return yyget_extra(scanner)->line;
+}
+
+static void buffer_init(struct buffer* b, size_t size)
+{
+    b->buf = malloc(size);
+    b->end = b->buf + size - 1;
+    b->ptr = b->buf;
+}
+
+static void buffer_free(struct buffer* b)
+{
+    free(b->buf);
+    b->buf = b->ptr = b->end = NULL;
+}
+
+static void buffer_realloc(struct buffer* b, size_t num_new_chars)
+{
+    assert(b->ptr != NULL);
+
+    size_t size = b->end - b->buf + 1;
+    size_t cur_size = b->ptr - b->buf;
     size_t new_size = cur_size + num_new_chars;
-    while ( strbuf_size < new_size ) {
-        strbuf_size <<= 1;
-    }
-    strbuf = realloc(strbuf, strbuf_size + 1);
-    strbuf_ptr = strbuf + cur_size;
-    strbuf_end = strbuf + strbuf_size - 1;
+
+    while (size < new_size)
+        size <<= 1;
+
+    b->buf = realloc(b->buf, size);
+
+    b->ptr = b->buf + cur_size;
+    b->end = b->buf + size - 1;
 }
 
 /* Convert an integer string to a number. */

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -100,7 +100,7 @@ static inline void buffer_begin(struct buffer* b)
 #define yy_encoding ((Parser*)parser)->encoding
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(PyObject* builder, const char* string, size_t length);
+void build_lexer_error(PyObject* builder, const char* format, ...);
 
 /* Build and accumulate an error on the builder object using the current
  * exception state. */
@@ -112,25 +112,25 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
     result = PyFile_Read((PyObject *)yyin, buf, max_size);
 
 /* Callback call site with error handling. */
-#define BUILD_LEX(method_name, format, ...)                                             \
-    yylval->pyobj = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);     \
-    /* Handle a Python exception raised by the handler {3cfb2739349a} */                \
-    if (yylval->pyobj == NULL) {                                                        \
-       build_lexer_error_from_exception(builder);                                       \
-       return LEX_ERROR;                                                                \
-    }                                                                                   \
-    /* Lexer builder methods should never return None, check for it. */                 \
-    else if (yylval->pyobj == Py_None) {                                                \
-        Py_DECREF(Py_None);                                                             \
-        build_lexer_error(builder, "Unexpected None result from lexer", 34);            \
-        return LEX_ERROR;                                                               \
+#define BUILD(method_name, format, ...)                                 \
+    yylval->pyobj = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);  \
+    if (yylval->pyobj == NULL) {                                        \
+        build_lexer_error_from_exception(builder);                      \
+        return LEX_ERROR;                                               \
+    }                                                                   \
+    if (yylval->pyobj == Py_None) {                                     \
+        Py_DECREF(Py_None);                                             \
+        build_lexer_error(builder,                                      \
+                          "ValueError: None return value from %s.%s",   \
+                          Py_TYPE(builder)->tp_name, method_name);      \
+        return LEX_ERROR;                                               \
     }
 
 #define YY_USER_ACTION {                                        \
         yy_line_tokens++;                                       \
         yylloc->first_line = yylloc->last_line = yylineno;      \
         yylloc->first_column = yycolumn;                        \
-        yylloc->last_column = yycolumn+yyleng-1;                \
+        yylloc->last_column = yycolumn + yyleng - 1;            \
         yycolumn += yyleng;                                     \
     }
 
@@ -345,20 +345,20 @@ NULL		{
     day = strtonl(day_str, yytext + yyleng - day_str);
 
     /* Attempt to create the date. */
-    BUILD_LEX("DATE", "iii", year, month, day);
+    BUILD("DATE", "iii", year, month, day);
     return DATE;
 }
 
  /* Account names. */
 {ACCOUNTTYPE}(:{ACCOUNTNAME})+		{
-    BUILD_LEX("ACCOUNT", "s", yytext);
+    BUILD("ACCOUNT", "s", yytext);
     return ACCOUNT;
 }
 
  /* Currencies. These are defined as uppercase only in order to disambiguate the
   * syntax. This is kept in sync with beancount.core.amount.CURRENCY_RE. */
 [A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9]	{
-    BUILD_LEX("CURRENCY", "s", yytext);
+    BUILD("CURRENCY", "s", yytext);
     return CURRENCY;
 }
 
@@ -383,7 +383,7 @@ NULL		{
             Py_INCREF(Py_None);
             return LEX_ERROR;
         }
-        BUILD_LEX("STRING", "O", str);
+        BUILD("STRING", "O", str);
         Py_DECREF(str);
         return STRING;
     }
@@ -402,25 +402,25 @@ NULL		{
 
  /* Numbers */
 ([0-9]+|[0-9][0-9,]+[0-9])(\.[0-9]*)? 		{
-    BUILD_LEX("NUMBER", "s", yytext);
+    BUILD("NUMBER", "s", yytext);
     return NUMBER;
 }
 
  /* Tags */
 #[A-Za-z0-9\-_/.]+ 		{
-    BUILD_LEX("TAG", "s", &(yytext[1]));
+    BUILD("TAG", "s", &(yytext[1]));
     return TAG;
 }
 
  /* Links */
 \^[A-Za-z0-9\-_/.]+ 		{
-    BUILD_LEX("LINK", "s", &(yytext[1]));
+    BUILD("LINK", "s", &(yytext[1]));
     return LINK;
 }
 
  /* Key */
 [a-z][a-zA-Z0-9\-_]+: 		{
-    BUILD_LEX("KEY", "s#", yytext, (Py_ssize_t)(yyleng-1));
+    BUILD("KEY", "s#", yytext, (Py_ssize_t)(yyleng - 1));
     unput(':');
     return KEY;
 }
@@ -447,9 +447,7 @@ NULL		{
     longer and thus would break the lexer. Writing our own lexer would fix
     this and more. {bba169a1d35a} */
 <INVALID>[^ \t\n\r]+     {
-    char buffer[256];
-    size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
-    build_lexer_error(builder, buffer, length);
+    build_lexer_error(builder, "Invalid token: '%s'", yytext);
     BEGIN(INITIAL);
     return LEX_ERROR;
 }
@@ -514,51 +512,50 @@ int strtonl(const char* buf, size_t nchars)
 }
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(PyObject* builder, const char* string, size_t length)
+void build_lexer_error(PyObject* builder, const char* format, ...)
 {
-    TRACE_ERROR("Invalid Token");
+    PyObject* error = NULL;
+    PyObject* rv = NULL;
+    va_list va;
+
+    va_start(va, format);
+    error = PyUnicode_FromFormatV(format, va);
+    va_end(va);
+
+    if (!error)
+        return;
 
     /* Build and accumulate a new error object. {27d1d459c5cd} */
-    PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error",
-                                       "s#", string, (Py_ssize_t)length);
-    if (rv == NULL) {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "Internal error: Building exception from default rule");
-    }
+    rv = PyObject_CallMethod(builder, "build_lexer_error", "(O)", error);
+
+    Py_XDECREF(error);
     Py_XDECREF(rv);
 }
 
 void build_lexer_error_from_exception(PyObject* builder)
 {
-    TRACE_ERROR("Lexer Builder Exception");
+    PyObject* ptraceback = NULL;
+    PyObject* pvalue = NULL;
+    PyObject* ptype = NULL;
+    PyObject* rv = NULL;
 
     /* Get the exception context. */
-    PyObject* ptype = NULL;
-    PyObject* pvalue = NULL;
-    PyObject* ptraceback = NULL;
     PyErr_Fetch(&ptype, &pvalue, &ptraceback);
     PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
 
     /* Clear the exception. */
     PyErr_Clear();
 
-    if (pvalue != NULL) {
+    if (pvalue)
         /* Build and accumulate a new error object. {27d1d459c5cd} */
-        PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error",
-                                           "OO", pvalue, ptype);
-        Py_XDECREF(ptype);
-        Py_XDECREF(pvalue);
-        Py_XDECREF(ptraceback);
+        rv = PyObject_CallMethod(builder, "build_lexer_error", "OO", pvalue, ptype);
+    else
+        PyErr_SetString(PyExc_RuntimeError, "No exception");
 
-        if (rv == NULL) {
-            PyErr_SetString(PyExc_RuntimeError,
-                            "Internal error: While building exception");
-        }
-    }
-    else {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "Internal error: No exception");
-    }
+    Py_XDECREF(rv);
+    Py_XDECREF(ptype);
+    Py_XDECREF(pvalue);
+    Py_XDECREF(ptraceback);
 }
 
 int PyFile_Read(PyObject *file, char *buf, size_t max_size)

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -177,6 +177,15 @@ ACCOUNTNAME     ([A-Z0-9]|{UTF-8-ONLY})([A-Za-z0-9\-]|{UTF-8-ONLY})*
 
 %% /* Rules */
 
+%{
+    /* If a Python exception has been raised, return immediately. This is
+     * useful to catch exceptions raised in the YY_INPUT routine or other
+     * exceptions not explicitly handled. */
+    if (PyErr_Occurred()) {
+        return -1;
+    }
+%}
+
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
 \n		{
     yy_line_tokens = 0;

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -1,5 +1,5 @@
 /* -*- mode: c -*- */
-/* A flex lexer for Beancount. */
+/* A Flex lexer for Beancount. */
 
 /* Options */
 %option noyywrap
@@ -22,22 +22,28 @@
 
 typedef struct _yyextra_t yyextra_t;
 
-/* Initialize scanner private data. */
-void yylex_initialize(yyscan_t yyscanner);
+/* Allocate a new scanner object including private data. This
+ * encapsulates the cumbersome Flex native yylex_init() API. */
+yyscan_t* yylex_new(void);
 
-/* Free scanner private data */
-void yylex_finalize(yyscan_t yyscanner);
+/* Free scanner object including private data. This encapsulates the
+ * cumbersome Flex native yylex_destroy() API. */
+yyscan_t* yylex_free(yyscan_t scanner);
+
+/* Initialize scanner private data and reset scanner state. */
+void yylex_initialize(yyscan_t scanner, PyObject* file, PyObject* filename, int line, const char* encoding);
+
+PyObject* yyget_filename(yyscan_t scanner);
+int yyget_firstline(yyscan_t scanner);
 
 }
 
 /* Definitions. */
 %{
 
-/* Includes. */
 #include <math.h>
 #include <stdlib.h>
 
-#include "parser.h"
 #include "grammar.h"
 
 struct buffer {
@@ -47,6 +53,12 @@ struct buffer {
 };
 
 struct _yyextra_t {
+    /* The filename being tokenized. */
+    PyObject* filename;
+    /* Reporting line offset. This is used like the #line cpp macro */
+    int line;
+    /* The encoding to use for converting strings. */
+    const char* encoding;
     /* The number of times EOF has been hit. This is used to
      * synthesize an EOL at the end of the file. */
     int n_eof;
@@ -87,7 +99,7 @@ static inline char* buffer_data(const struct buffer* b)
     return b->buf;
 }
 
-static inline void buffer_begin(struct buffer* b)
+static inline void buffer_beginning(struct buffer* b)
 {
     b->ptr = b->buf;
 }
@@ -95,9 +107,9 @@ static inline void buffer_begin(struct buffer* b)
 #define strbuf &yyget_extra(yyscanner)->str
 #define yy_eof_times yyget_extra(yyscanner)->n_eof
 #define yy_line_tokens yyget_extra(yyscanner)->n_line_tokens
-#define yy_filename ((Parser*)parser)->filename
-#define yy_firstline ((Parser*)parser)->line
-#define yy_encoding ((Parser*)parser)->encoding
+#define yy_filename yyget_extra(yyscanner)->filename
+#define yy_firstline yyget_extra(yyscanner)->line
+#define yy_encoding yyget_extra(yyscanner)->encoding
 
 /* Build and accumulate an error on the builder object. */
 void build_lexer_error(PyObject* builder, const char* format, ...);
@@ -126,12 +138,15 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
         return LEX_ERROR;                                               \
     }
 
-#define YY_USER_ACTION {                                        \
-        yy_line_tokens++;                                       \
-        yylloc->first_line = yylloc->last_line = yylineno;      \
-        yylloc->first_column = yycolumn;                        \
-        yylloc->last_column = yycolumn + yyleng - 1;            \
-        yycolumn += yyleng;                                     \
+#define YY_USER_ACTION                                                  \
+    {                                                                   \
+        yy_line_tokens++;                                               \
+        yylloc->first_line = yylineno + yy_firstline;                   \
+        yylloc->last_line = yylloc->first_line;                         \
+        yylloc->first_column = yycolumn;                                \
+        yylloc->last_column = yycolumn + yyleng - 1;                    \
+        yylloc->file_name = yy_filename;                                \
+        yycolumn += yyleng;                                             \
     }
 
 /* Skip the rest of the input line.  This needs to be implemented as a
@@ -366,7 +381,7 @@ NULL		{
  /* Note that we use an exclusive start condition.
     See section "Start Conditions" in the GNU Flex manual. */
 \"	{
-    buffer_begin(strbuf);
+    buffer_beginning(strbuf);
     BEGIN(STRLIT);
 }
 
@@ -434,10 +449,11 @@ NULL		{
  /* Fake an EOL at the end of file, to ensure that files without a final newline
   * will process postings right. */
 <<EOF>>     		{
-  if ( yy_eof_times == 0 ) {
-    yy_eof_times = 1;
-    yylloc->first_line = yylineno;
-    return EOL;
+  if (yy_eof_times == 0) {
+      yy_eof_times = 1;
+      /* Ensure location data is populated. */
+      YY_USER_ACTION;
+      return EOL;
   }
   return 0;
 }
@@ -455,18 +471,95 @@ NULL		{
 
 %% /* User Code */
 
-void yylex_initialize(yyscan_t yyscanner)
+yyscan_t* yylex_new(void)
 {
-    yyset_extra(malloc(sizeof(yyextra_t)), yyscanner);
-    yy_eof_times = 0;
-    yy_line_tokens = 0;
-    buffer_init(strbuf, 1024);
+    yyscan_t scanner;
+    yyextra_t* extra;
+
+    extra = malloc(sizeof(*extra));
+    if (!extra)
+        return NULL;
+
+    extra->filename = PyUnicode_FromString("");
+    if (!extra->filename) {
+        free(extra);
+        return NULL;
+    }
+
+    buffer_init(&extra->str, 1024);
+
+    if (yylex_init_extra(extra, &scanner)) {
+        free(extra);
+        return NULL;
+    }
+
+    return scanner;
 }
 
-void yylex_finalize(yyscan_t yyscanner)
+yyscan_t* yylex_free(yyscan_t scanner)
 {
-    buffer_free(strbuf);
-    free(yyget_extra(yyscanner));
+    yyextra_t* extra = yyget_extra(scanner);
+
+    Py_XDECREF(yyget_in(scanner));
+    Py_XDECREF(extra->filename);
+    buffer_free(&extra->str);
+    free(extra);
+    yylex_destroy(scanner);
+
+    return NULL;
+}
+
+/* yyrestart() does not reset the scanner start back to INITIAL and
+ * Flex does not provide a way of doing so outside a scanner
+ * relu. This function does just that accessing Flex internals. */
+static void yybegin(yyscan_t scanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)scanner;
+    BEGIN(INITIAL);
+}
+
+void yylex_initialize(yyscan_t scanner, PyObject* file, PyObject* filename, int line, const char* encoding)
+{
+    yyextra_t* extra = yyget_extra(scanner);
+
+    Py_XDECREF(yyget_in(scanner));
+    yyrestart((void*)file, scanner);
+    Py_INCREF(file);
+    yybegin(scanner);
+
+    /* If a filename has not been specified explicitly, try to get it
+     * from the file object. The io.BaseIO object returned from open()
+     * stores the file path in the 'name' property. */
+    if (!filename || filename == Py_None) {
+        filename = PyObject_GetAttrString(file, "name");
+        if (!filename)
+            PyErr_Clear();
+    }
+
+    if (filename && filename != Py_None) {
+        Py_XDECREF(extra->filename);
+        extra->filename = filename;
+        Py_INCREF(filename);
+    }
+
+    extra->encoding = encoding ? encoding : "utf-8";
+    extra->line = line;
+    extra->n_eof = 0;
+    extra->n_line_tokens = 0;
+
+    buffer_beginning(&extra->str);
+}
+
+PyObject* yyget_filename(yyscan_t scanner)
+{
+    yyextra_t* extra = yyget_extra(scanner);
+    return extra->filename;
+}
+
+int yyget_firstline(yyscan_t scanner)
+{
+    yyextra_t* extra = yyget_extra(scanner);
+    return extra->line;
 }
 
 static void buffer_init(struct buffer* b, size_t size)

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -33,9 +33,6 @@ yyscan_t* yylex_free(yyscan_t scanner);
 /* Initialize scanner private data and reset scanner state. */
 void yylex_initialize(yyscan_t scanner, PyObject* file, PyObject* filename, int line, const char* encoding);
 
-PyObject* yyget_filename(yyscan_t scanner);
-int yyget_firstline(yyscan_t scanner);
-
 }
 
 /* Definitions. */
@@ -548,18 +545,6 @@ void yylex_initialize(yyscan_t scanner, PyObject* file, PyObject* filename, int 
     extra->n_line_tokens = 0;
 
     buffer_beginning(&extra->str);
-}
-
-PyObject* yyget_filename(yyscan_t scanner)
-{
-    yyextra_t* extra = yyget_extra(scanner);
-    return extra->filename;
-}
-
-int yyget_firstline(yyscan_t scanner)
-{
-    yyextra_t* extra = yyget_extra(scanner);
-    return extra->line;
 }
 
 static void buffer_init(struct buffer* b, size_t size)

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -112,11 +112,11 @@ static inline void buffer_beginning(struct buffer* b)
 #define yy_encoding yyget_extra(yyscanner)->encoding
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(PyObject* builder, const char* format, ...);
+void build_lexer_error(YYLTYPE* loc, PyObject* builder, const char* format, ...);
 
 /* Build and accumulate an error on the builder object using the current
  * exception state. */
-void build_lexer_error_from_exception(PyObject* builder);
+void build_lexer_error_from_exception(YYLTYPE* loc, PyObject* builder);
 
 int PyFile_Read(PyObject *file, char *buf, size_t max_size);
 
@@ -125,14 +125,14 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
 
 /* Callback call site with error handling. */
 #define BUILD(method_name, format, ...)                                 \
-    yylval->pyobj = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);  \
+    yylval->pyobj = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__); \
     if (yylval->pyobj == NULL) {                                        \
-        build_lexer_error_from_exception(builder);                      \
+        build_lexer_error_from_exception(yylloc, builder);              \
         return LEX_ERROR;                                               \
     }                                                                   \
     if (yylval->pyobj == Py_None) {                                     \
-        Py_DECREF(Py_None);                                             \
-        build_lexer_error(builder,                                      \
+        Py_DECREF(yylval->pyobj);                                       \
+        build_lexer_error(yylloc, builder,                              \
                           "ValueError: None return value from %s.%s",   \
                           Py_TYPE(builder)->tp_name, method_name);      \
         return LEX_ERROR;                                               \
@@ -393,7 +393,7 @@ NULL		{
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
                                          yy_encoding, "ignore");
         if (!str) {
-            build_lexer_error_from_exception(builder);
+            build_lexer_error_from_exception(yylloc, builder);
             yylval->pyobj = Py_None;
             Py_INCREF(Py_None);
             return LEX_ERROR;
@@ -463,7 +463,7 @@ NULL		{
     longer and thus would break the lexer. Writing our own lexer would fix
     this and more. {bba169a1d35a} */
 <INVALID>[^ \t\n\r]+     {
-    build_lexer_error(builder, "Invalid token: '%s'", yytext);
+    build_lexer_error(yylloc, builder, "Invalid token: '%s'", yytext);
     BEGIN(INITIAL);
     return LEX_ERROR;
 }
@@ -605,7 +605,7 @@ int strtonl(const char* buf, size_t nchars)
 }
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(PyObject* builder, const char* format, ...)
+void build_lexer_error(YYLTYPE* loc, PyObject* builder, const char* format, ...)
 {
     PyObject* error = NULL;
     PyObject* rv = NULL;
@@ -619,13 +619,14 @@ void build_lexer_error(PyObject* builder, const char* format, ...)
         return;
 
     /* Build and accumulate a new error object. {27d1d459c5cd} */
-    rv = PyObject_CallMethod(builder, "build_lexer_error", "(O)", error);
+    rv = PyObject_CallMethod(builder, "build_lexer_error", "OiO",
+                             loc->file_name, loc->first_line, error);
 
     Py_XDECREF(error);
     Py_XDECREF(rv);
 }
 
-void build_lexer_error_from_exception(PyObject* builder)
+void build_lexer_error_from_exception(YYLTYPE* loc, PyObject* builder)
 {
     PyObject* ptraceback = NULL;
     PyObject* pvalue = NULL;
@@ -641,7 +642,8 @@ void build_lexer_error_from_exception(PyObject* builder)
 
     if (pvalue)
         /* Build and accumulate a new error object. {27d1d459c5cd} */
-        rv = PyObject_CallMethod(builder, "build_lexer_error", "OO", pvalue, ptype);
+        rv = PyObject_CallMethod(builder, "build_lexer_error", "OiOO",
+                                 loc->file_name, loc->first_line, pvalue, ptype);
     else
         PyErr_SetString(PyExc_RuntimeError, "No exception");
 

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -23,14 +23,10 @@
 typedef struct _yyextra_t yyextra_t;
 
 /* Initialize scanner private data. */
-void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner);
+void yylex_initialize(yyscan_t yyscanner);
 
 /* Free scanner private data */
 void yylex_finalize(yyscan_t yyscanner);
-
-const char* yyget_filename(yyscan_t *scanner);
-
-int yyget_firstline(yyscan_t *scanner);
 
 }
 
@@ -56,12 +52,6 @@ struct _yyextra_t {
     int n_eof;
     /* Number of tokens since the beginning of the line. */
     int n_line_tokens;
-    /* The filename being tokenized. */
-    const char* filename;
-    /* Reporting line offset. This is used like the #line cpp macro */
-    int line;
-    /* The encoding to use for converting strings. */
-    const char* encoding;
     /* Variable size buffer used to accumulate string data. */
     struct buffer str;
 };
@@ -105,16 +95,16 @@ static inline void buffer_begin(struct buffer* b)
 #define strbuf &yyget_extra(yyscanner)->str
 #define yy_eof_times yyget_extra(yyscanner)->n_eof
 #define yy_line_tokens yyget_extra(yyscanner)->n_line_tokens
-#define yy_filename yyget_extra(yyscanner)->filename
-#define yy_firstline yyget_extra(yyscanner)->line
-#define yy_encoding yyget_extra(yyscanner)->encoding
+#define yy_filename ((Parser*)parser)->filename
+#define yy_firstline ((Parser*)parser)->line
+#define yy_encoding ((Parser*)parser)->encoding
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(const char* string, size_t length);
+void build_lexer_error(PyObject* builder, const char* string, size_t length);
 
 /* Build and accumulate an error on the builder object using the current
  * exception state. */
-void build_lexer_error_from_exception(void);
+void build_lexer_error_from_exception(PyObject* builder);
 
 int PyFile_Read(PyObject *file, char *buf, size_t max_size);
 
@@ -126,13 +116,13 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
     yylval->pyobj = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);     \
     /* Handle a Python exception raised by the handler {3cfb2739349a} */                \
     if (yylval->pyobj == NULL) {                                                        \
-       build_lexer_error_from_exception();                                              \
+       build_lexer_error_from_exception(builder);                                       \
        return LEX_ERROR;                                                                \
     }                                                                                   \
     /* Lexer builder methods should never return None, check for it. */                 \
     else if (yylval->pyobj == Py_None) {                                                \
         Py_DECREF(Py_None);                                                             \
-        build_lexer_error("Unexpected None result from lexer", 34);                     \
+        build_lexer_error(builder, "Unexpected None result from lexer", 34);            \
         return LEX_ERROR;                                                               \
     }
 
@@ -379,7 +369,7 @@ NULL		{
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
                                          yy_encoding, "ignore");
         if (!str) {
-            build_lexer_error_from_exception();
+            build_lexer_error_from_exception(builder);
             yylval->pyobj = Py_None;
             Py_INCREF(Py_None);
             return LEX_ERROR;
@@ -450,7 +440,7 @@ NULL		{
 <INVALID>[^ \t\n\r]+     {
     char buffer[256];
     size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
-    build_lexer_error(buffer, length);
+    build_lexer_error(builder, buffer, length);
     BEGIN(INITIAL);
     return LEX_ERROR;
 }
@@ -458,15 +448,11 @@ NULL		{
 
 %% /* User Code */
 
-void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner)
+void yylex_initialize(yyscan_t yyscanner)
 {
     yyset_extra(malloc(sizeof(yyextra_t)), yyscanner);
-
     yy_eof_times = 0;
     yy_line_tokens = 0;
-    yy_filename = filename ?: "";
-    yy_firstline = firstline;
-    yy_encoding = encoding ?: "utf-8";
     buffer_init(strbuf, 1024);
 }
 
@@ -474,16 +460,6 @@ void yylex_finalize(yyscan_t yyscanner)
 {
     buffer_free(strbuf);
     free(yyget_extra(yyscanner));
-}
-
-const char* yyget_filename(yyscan_t *scanner)
-{
-    return yyget_extra(scanner)->filename;
-}
-
-int yyget_firstline(yyscan_t *scanner)
-{
-    return yyget_extra(scanner)->line;
 }
 
 static void buffer_init(struct buffer* b, size_t size)
@@ -529,7 +505,7 @@ int strtonl(const char* buf, size_t nchars)
 }
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(const char* string, size_t length)
+void build_lexer_error(PyObject* builder, const char* string, size_t length)
 {
     TRACE_ERROR("Invalid Token");
 
@@ -543,7 +519,7 @@ void build_lexer_error(const char* string, size_t length)
     Py_XDECREF(rv);
 }
 
-void build_lexer_error_from_exception()
+void build_lexer_error_from_exception(PyObject* builder)
 {
     TRACE_ERROR("Lexer Builder Exception");
 

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -36,6 +36,10 @@ void build_lexer_error(const char* string, size_t length);
  * exception state. */
 void build_lexer_error_from_exception(void);
 
+int PyFile_Read(PyObject *file, char *buf, size_t max_size);
+
+#define YY_INPUT(buf, result, max_size)                         \
+    result = PyFile_Read((PyObject *)yyin, buf, max_size);
 
 
 /* Callback call site with error handling. */
@@ -441,7 +445,7 @@ void yylex_initialize(const char* filename, const char* encoding)
 {
     assert(filename != NULL);
     yy_eof_times = 0;
-    yy_filename = filename;
+    yy_filename = filename ?: "";
     yy_line_tokens = 0;
     yycolumn = 1;
     if ( encoding == 0 ) {
@@ -572,4 +576,28 @@ void build_lexer_error_from_exception()
         PyErr_SetString(PyExc_RuntimeError,
                         "Internal error: No exception");
     }
+}
+
+int PyFile_Read(PyObject *file, char *buf, size_t max_size)
+{
+     PyObject* dest = NULL;
+     PyObject* read = NULL;
+     int ret = 0;
+
+     dest = PyMemoryView_FromMemory(buf, max_size, PyBUF_WRITE);
+     if (!dest)
+          goto error;
+
+     read = PyObject_CallMethod(file, "readinto", "(O)", dest);
+     if (!read)
+          goto error;
+
+     ret = PyLong_AsSize_t(read);
+     if (PyErr_Occurred())
+          ret = 0;
+
+error:
+     Py_XDECREF(dest);
+     Py_XDECREF(read);
+     return ret;
 }

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -6,13 +6,13 @@
 
 /* Options */
 %option noyywrap
-/* %option nodefault */
 %option yylineno
 %option never-interactive
 %option warn
 %option bison-bridge
 %option bison-locations
-/* %option reentrant */
+%option reentrant
+/* %option nodefault */
 /* %option debug */
 /* %option stack */
 /* %option 8bit */
@@ -57,17 +57,14 @@ int PyFile_Read(PyObject *file, char *buf, size_t max_size);
         return LEX_ERROR;                                                               \
     }
 
-
 /* Initialization/finalization methods. These are separate from the yylex_init()
  * and yylex_destroy() and they call them. */
 void yylex_initialize(const char* filename, const char* encoding);
 void yylex_finalize(void);
 
-
 /* Global declarations; defined below. */
 extern int yy_eof_times;
 extern const char* yy_filename;
-extern int yycolumn;
 extern const char* yy_encoding;
 
 /* String buffer statics. */
@@ -76,8 +73,6 @@ extern char* strbuf;       /* Current buffer head. */
 extern char* strbuf_end;   /* Current buffer sentinel (points to the final nul). */
 extern char* strbuf_ptr;   /* Current insertion point in buffer. */
 void strbuf_realloc(size_t num_new_chars);
-
-
 
 /* Handle detecting the beginning of line. */
 extern int yy_line_tokens; /* Number of tokens since the bol. */
@@ -90,14 +85,25 @@ extern int yy_line_tokens; /* Number of tokens since the bol. */
     yycolumn += yyleng;                                 \
   }
 
-
-/* Skip the rest of the input line. */
-int yy_skip_line(void);
-
-
+/* Skip the rest of the input line.  This needs to be implemented as a
+ * macro because input() and unput() are thmeselves macros tha use
+ * variable definitions internal to the yylex() function. */
+#define yy_skip_line()                          \
+    do {                                        \
+        for (;;) {                              \
+            int c = input(yyscanner);           \
+            if (c == EOF || c == -1) {          \
+                break;                          \
+            }                                   \
+            if (c == '\n') {                    \
+                unput(c);                       \
+                break;                          \
+            }                                   \
+        }                                       \
+    } while (0)
+       
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
-
 
 /* Append characters to the static string buffer and verify. */
 #define SAFE_COPY_CHAR(value)                    \
@@ -105,7 +111,7 @@ int strtonl(const char* buf, size_t nchars);
             strbuf_realloc(1);                  \
 	}                                       \
         *strbuf_ptr++ = value;
-
+ 
 }
 
 /* A start condition for chomping an invalid token. */
@@ -146,9 +152,9 @@ ACCOUNTNAME     ([A-Z0-9]|{UTF-8-ONLY})([A-Za-z0-9\-]|{UTF-8-ONLY})*
 [ \t\r]+	{
     if ( yy_line_tokens == 1 ) {
         /* If the next character completes the line, skip it. */
-        if ( yy_hold_char == '\n' ||
-             yy_hold_char == '\r' ||
-             yy_hold_char == '\0' ) {
+        if ( yyg->yy_hold_char == '\n' ||
+             yyg->yy_hold_char == '\r' ||
+             yyg->yy_hold_char == '\0' ) {
             return SKIPPED;
         }
         else {
@@ -428,9 +434,6 @@ const char* yy_filename = 0;
 /* Number of tokens since the beginning of the line. */
 int yy_line_tokens = 0;
 
-/* The current column we're tokenizing at. */
-int yycolumn = 1;
-
 /* The encoding to use for converting strings. */
 const char* yy_encoding = NULL;
 
@@ -447,7 +450,6 @@ void yylex_initialize(const char* filename, const char* encoding)
     yy_eof_times = 0;
     yy_filename = filename ?: "";
     yy_line_tokens = 0;
-    yycolumn = 1;
     if ( encoding == 0 ) {
         yy_encoding = "utf8";
     }
@@ -460,9 +462,6 @@ void yylex_initialize(const char* filename, const char* encoding)
     strbuf = realloc(strbuf, strbuf_size + 1);
     strbuf_end = strbuf + strbuf_size - 1;
     strbuf_ptr = NULL;
-
-    /* Note: If we used a reentrant parser, this routine should eventually call
-     * yylex_init(). */
 }
 
 /* Finalize the globals before running the lexer. */
@@ -475,9 +474,6 @@ void yylex_finalize(void)
         free(strbuf);
         strbuf = NULL;
     }
-
-    /* Call the yylex finalization routine. */
-    yylex_destroy();
 }
 
 
@@ -493,29 +489,6 @@ void strbuf_realloc(size_t num_new_chars)
     strbuf = realloc(strbuf, strbuf_size + 1);
     strbuf_ptr = strbuf + cur_size;
     strbuf_end = strbuf + strbuf_size - 1;
-}
-
-
-
-
-#define LEXEOF 0
-
-int yy_skip_line()
-{
-    int num_chars = 0;
-    for ( ;; ) {
-        int c = input();
-        num_chars++;
-        if ( c == LEXEOF || c == -1 ) {
-            break;
-        }
-        if ( c == '\n' ) {
-            unput(c);
-            num_chars--;
-            break;
-        }
-    }
-    return num_chars;
 }
 
 /* Convert an integer string to a number. */

--- a/beancount/parser/lexer.py
+++ b/beancount/parser/lexer.py
@@ -60,9 +60,6 @@ class LexBuilder:
         """
         return 'Equity:InvalidAccountName'
 
-    def get_lexer_location(self):
-        return data.new_metadata(*self.parser.location)
-
     # Note: We could simplify the code by removing this if we could find a good
     # way to have the lexer communicate the error contents to the parser.
     def build_lexer_error(self, filename, lineno, message, exc_type=None): # {0e31aeca3363}

--- a/beancount/parser/lexer.py
+++ b/beancount/parser/lexer.py
@@ -5,6 +5,7 @@ __license__ = "GNU GPLv2"
 
 import collections
 import datetime
+import io
 import re
 import tempfile
 from decimal import Decimal
@@ -218,13 +219,11 @@ def lex_iter(file, builder=None, encoding=None):
       Tuples of the token (a string), the matched text (a string), and the line
       no (an integer).
     """
-    if isinstance(file, str):
-        filename = file
-    else:
-        filename = file.name
+    if not isinstance(file, io.IOBase):
+        file = open(file, 'rb')
     if builder is None:
         builder = LexBuilder()
-    _parser.lexer_initialize(filename, builder, encoding)
+    _parser.lexer_initialize(file, builder, encoding=encoding)
     try:
         while 1:
             token_tuple = _parser.lexer_next()
@@ -246,8 +245,7 @@ def lex_iter_string(string, builder=None, encoding=None):
     Returns:
       A iterator on the string. See lex_iter() for details.
     """
-    tmp_file = tempfile.NamedTemporaryFile('w' if isinstance(string, str) else 'wb')
-    tmp_file.write(string)
-    tmp_file.flush()
-    # Note: We pass in the file object in order to keep it alive during parsing.
-    return lex_iter(tmp_file, builder, encoding)
+    if isinstance(string, str):
+        string = string.encode('utf-8')
+    file = io.BytesIO(string)
+    return lex_iter(file, builder, encoding)

--- a/beancount/parser/lexer.py
+++ b/beancount/parser/lexer.py
@@ -11,6 +11,7 @@ import tempfile
 from decimal import Decimal
 
 from beancount.core import data
+from beancount.core.data import new_metadata
 from beancount.core import account
 from beancount.parser import _parser
 
@@ -35,13 +36,16 @@ class LexBuilder:
         # A regexp for valid account names.
         self.account_regexp = re.compile(account.ACCOUNT_RE)
 
+        # A regexp for valid numbers.
+        self.number_regexp = re.compile(r'\d{0,3}(,\d{3})+(\.\d+)?$')
+
         # A set of all the commodities that we have seen in the file.
         self.commodities = set()
 
         # Errors that occurred during lexing and parsing.
         self.errors = []
 
-        # Default number of lines as threshold to warn over long strings.
+        # Default number of lines in string literals.
         self.long_string_maxlines_default = 64
 
     def get_invalid_account(self):
@@ -61,7 +65,7 @@ class LexBuilder:
 
     # Note: We could simplify the code by removing this if we could find a good
     # way to have the lexer communicate the error contents to the parser.
-    def build_lexer_error(self, message, exc_type=None): # {0e31aeca3363}
+    def build_lexer_error(self, filename, lineno, message, exc_type=None): # {0e31aeca3363}
         """Build a lexer error and appends it to the list of pending errors.
 
         Args:
@@ -73,7 +77,7 @@ class LexBuilder:
         if exc_type is not None:
             message = '{}: {}'.format(exc_type.__name__, message)
         self.errors.append(
-            LexerError(self.get_lexer_location(), message, None))
+            LexerError(new_metadata(filename, lineno), message, None))
 
 
     def DATE(self, year, month, day):
@@ -133,12 +137,7 @@ class LexBuilder:
         if '\n' in string:
             num_lines = string.count('\n') + 1
             if num_lines > self.long_string_maxlines_default:
-                # This is just a warning; accept the string anyhow.
-                self.errors.append(
-                    LexerError(
-                        self.get_lexer_location(),
-                        "String too long ({} lines); possible error".format(num_lines),
-                        None))
+                raise ValueError("String too long ({} lines)".format(num_lines))
         return string
 
     def NUMBER(self, number):
@@ -152,24 +151,10 @@ class LexBuilder:
         # Note: We don't use D() for efficiency here.
         # The lexer will only yield valid number strings.
         if ',' in number:
-            # Extract the integer part and check the commas match the
-            # locale-aware formatted version. This
-            match = re.match(r"([\d,]*)(\.\d*)?$", number)
-            if not match:
-                # This path is never taken because the lexer will parse a comma
-                # in the fractional part as two NUMBERs with a COMMA token in
-                # between.
-                self.errors.append(
-                    LexerError(self.get_lexer_location(),
-                               "Invalid number format: '{}'".format(number), None))
-            else:
-                int_string, float_string = match.groups()
-                reformatted_number = r"{:,.0f}".format(int(int_string.replace(",", "")))
-                if int_string != reformatted_number:
-                    self.errors.append(
-                        LexerError(self.get_lexer_location(),
-                                   "Invalid commas: '{}'".format(number), None))
-
+            # Check for a number with commas as thousands separator.
+            if not self.number_regexp.match(number):
+                raise ValueError("Invalid number format: '{}'".format(number))
+            # Remove commas.
             number = number.replace(',', '')
         return Decimal(number)
 

--- a/beancount/parser/lexer.py
+++ b/beancount/parser/lexer.py
@@ -7,10 +7,8 @@ import collections
 import datetime
 import io
 import re
-import tempfile
 from decimal import Decimal
 
-from beancount.core import data
 from beancount.core.data import new_metadata
 from beancount.core import account
 from beancount.parser import _parser

--- a/beancount/parser/lexer_test.py
+++ b/beancount/parser/lexer_test.py
@@ -573,7 +573,8 @@ class TestLexerErrors(unittest.TestCase):
         self.assertEqual([('LEX_ERROR', 1, '"', None),
                           ('EOL', 1, '\x00', None)], tokens)
         self.assertEqual(1, len(builder.errors))
-        self.assertRegex(builder.errors[0].message, "None return value from LexBuilder.STRING")
+        self.assertRegex(builder.errors[0].message,
+                         "None return value from LexBuilder.STRING")
 
     @lex_tokens
     def test_lexer_exception_DATE(self, tokens, errors):

--- a/beancount/parser/lexer_test.py
+++ b/beancount/parser/lexer_test.py
@@ -577,7 +577,7 @@ class TestLexerErrors(unittest.TestCase):
         self.assertEqual([('LEX_ERROR', 1, '"', None),
                           ('EOL', 1, '\x00', None)], tokens)
         self.assertEqual(1, len(builder.errors))
-        self.assertRegex(builder.errors[0].message, "None result from lexer")
+        self.assertRegex(builder.errors[0].message, "None return value from LexBuilder.STRING")
 
     @lex_tokens
     def test_lexer_exception_DATE(self, tokens, errors):
@@ -735,14 +735,14 @@ class TestLexerUnicode(unittest.TestCase):
     def test_bytes_encoded_utf16_invalid(self):
         utf16_bytes = self.test_utf8_string.encode('utf16')
         builder = lexer.LexBuilder()
-        with self.assertRaises(SystemError):
+        with self.assertRaises(UnicodeDecodeError):
             tokens = list(lexer.lex_iter_string(utf16_bytes, builder))
 
     # Test providing utf16 bytes to the lexer with an encoding.
     def test_bytes_encoded_utf16(self):
         utf16_bytes = self.test_utf8_string.encode('utf16')
         builder = lexer.LexBuilder()
-        with self.assertRaises(SystemError):
+        with self.assertRaises(UnicodeDecodeError):
             tokens = list(lexer.lex_iter_string(utf16_bytes, builder))
 
 

--- a/beancount/parser/lexer_test.py
+++ b/beancount/parser/lexer_test.py
@@ -412,8 +412,6 @@ class TestLexer(unittest.TestCase):
         '''
         popmeta location:
         '''
-        # Note that this test contains an _actual_ newline, not an escape one as
-        # in the previous test. This should allow us to parse multiline strings.
         self.assertEqual([
             ('EOL', 2, '\n', None),
             ('POPMETA', 2, 'popmeta', None),
@@ -429,13 +427,11 @@ class TestLexer(unittest.TestCase):
         '''
         TRUE FALSE NULL
         '''
-        # Note that this test contains an _actual_ newline, not an escape one as
-        # in the previous test. This should allow us to parse multiline strings.
         self.assertEqual([
             ('EOL', 2, '\n', None),
             ('BOOL', 2, 'TRUE', None),
             ('BOOL', 2, 'FALSE', None),
-            ('NULL', 2, 'NULL', None),
+            ('NONE', 2, 'NULL', None),
             ('EOL', 3, '\n', None),
             ('EOL', 3, '\x00', None),
         ], tokens)

--- a/beancount/parser/lexer_test.py
+++ b/beancount/parser/lexer_test.py
@@ -767,7 +767,7 @@ class TestLexerMisc(unittest.TestCase):
         """
         self.assertEqual(1, len(errors))
         self.assertEqual([
-            ('NUMBER', 1, '452,34.00', D('45234.00')),
+            ('LEX_ERROR', 1, '452,34.00', None),
             ('EOL', 2, '\n', None),
             ('EOL', 2, '\x00', None),
         ], tokens)

--- a/beancount/parser/macros.h
+++ b/beancount/parser/macros.h
@@ -1,0 +1,25 @@
+#define _CC_FUNC_01(FN, X, ...) FN(X)
+#define _CC_FUNC_02(FN, X, ...) FN(X); _CC_FUNC_01(FN, __VA_ARGS__)
+#define _CC_FUNC_03(FN, X, ...) FN(X); _CC_FUNC_02(FN, __VA_ARGS__)
+#define _CC_FUNC_04(FN, X, ...) FN(X); _CC_FUNC_03(FN, __VA_ARGS__)
+#define _CC_FUNC_05(FN, X, ...) FN(X); _CC_FUNC_04(FN, __VA_ARGS__)
+#define _CC_FUNC_06(FN, X, ...) FN(X); _CC_FUNC_05(FN, __VA_ARGS__)
+#define _CC_FUNC_07(FN, X, ...) FN(X); _CC_FUNC_06(FN, __VA_ARGS__)
+#define _CC_FUNC_08(FN, X, ...) FN(X); _CC_FUNC_07(FN, __VA_ARGS__)
+#define _CC_FUNC_09(FN, X, ...) FN(X); _CC_FUNC_08(FN, __VA_ARGS__)
+#define _CC_FUNC_10(FN, X, ...) FN(X); _CC_FUNC_09(FN, __VA_ARGS__)
+
+#define _CC_FUNC_SEQ(_01, _02, _03, _04, _05, _06, _07, _08, _09, _10, NAME, ...) NAME
+
+#define _CC_FUNC(FN, ...)                               \
+        _CC_FUNC_SEQ(__VA_ARGS__,                       \
+                     _CC_FUNC_10,                       \
+                     _CC_FUNC_09,                       \
+                     _CC_FUNC_08,                       \
+                     _CC_FUNC_07,                       \
+                     _CC_FUNC_06,                       \
+                     _CC_FUNC_05,                       \
+                     _CC_FUNC_04,                       \
+                     _CC_FUNC_03,                       \
+                     _CC_FUNC_02,                       \
+                     _CC_FUNC_01) (FN, __VA_ARGS__)

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -128,12 +128,10 @@ static PyObject* parser_parse(Parser* self, PyObject* args, PyObject* kwds)
     switch (ret) {
     case 0:
         Py_RETURN_NONE;
-    case 1:
-        return PyErr_Format(PyExc_RuntimeError, "Parser internal error");
     case 2:
-        return PyErr_Format(PyExc_MemoryError, "Parser ran out of memory");
+        return PyErr_NoMemory();
     default:
-        return PyErr_Format(PyExc_ValueError, "Unexpected yyparse() return value: %d", ret);
+        return PyErr_Format(PyExc_RuntimeError, "parser internal error: %d", ret);
     }
 }
 
@@ -179,7 +177,10 @@ static PyObject* parser_iternext(Parser* self)
     }
 
     token = yylex(&yylval, &yylloc, self->scanner, (PyObject*)self, self->builder);
-    if (token == 0)
+    if (!token)
+        return NULL;
+
+    if (PyErr_Occurred())
         return NULL;
 
     switch (token) {

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -13,8 +13,6 @@ extern YY_DECL;
 #define XSTRINGIFY(s) STRINGIFY(s)
 #define STRINGIFY(s) #s
 
-extern const char* getTokenName(int token);
-
 /* Placeolder object for missing cost specifications. */
 PyObject* missing;
 
@@ -113,7 +111,6 @@ static PyObject* parser_lex(Parser *self, PyObject* args, PyObject* kwds)
 
 static PyObject* parser_iternext(Parser* self)
 {
-    const char* name;
     YYSTYPE yylval;
     YYLTYPE yylloc;
     int token = 0;
@@ -146,10 +143,8 @@ static PyObject* parser_iternext(Parser* self)
         obj = Py_None;
     }
 
-    name = getTokenName(token);
-
     return Py_BuildValue("(sis#O)",
-                         name,
+                         token_to_string(token),
                          yylloc.first_line,
                          yyget_text(self->scanner),
                          (Py_ssize_t)yyget_leng(self->scanner),

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -50,16 +50,6 @@ static int parser___init__(Parser* self, PyObject* args, PyObject* kwds)
     self->builder = builder;
     Py_INCREF(builder);
 
-    /* The builder need to know about the parser to report parsing
-     * location in some circumstances. However storing a reference to
-     * the parser in the builder creates a circular reference. We
-     * ignore this issue for the moment as it is probably better
-     * solved removing the need for the builder to call into the
-     * parser. This can be achieved passing the parser location when
-     * calling methods of the builder as it is already done in some
-     * cases. */
-    PyObject_SetAttrString(builder, "parser", (PyObject*)self);
-
     return 0;
 }
 
@@ -69,20 +59,6 @@ static void parser_dealloc(Parser* self)
     yylex_free(self->scanner);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
-
-PyDoc_STRVAR(parser_location_doc, "");
-
-static PyObject* parser_location(Parser* self)
-{
-    return Py_BuildValue("Oi",
-                         yyget_filename(self->scanner),
-                         yyget_firstline(self->scanner) + yyget_lineno(self->scanner));
-}
-
-static PyGetSetDef parser_getsetters[] = {
-    {"location", (getter)parser_location, NULL, parser_location_doc, NULL},
-    {NULL}
-};
 
 PyDoc_STRVAR(parser_parse_doc, "");
 
@@ -216,7 +192,7 @@ PyTypeObject Parser_Type = {
     (iternextfunc)parser_iternext,            /* tp_iternext */
     parser_methods,                           /* tp_methods */
     0,                                        /* tp_members */
-    parser_getsetters,                        /* tp_getset */
+    0,                                        /* tp_getset */
     0,                                        /* tp_base */
     0,                                        /* tp_dict */
     0,                                        /* tp_descr_get */

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -46,10 +46,10 @@ static PyObject* parser_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 
 static int parser___init__(Parser* self, PyObject* args, PyObject* kwds)
 {
-    static char* kwlist[] = {"builder", NULL};
+    static char* kwlist[] = {"builder", "debug", NULL};
     PyObject* builder;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &builder))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|p", kwlist, &builder, &yydebug))
         return -1;
 
     Py_XDECREF(self->builder);

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -7,16 +7,16 @@
 #include "parser.h"
 #include "lexer.h"
 
+extern YY_DECL;
+
 #define XSTRINGIFY(s) STRINGIFY(s)
 #define STRINGIFY(s) #s
-
-/* The bison header file does not contain this... silly. */
-extern int yyparse(void);
 
 extern const char* getTokenName(int token);
 
 extern int yy_firstline;
 
+yyscan_t _scanner;
 
 /* The current builder during parsing (as a global variable for now). */
 PyObject* builder = 0;
@@ -80,20 +80,22 @@ PyObject* parse_file(PyObject *self, PyObject *args, PyObject* kwds)
     }
 
     /* Initialize the lexer. */
+    yylex_init(&_scanner);
     yylex_initialize(report_filename ?: "", encoding);
-    yyset_in((void*)file);
+    yyset_in((void*)file, _scanner);
 
     /* Initialize the parser. */
     yy_firstline = report_firstline;
 
     /* Parse! This will call back methods on the builder instance. */
-    rv = yyparse();
+    rv = yyparse(_scanner);
 
     /* Finalize the parser. */
     /* Noop. */
 
     /* Finalize the lexer. */
     yylex_finalize();
+    yylex_destroy(_scanner);
 
     Py_XDECREF(name);
     builder = NULL;
@@ -108,7 +110,7 @@ PyObject* get_yyfilename(PyObject *self, PyObject *args)
 
 PyObject* get_yylineno(PyObject *self, PyObject *args)
 {
-    return PyLong_FromLong(yylineno + yy_firstline);
+    return PyLong_FromLong(yyget_lineno(_scanner) + yy_firstline);
 }
 
 /* Inititalize the lexer to start running in debug mode. */
@@ -144,8 +146,9 @@ PyObject* lexer_initialize(PyObject *self, PyObject *args, PyObject *kwds)
     }
 
     /* Initialize the lexer. */
+    yylex_init(&_scanner);
     yylex_initialize(report_filename ?: "", encoding);
-    yyset_in((void*)file);
+    yyset_in((void*)file, _scanner);
 
     /* Initialize the parser. */
     yy_firstline = report_firstline;
@@ -161,11 +164,12 @@ PyObject* lexer_initialize(PyObject *self, PyObject *args, PyObject *kwds)
 PyObject* lexer_finalize(PyObject *self, PyObject *args)
 {
     /* Now we can let those objects go. */
-    Py_XDECREF((void*)yyget_in());
+    Py_XDECREF((void*)yyget_in(_scanner));
     Py_XDECREF(builder);
 
     /* Finalize the lexer. */
     yylex_finalize();
+    yylex_destroy(_scanner);
 
     Py_RETURN_NONE;
 }
@@ -180,9 +184,8 @@ PyObject* lexer_next(PyObject *self, PyObject *args)
     PyObject* obj;
 
     /* Run the lexer. */
-    token = yylex(&yylval, &yylloc);
+    token = yylex(&yylval, &yylloc, _scanner);
     if ( token == 0 ) {
-        yylex_destroy();
         Py_RETURN_NONE;
     }
 
@@ -200,7 +203,7 @@ PyObject* lexer_next(PyObject *self, PyObject *args)
     }
 
     tokenName = getTokenName(token);
-    return Py_BuildValue("(sis#O)", tokenName, yylloc.first_line, yytext, (Py_ssize_t)yyleng, obj);
+    return Py_BuildValue("(sis#O)", tokenName, yylloc.first_line, yyget_text(_scanner), (Py_ssize_t)yyget_leng(_scanner), obj);
 }
 
 

--- a/beancount/parser/parser.h
+++ b/beancount/parser/parser.h
@@ -4,16 +4,28 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-extern PyObject* builder;
-extern PyObject* missing_obj;
-
 /* This typedef is included in the Flex generated lexer.h header, but
  * it is needed in the Bison generted header grammar.h that needs to
  * be included before lexer.h. Repeat it here and make sure to include
  * the headers in the right order. */
 typedef void* yyscan_t;
 
-#define YY_DECL int yylex (YYSTYPE * yylval_param, YYLTYPE * yylloc_param, yyscan_t yyscanner)
+#define YY_DECL int yylex (YYSTYPE * yylval_param, YYLTYPE * yylloc_param, \
+                           yyscan_t yyscanner, PyObject* parser, PyObject* builder)
+
+typedef struct {
+    PyObject_HEAD
+    yyscan_t scanner;
+    /* The filename being tokenized. */
+    PyObject* filename;
+    /* Reporting line offset. This is used like the #line cpp macro */
+    int line;
+    /* The encoding to use for converting strings. */
+    const char* encoding;
+    PyObject* builder;
+} Parser;
+
+extern PyObject* missing;
 
 /* #define DO_TRACE_ERRORS   1 */
 

--- a/beancount/parser/parser.h
+++ b/beancount/parser/parser.h
@@ -27,22 +27,4 @@ typedef struct {
 
 extern PyObject* missing;
 
-/* #define DO_TRACE_ERRORS   1 */
-
-/* Error tracing (use for debugging error handling). */
-#ifdef DO_TRACE_ERRORS
-#  define TRACE_ERROR(...)                              \
-    {                                                   \
-        fprintf(stdout, "\n");                          \
-        fprintf(stdout, "%s:%d: TRACE - In function '%s':\n",   \
-                __FILE__, __LINE__, __func__);          \
-        fprintf(stdout, __VA_ARGS__);                   \
-        fprintf(stdout, "\n");                          \
-        fflush(stdout);                                 \
-    }
-#else
-#  define TRACE_ERROR(...)
-#endif
-
-
 #endif /* BEANCOUNT_BUILDER_H */

--- a/beancount/parser/parser.h
+++ b/beancount/parser/parser.h
@@ -11,17 +11,11 @@
 typedef void* yyscan_t;
 
 #define YY_DECL int yylex (YYSTYPE * yylval_param, YYLTYPE * yylloc_param, \
-                           yyscan_t yyscanner, PyObject* parser, PyObject* builder)
+                           yyscan_t yyscanner, PyObject* builder)
 
 typedef struct {
     PyObject_HEAD
     yyscan_t scanner;
-    /* The filename being tokenized. */
-    PyObject* filename;
-    /* Reporting line offset. This is used like the #line cpp macro */
-    int line;
-    /* The encoding to use for converting strings. */
-    const char* encoding;
     PyObject* builder;
 } Parser;
 

--- a/beancount/parser/parser.h
+++ b/beancount/parser/parser.h
@@ -4,12 +4,18 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-
 extern PyObject* builder;
 extern PyObject* missing_obj;
 
-/* #define DO_TRACE_ERRORS   1 */
+/* This typedef is included in the Flex generated lexer.h header, but
+ * it is needed in the Bison generted header grammar.h that needs to
+ * be included before lexer.h. Repeat it here and make sure to include
+ * the headers in the right order. */
+typedef void* yyscan_t;
 
+#define YY_DECL int yylex (YYSTYPE * yylval_param, YYLTYPE * yylloc_param, yyscan_t yyscanner)
+
+/* #define DO_TRACE_ERRORS   1 */
 
 /* Error tracing (use for debugging error handling). */
 #ifdef DO_TRACE_ERRORS

--- a/beancount/parser/parser.py
+++ b/beancount/parser/parser.py
@@ -197,7 +197,7 @@ def parse_file(file, report_filename=None, report_firstline=0, **kw):
         file = sys.stdin.buffer
     elif not isinstance(file, io.IOBase):
         file = open(file, 'rb')
-    builder = grammar.Builder(report_filename)
+    builder = grammar.Builder()
     parser = _parser.Parser(builder)
     parser.parse(file, filename=report_filename, lineno=report_firstline, **kw)
     return builder.finalize()

--- a/beancount/parser/parser.py
+++ b/beancount/parser/parser.py
@@ -114,7 +114,6 @@ import inspect
 import textwrap
 import io
 import sys
-from os import path
 
 from beancount.parser import _parser
 from beancount.parser import grammar

--- a/beancount/parser/parser.py
+++ b/beancount/parser/parser.py
@@ -180,12 +180,12 @@ def is_entry_incomplete(entry):
     return False
 
 
-def parse_file(file, report_filename=None, **kw):
+def parse_file(file, report_filename=None, report_firstline=0, **kw):
     """Parse a beancount input file and return Ledger with the list of
     transactions and tree of accounts.
 
     Args:
-      filename: the name of the file to be parsed.
+      file: file object or path of the file to be parsed.
       kw: a dict of keywords to be applied to the C parser.
     Returns:
       A tuple of (
@@ -198,7 +198,8 @@ def parse_file(file, report_filename=None, **kw):
     elif not isinstance(file, io.IOBase):
         file = open(file, 'rb')
     builder = grammar.Builder(report_filename)
-    _parser.parse_file(file, builder, report_filename=report_filename, **kw)
+    parser = _parser.Parser(builder)
+    parser.parse(file, filename=report_filename, lineno=report_firstline, **kw)
     return builder.finalize()
 
 

--- a/beancount/parser/parser_test.py
+++ b/beancount/parser/parser_test.py
@@ -124,6 +124,13 @@ class TestParserInputs(unittest.TestCase):
         with self.assertRaises(TypeError):
             entries, errors, _ = parser.parse_file(None)
 
+    # Exceptions raised while reading the input file are propagated.
+    def test_parse_file_readerror(self):
+        class Mock(io.BytesIO):
+            def readinto(self, b):
+                raise IOError("mock error");
+        with self.assertRaises(IOError):
+            entries, errors, _ = parser.parse_file(Mock())
 
 class TestUnicodeErrors(unittest.TestCase):
 

--- a/beancount/parser/parser_test.py
+++ b/beancount/parser/parser_test.py
@@ -128,7 +128,7 @@ class TestParserInputs(unittest.TestCase):
     def test_parse_file_readerror(self):
         class Mock(io.BytesIO):
             def readinto(self, b):
-                raise IOError("mock error");
+                raise IOError("mock error")
         with self.assertRaises(IOError):
             entries, errors, _ = parser.parse_file(Mock())
 

--- a/beancount/parser/parser_test.py
+++ b/beancount/parser/parser_test.py
@@ -4,6 +4,7 @@ Tests for parser.
 __copyright__ = "Copyright (C) 2014-2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
+import io
 import unittest
 import tempfile
 import textwrap
@@ -82,11 +83,19 @@ class TestParserInputs(unittest.TestCase):
         self.assertEqual(1, len(entries))
         self.assertEqual(0, len(errors))
 
-    def test_parse_file(self):
+    def test_parse_filename(self):
         with tempfile.NamedTemporaryFile('w', suffix='.beancount') as file:
             file.write(self.INPUT)
             file.flush()
             entries, errors, _ = parser.parse_file(file.name)
+            self.assertEqual(1, len(entries))
+            self.assertEqual(0, len(errors))
+
+    def test_parse_file(self):
+        with tempfile.TemporaryFile('w+b', suffix='.beancount') as file:
+            file.write(self.INPUT.encode('utf-8'))
+            file.seek(0)
+            entries, errors, _ = parser.parse_file(file)
             self.assertEqual(1, len(entries))
             self.assertEqual(0, len(errors))
 
@@ -106,12 +115,14 @@ class TestParserInputs(unittest.TestCase):
         output, errors = pipe.communicate(self.INPUT.encode('utf-8'))
         self.assertEqual(0, pipe.returncode)
 
-    def test_parse_string_None(self):
-        input_string = report_filename = None
+    def test_parse_None(self):
+        # None is treated as the empty string...
+        entries, errors, _ = parser.parse_string(None)
+        self.assertEqual(0, len(entries))
+        self.assertEqual(0, len(errors))
+        # ...however None in not a valid file like object
         with self.assertRaises(TypeError):
-            entries, errors, _ = parser.parse_string(input_string)
-        with self.assertRaises(TypeError):
-            entries, errors, _ = parser.parse_string("something", None, report_filename)
+            entries, errors, _ = parser.parse_file(None)
 
 
 class TestUnicodeErrors(unittest.TestCase):


### PR DESCRIPTION
This makes the parser accept a Python `file` object as input, makes the parser reentrant, and generally cleans up the parsing code. This should fix bugs related to non ASCII file names on Windows (was reported as a bug but I am not able to find it now) and help fixing #222 (I need to check if some more work is required to completely fix the issue).
