### PR TITLE
parser: Drop options['commodities']

### DIFF
--- a/beancount/core/getters.py
+++ b/beancount/core/getters.py
@@ -10,10 +10,7 @@ from collections import OrderedDict
 from beancount.core.data import Transaction
 from beancount.core.data import Open
 from beancount.core.data import Close
-from beancount.core.data import Balance
-from beancount.core.data import Price
 from beancount.core.data import Commodity
-from beancount.core import data
 from beancount.core import account
 
 
@@ -325,59 +322,15 @@ def get_account_open_close(entries):
     return dict(open_close_map)
 
 
-def get_commodity_map(entries, create_missing=True):
+def get_commodity_directives(entries):
     """Create map of commodity names to Commodity entries.
 
     Args:
       entries: A list of directive instances.
-      create_missing: A boolean, true if you want to automatically generate
-        missing commodity directives if not present in the output map.
     Returns:
       A map of commodity name strings to Commodity directives.
     """
-    if not entries:
-        return {}
-
-    commodities_map = {}
-    for entry in entries:
-        if isinstance(entry, Commodity):
-            commodities_map[entry.currency] = entry
-
-        elif isinstance(entry, Transaction):
-            for posting in entry.postings:
-
-                # Main currency.
-                units = posting.units
-                commodities_map.setdefault(units.currency, None)
-
-                # Currency in cost.
-                cost = posting.cost
-                if cost:
-                    commodities_map.setdefault(cost.currency, None)
-
-                # Currency in price.
-                price = posting.price
-                if price:
-                    commodities_map.setdefault(price.currency, None)
-
-        elif isinstance(entry, Balance):
-            commodities_map.setdefault(entry.amount.currency, None)
-
-        elif isinstance(entry, Price):
-            commodities_map.setdefault(entry.currency, None)
-
-    if create_missing:
-        # Create missing Commodity directives when they haven't been specified explicitly.
-        # (I think it might be better to always do this from the loader.)
-        date = entries[0].date
-        meta = data.new_metadata('<getters>', 0)
-        commodities_map = {
-            commodity: (entry
-                        if entry is not None
-                        else Commodity(meta, date, commodity))
-            for commodity, entry in commodities_map.items()}
-
-    return commodities_map
+    return { entry.currency: entry for entry in entries if isinstance(entry, Commodity) }
 
 
 def get_values_meta(name_to_entries_map, *meta_keys, default=None):

--- a/beancount/core/getters_test.py
+++ b/beancount/core/getters_test.py
@@ -200,34 +200,26 @@ class TestGetters(unittest.TestCase):
                                'Cash', 'Coffee', 'Expenses', 'Credit-Card'}
         self.assertEqual(sorted(expected_components), components)
 
-    def test_get_commodities_map(self):
+    def test_get_commodity_directives(self):
         entries, _, options_map = loader.load_string(TEST_INPUT)
-        commodity_map = getters.get_commodity_map(entries)
-        self.assertEqual({'HOOL', 'PIPA', 'USD'}, commodity_map.keys())
+        commodities = getters.get_commodity_directives(entries)
+        self.assertEqual({'HOOL', 'PIPA'}, commodities.keys())
         self.assertTrue(all(isinstance(value, data.Commodity)
-                            for value in commodity_map.values()))
-        self.assertEqual(commodity_map['HOOL'],
-                         next(entry
-                              for entry in entries
-                              if isinstance(entry, data.Commodity)))
+                            for value in commodities.values()))
 
     def test_get_values_meta__single(self):
         entries, _, options_map = loader.load_string(TEST_INPUT)
-        commodity_map = getters.get_commodity_map(entries)
-        values = getters.get_values_meta(commodity_map, 'name', default='BLA')
-        self.assertEqual({'USD': 'BLA',
-                          'PIPA': 'Pied Piper',
-                          'HOOL': 'Hooli Corp.'},
-                         values)
+        commodities = getters.get_commodity_directives(entries)
+        values = getters.get_values_meta(commodities, 'name', default='BLA')
+        self.assertEqual({'PIPA': 'Pied Piper',
+                          'HOOL': 'Hooli Corp.'}, values)
 
     def test_get_values_meta__multi(self):
         entries, _, options_map = loader.load_string(TEST_INPUT)
