### PR TITLE
parser: Allow to specify commodities precision

### DIFF
--- a/beancount/core/display_context.py
+++ b/beancount/core/display_context.py
@@ -99,9 +99,10 @@ class _CurrencyContext:
         self.has_sign = False
         self.integer_max = 1
         self.fractional_dist = distribution.Distribution()
+        self.precision = None
 
     def __str__(self):
-        fmt = ('sign={:<2}  integer_max={:<2}  '
+        fmt = ('sign={:<2}  precision={:}  integer_max={:<2}  '
                'fractional_common={:<2}  fractional_max={:<2}  '
                '"{}" "{}"')
         dist = self.fractional_dist
@@ -126,8 +127,7 @@ class _CurrencyContext:
             example_max = example + '.' + ('0' * fractional_max)
 
         return fmt.format(
-            int(self.has_sign),
-            self.integer_max,
+            int(self.has_sign), self.precision, self.integer_max,
             '_' if dist.empty() else dist.mode(),
             '_' if dist.empty() else dist.max(),
             example_common, example_max)
@@ -157,6 +157,9 @@ class _CurrencyContext:
         Returns:
           An integer for the number of fractional digits, or None.
         """
+        if self.precision is not None:
+            return -self.precision.as_tuple().exponent
+
         if self.fractional_dist.empty():
             return None
         if precision == Precision.MOST_COMMON:
@@ -183,6 +186,11 @@ class DisplayContext:
     def set_commas(self, commas):
         """Set the default value for rendering commas."""
         self.commas = commas
+
+    def set_precision(self, precision, currency='__default__'):
+        if precision is None:
+            return
+        self.ccontexts[currency].precision = precision
 
     def __str__(self):
         oss = io.StringIO()

--- a/beancount/parser/grammar_test.py
+++ b/beancount/parser/grammar_test.py
@@ -763,6 +763,35 @@ class TestToleranceOptions(unittest.TestCase):
                           "JPY": D("0.5")},
                          options_map['inferred_tolerance_default'])
 
+class TestPrecisionMetadata(unittest.TestCase):
+
+    # pylint: disable=empty-docstring
+    @parser.parse_doc()
+    def test_precision_auto(self, _, __, options_map):
+        """
+        """
+        self.assertEqual(options_map['dcontext'].ccontexts['EUR'].precision,
+                         None)
+
+    @parser.parse_doc()
+    def test_precision_explicit(self, _, __, options_map):
+        """
+        1993-11-01 commodity EUR
+          precision: 0.01
+        """
+        self.assertEqual(options_map['dcontext'].ccontexts['EUR'].precision,
+                         Decimal('0.01'))
+
+    @parser.parse_doc(expect_errors=True)
+    def test_precision_invalid(self, _, errors, options_map):
+        """
+        1993-11-01 commodity EUR
+          precision: 0.02
+        """
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].message, "Invalid precision: 0.02")
+        self.assertEqual(options_map['dcontext'].ccontexts['EUR'].precision,
+                         None)
 
 class TestDeprecatedOptions(unittest.TestCase):
 


### PR DESCRIPTION
Use metadata on `commodity` entries to explicitly set the precision to
be used when reporting amounts in the given currency, overriding the
automagic determination. Example:

```
1993-11-01 commodity EUR
  precision: 0.01
```

I need to write a few more tests for this and implement a simple optimization, but I would like to know if this is a direction in which we want to go or not before.