-        commodity_map = getters.get_commodity_map(entries)
-        values = getters.get_values_meta(commodity_map, 'name', 'ticker')
+        commodities = getters.get_commodity_directives(entries)
+        values = getters.get_values_meta(commodities, 'name', 'ticker')
         self.assertEqual({'HOOL': ('Hooli Corp.', 'NYSE:HOOLI'),
-                          'PIPA': ('Pied Piper', None),
-                          'USD': (None, None)},
-                         values)
+                          'PIPA': ('Pied Piper', None)}, values)
 
 
 if __name__ == '__main__':

--- a/beancount/loader.py
+++ b/beancount/loader.py
@@ -464,10 +464,6 @@ def aggregate_options_map(options_map, src_options_map):
         if currency not in op_currencies:
             op_currencies.append(currency)
 
-    commodities = options_map["commodities"]
-    for currency in src_options_map["commodities"]:
-        commodities.add(currency)
-
 
 def _load(sources, log_timings, extra_validations, encoding):
     """Parse Beancount input, run its transformations and validate it.

--- a/beancount/loader_test.py
+++ b/beancount/loader_test.py
@@ -538,25 +538,6 @@ class TestOptionsAggregation(unittest.TestCase):
 
             self.assertEqual({'USD', 'EUR', 'CAD'}, set(options_map['operating_currency']))
 
-    def test_aggregate_commodities(self):
-        with test_utils.tempdir() as tmp:
-            test_utils.create_temporary_files(tmp, {
-                'apples.beancount': """
-                  include "oranges.beancount"
-                  include "bananas.beancount"
-                  option "operating_currency" "USD"
-                """,
-                'oranges.beancount': """
-                  2015-12-12 open Assets:CA:Checking  CAD
-                """,
-                'bananas.beancount': """
-                  2015-12-13 open Assets:FR:Checking  EUR
-                """})
-            top_filename = path.join(tmp, 'apples.beancount')
-            entries, errors, options_map = loader.load_file(top_filename)
-
-            self.assertEqual({'EUR', 'CAD'}, options_map['commodities'])
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/beancount/ops/holdings.py
+++ b/beancount/ops/holdings.py
@@ -211,11 +211,11 @@ def get_commodities_at_date(entries, options_map, date=None):
                         for holding in holdings_list}
 
     # Add in the associated ticker symbols.
-    commodities_map = getters.get_commodity_map(entries)
+    commodities = getters.get_commodity_directives(entries)
     commodities_symbols_list = []
     for currency, cost_currency in sorted(commodities_list):
         try:
-            commodity_entry = commodities_map[currency]
+            commodity_entry = commodities[currency]
             ticker = commodity_entry.meta.get('ticker', None)
             quote_currency = commodity_entry.meta.get('quote', None)
         except KeyError:

--- a/beancount/parser/grammar.py
+++ b/beancount/parser/grammar.py
@@ -186,18 +186,6 @@ class Builder(lexer.LexBuilder):
         # Build and store the inferred DisplayContext instance.
         self.options['dcontext'] = self.dcontext
 
-        # Add the full list of seen commodities.
-        #
-        # IMPORTANT: This is currently where the list of all commodities seen
-        # from the parser lives. The
-        # beancount.core.getters.get_commodities_map() routine uses this to
-        # automatically generate a full list of directives. An alternative would
-        # be to implement a plugin that enforces the generate of these
-        # post-parsing so that they are always guaranteed to live within the
-        # flow of entries. This would allow us to keep all the data in that list
-        # of entries and to avoid depending on the options to store that output.
-        self.options['commodities'] = self.commodities
-
         return self.options
 
     def get_invalid_account(self):

--- a/beancount/parser/lexer.py
+++ b/beancount/parser/lexer.py
@@ -37,9 +37,6 @@ class LexBuilder:
         # A regexp for valid numbers.
         self.number_regexp = re.compile(r'(\d+|\d{1,3}(,\d{3})+)(\.\d+)?$')
 
-        # A set of all the commodities that we have seen in the file.
-        self.commodities = set()
-
         # Errors that occurred during lexing and parsing.
         self.errors = []
 
@@ -117,7 +114,6 @@ class LexBuilder:
           A new currency object; for now, these are simply represented
           as the currency name.
         """
-        self.commodities.add(currency_name)
         return currency_name
 
     def STRING(self, string):

--- a/beancount/parser/lexer_test.py
+++ b/beancount/parser/lexer_test.py
@@ -608,20 +608,6 @@ class TestLexerErrors(unittest.TestCase):
                           ('EOL', 3, '\x00', None)], tokens)
         self.assertEqual(1, len(builder.errors))
 
-    def test_lexer_exception_CURRENCY(self):
-        test_input = """
-          USD
-        """
-        builder = lexer.LexBuilder()
-        builder.commodities = {}  # This will force an exception because the
-                                  # parser calls add() on it.
-        tokens = list(lexer.lex_iter_string(textwrap.dedent(test_input), builder))
-        self.assertEqual([('EOL', 2, '\n', None),
-                          ('LEX_ERROR', 2, 'USD', None),
-                          ('EOL', 3, '\n', None),
-                          ('EOL', 3, '\x00', None)], tokens)
-        self.assertEqual(1, len(builder.errors))
-
     def test_lexer_exception_substring_with_quotes(self):
         test_input = """
           2016-07-15 query "hotels" "SELECT * WHERE account ~ 'Expenses:Accommodation'"

--- a/beancount/plugins/check_commodity.py
+++ b/beancount/plugins/check_commodity.py
@@ -8,9 +8,10 @@ __copyright__ = "Copyright (C) 2015-2017  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import collections
+import re
 
 from beancount.core import data
-from beancount.core import getters
+from beancount.core.amount import CURRENCY_RE
 
 __plugins__ = ('validate_commodity_directives',)
 
@@ -18,28 +19,84 @@ __plugins__ = ('validate_commodity_directives',)
 CheckCommodityError = collections.namedtuple('CheckCommodityError', 'source message entry')
 
 
+def get_commodity_map_ex(entries):
+
+    ignore = set(['filename', 'lineno', '__automatic__'])
+    regexp = re.compile(CURRENCY_RE)
+
+    def currencies_in_meta(entry):
+        if entry.meta is not None:
+            for key, value in entry.meta.items():
+                if isinstance(value, str) and key not in ignore:
+                    if regexp.fullmatch(value):
+                        yield value
+
+    commodities_map = {}
+
+    for entry in entries:
+        if isinstance(entry, data.Commodity):
+            commodities_map[entry.currency] = entry
+
+        elif isinstance(entry, data.Open):
+            if entry.currencies:
+                for currency in entry.currencies:
+                    commodities_map.setdefault(currency, None)
+
+        elif isinstance(entry, data.Transaction):
+            for posting in entry.postings:
+
+                # Main currency.
+                units = posting.units
+                commodities_map.setdefault(units.currency, None)
+
+                # Currency in cost.
+                cost = posting.cost
+                if cost:
+                    commodities_map.setdefault(cost.currency, None)
+
+                # Currency in price.
+                price = posting.price
+                if price:
+                    commodities_map.setdefault(price.currency, None)
+
+                # Currency in posting metadata.
+                for currency in currencies_in_meta(posting):
+                    commodities_map.setdefault(currency, None)
+
+        elif isinstance(entry, data.Balance):
+            commodities_map.setdefault(entry.amount.currency, None)
+
+        elif isinstance(entry, data.Price):
+            commodities_map.setdefault(entry.currency, None)
+            commodities_map.setdefault(entry.amount.currency, None)
+
+        # Entry metadata.
+        for currency in currencies_in_meta(entry):
+            commodities_map.setdefault(currency, None)
+
+    return commodities_map
+
+
 def validate_commodity_directives(entries, options_map):
     """Find all commodities used and ensure they have a corresponding Commodity directive.
 
     Args:
       entries: A list of directives.
-      unused_options_map: An options map.
+      options_map: An options map.
     Returns:
       A list of new errors, if any were found.
     """
-    commodities_used = options_map['commodities']
     errors = []
 
     meta = data.new_metadata('<check_commodity>', 0)
 
-    commodity_map = getters.get_commodity_map(entries, create_missing=False)
-    for currency in commodities_used:
-        commodity_entry = commodity_map.get(currency, None)
+    commodity_map = get_commodity_map_ex(entries)
+    for commodity, commodity_entry in commodity_map.items():
         if commodity_entry is None:
             errors.append(
                 CheckCommodityError(
                     meta,
-                    "Missing Commodity directive for '{}'".format(currency),
+                    "Missing Commodity directive for '{}'".format(commodity),
                     None))
 
     return entries, errors

--- a/beancount/plugins/check_commodity_test.py
+++ b/beancount/plugins/check_commodity_test.py
@@ -9,6 +9,36 @@ from beancount.plugins import check_commodity
 
 class TestCheckCommodity(unittest.TestCase):
 
+    @loader.load_doc()
+    def test_get_commodity_map_ex(self, entries, _, __):
+        """
+            2011-01-01 commodity BAZ
+
+            2011-01-01 open Expenses:Test  TEST1, TEST2, TEST7
+            2011-01-01 open Expenses:Other
+            2011-01-01 open Assets:Test
+            2011-01-01 open Assets:Investments
+            2011-01-01 open Equity:Opening-Balances
+
+            2011-05-17 * "Something"
+              foo: TEST3
+              Expenses:Other  1.00 TEST4
+                bar: TEST5
+              Assets:Test
+
+            2011-05-17 * "Something"
+              Assets:Investments  5.00 FOO @ 1.00 TEST6
+              Assets:Test
+
+            2011-05-18 pad Assets:Test Equity:Opening-Balances
+            2011-05-19 balance Assets:Test -1.00 TEST7
+
+            2011-05-20 price BAR 1.00 TEST6
+        """
+        commodities = check_commodity.get_commodity_map_ex(entries)
+        self.assertEqual(commodities.keys(), {'TEST1', 'TEST2', 'TEST3', 'TEST4', 'TEST5',
+                                              'TEST6', 'TEST7', 'FOO', 'BAR', 'BAZ'})
+
     @loader.load_doc(expect_errors=True)
     def test_check_commodity_transaction(self, _, errors, __):
         """

--- a/beancount/plugins/check_commodity_test.py
+++ b/beancount/plugins/check_commodity_test.py
@@ -35,7 +35,7 @@ class TestCheckCommodity(unittest.TestCase):
 
             2011-05-20 price BAR 1.00 TEST6
         """
-        commodities = check_commodity.get_commodity_map_ex(entries)
+        commodities = check_commodity.get_commodity_map_ex(entries, metadata=True)
         self.assertEqual(commodities.keys(), {'TEST1', 'TEST2', 'TEST3', 'TEST4', 'TEST5',
                                               'TEST6', 'TEST7', 'FOO', 'BAR', 'BAZ'})
 

--- a/beancount/plugins/merge_meta.py
+++ b/beancount/plugins/merge_meta.py
@@ -55,11 +55,11 @@ def merge_meta(entries, options_map, config):
             close_entry.meta.update(ext_close_entry.meta)
 
     # Map Commodity directives.
-    comm_map = getters.get_commodity_map(entries, False)
-    ext_comm_map = getters.get_commodity_map(ext_entries, False)
-    for currency in set(comm_map) & set(ext_comm_map):
-        comm_entry = comm_map[currency]
-        ext_comm_entry = ext_comm_map[currency]
+    commodities = getters.get_commodity_directives(entries)
+    ext_commodities = getters.get_commodity_directives(ext_entries)
+    for currency in set(commodities) & set(ext_commodities):
+        comm_entry = commodities[currency]
+        ext_comm_entry = ext_commodities[currency]
         if comm_entry and ext_comm_entry:
             comm_entry.meta.update(ext_comm_entry.meta)
 

--- a/beancount/projects/export.py
+++ b/beancount/projects/export.py
@@ -71,10 +71,10 @@ def get_metamap_table(metamap: Dict[str, data.Directive],
 
 def get_commodities_table(entries: data.Entries, attributes: List[str]) -> Table:
     """Produce a Table of per-commodity attributes."""
-    commodities_map = getters.get_commodity_map(entries)
+    commodities = getters.get_commodity_directives(entries)
     header = ['currency'] + attributes
     getter = lambda entry, key: entry.meta.get(key, None)
-    table = get_metamap_table(commodities_map, header, getter)
+    table = get_metamap_table(commodities, header, getter)
     return table
 
 

--- a/beancount/query/query_env.py
+++ b/beancount/query/query_env.py
@@ -418,7 +418,9 @@ class CurrencyMeta(query_compile.EvalFunction):
 
     def __call__(self, context):
         args = self.eval_args(context)
-        commodity_entry = context.commodity_map[args[0]]
+        commodity_entry = context.commodity_map.get(args[0], None)
+        if commodity_entry is None:
+            return {}
         return commodity_entry.meta
 
 

--- a/beancount/query/query_execute.py
+++ b/beancount/query/query_execute.py
@@ -203,7 +203,7 @@ def create_row_context(entries, options_map):
     context.options_map = options_map
     context.account_types = options.get_account_types(options_map)
     context.open_close_map = getters.get_account_open_close(entries)
-    context.commodity_map = getters.get_commodity_map(entries)
+    context.commodity_map = getters.get_commodity_directives(entries)
     context.price_map = prices.build_price_map(entries)
 
     return context

--- a/beancount/reports/export_reports.py
+++ b/beancount/reports/export_reports.py
@@ -136,7 +136,7 @@ def export_holdings(entries, options_map, promiscuous, aggregate_by_commodity=Fa
     """
     # Get the desired list of holdings.
     holdings_list, price_map = holdings.get_assets_holdings(entries, options_map)
-    commodities_map = getters.get_commodity_map(entries)
+    commodities = getters.get_commodity_directives(entries)
     dcontext = options_map['dcontext']
 
     # Aggregate the holdings, if requested. Google Finance is notoriously
@@ -146,7 +146,7 @@ def export_holdings(entries, options_map, promiscuous, aggregate_by_commodity=Fa
                                                        lambda holding: holding.currency)
 
     # Classify all the holdings for export.
-    action_holdings = classify_holdings_for_export(holdings_list, commodities_map)
+    action_holdings = classify_holdings_for_export(holdings_list, commodities)
 
     # The lists of exported and converted export entries, and the list of
     # ignored holdings.
@@ -190,7 +190,7 @@ def export_holdings(entries, options_map, promiscuous, aggregate_by_commodity=Fa
             holdings_ignored.append(holding)
 
     # Get the money instruments.
-    money_instruments = get_money_instruments(commodities_map)
+    money_instruments = get_money_instruments(commodities)
 
     # Convert all the cash values to money instruments, if possible. If not
     # possible, we'll just have to ignore those values.

--- a/beancount/reports/export_reports_test.py
+++ b/beancount/reports/export_reports_test.py
@@ -47,9 +47,9 @@ class TestCommodityClassifications(unittest.TestCase):
         @functools.wraps(fun)
         def wrapped(self, entries, unused_errors, options_map):
             holdings_list, _ = holdings.get_assets_holdings(entries, options_map)
-            commodities_map = getters.get_commodity_map(entries)
+            commodities = getters.get_commodity_directives(entries)
             action_holdings = export_reports.classify_holdings_for_export(holdings_list,
-                                                                          commodities_map)
+                                                                          commodities)
             return fun(self, action_holdings)
         return wrapped
 
@@ -157,10 +157,10 @@ class TestCommodityClassifications(unittest.TestCase):
         1900-01-01 commodity IGI806
           export: "(MONEY:CAD)"
         """
-        commodities_map = getters.get_commodity_map(entries)
+        commodities = getters.get_commodity_directives(entries)
         self.assertEqual({'USD': 'MUTF:VMMXX',
                           'CAD': 'IGI806'},
-                         export_reports.get_money_instruments(commodities_map))
+                         export_reports.get_money_instruments(commodities))
 
 
 EE = export_reports.ExportEntry

--- a/beancount/reports/price_reports.py
+++ b/beancount/reports/price_reports.py
@@ -167,8 +167,8 @@ class TickerReport(base.TableReport):
     names = ['tickers', 'symbols']
 
     def generate_table(self, entries, errors, options_map):
-        commodity_map = getters.get_commodity_map(entries)
-        ticker_info = getters.get_values_meta(commodity_map, 'name', 'ticker', 'quote')
+        commodities = getters.get_commodity_directives(entries)
+        ticker_info = getters.get_values_meta(commodities, 'name', 'ticker', 'quote')
 
         price_rows = [
             (currency, cost_currency, ticker, name)


### PR DESCRIPTION
The lexer updates a set with all the currencies seen during
parsing. This set is then assigned to the automatic 'currencies'
option. Despite what is reported in a comment, this information is not
used by beancount.core.getters.get_commodity_map(). Besides tests, the
only user is in the beancount.plugins.check_commodity plugin. The
plugin can however be rewritten in a simpler form relaying exclusively
on the information returned by get_commodity_map().

It may be argued that the set in the options dictionary is more efficient than recomputing the set with get_commodity_map(), however, the only user of the options calls this function anyway, so keeping the set around is actually more work than not doing it.