### PR TITLE
Reentrant parser preparatory work

### DIFF
--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -67,12 +67,9 @@
 
 
 /* First part of user prologue.  */
-#line 11 "beancount/parser/grammar.y"
+#line 49 "beancount/parser/grammar.y"
 
 
-#include <stdio.h>
-#include <assert.h>
-#include "parser.h"
 #include "grammar.h"
 #include "lexer.h"
 
@@ -88,15 +85,15 @@ extern YY_DECL;
                                  FILENAME, LINENO, ## __VA_ARGS__);             \
     clean;                                                                      \
     if (target == NULL) {                                                       \
-        build_grammar_error_from_exception(scanner);                            \
+        build_grammar_error_from_exception(&yyloc);                             \
         YYERROR;                                                                \
     }
 
-#define FILENAME yyget_filename(scanner)
-#define LINENO ((yyloc).first_line + yyget_firstline(scanner))
+#define FILENAME (yyloc).file_name
+#define LINENO (yyloc).first_line
 
 /* Build a grammar error from the exception context. */
-void build_grammar_error_from_exception(yyscan_t scanner)
+void build_grammar_error_from_exception(YYLTYPE* loc)
 {
     TRACE_ERROR("Grammar Builder Exception");
 
@@ -113,10 +110,8 @@ void build_grammar_error_from_exception(yyscan_t scanner)
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "siOOO",
-                                           yyget_filename(scanner),
-                                           yyget_lineno(scanner) + yyget_firstline(scanner),
+                                           loc->file_name, loc->first_line,
                                            pvalue, ptype, ptraceback);
-
         if (rv == NULL) {
             /* Note: Leave the internal error trickling up its detail. */
             /* PyErr_SetString(PyExc_RuntimeError, */
@@ -133,10 +128,8 @@ void build_grammar_error_from_exception(yyscan_t scanner)
     Py_XDECREF(ptraceback);
 }
 
-
-
 /* Error-handling function. {ca6aab8b9748} */
-void yyerror(YYLTYPE *locp, yyscan_t scanner, char const* message)
+void yyerror(YYLTYPE* loc, yyscan_t scanner, char const* message)
 {
     /* Skip lex errors: they have already been registered the lexer itself. */
     if (strstr(message, "LEX_ERROR") != NULL) {
@@ -145,8 +138,7 @@ void yyerror(YYLTYPE *locp, yyscan_t scanner, char const* message)
     else {
         /* Register a syntax error with the builder. */
         PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "sis",
-                                           yyget_filename(scanner),
-                                           yyget_lineno(scanner) + yyget_firstline(scanner),
+                                           loc->file_name, loc->first_line,
                                            message);
         if (rv == NULL) {
             PyErr_SetString(PyExc_RuntimeError,
@@ -169,7 +161,7 @@ const char* getTokenName(int token);
 #define DECREF6(x1, x2, x3, x4, x5, x6)    DECREF5(x1, x2, x3, x4, x5); Py_DECREF(x6);
 
 
-#line 173 "beancount/parser/grammar.c"
+#line 165 "beancount/parser/grammar.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -203,6 +195,45 @@ const char* getTokenName(int token);
 #if YYDEBUG
 extern int yydebug;
 #endif
+/* "%code requires" blocks.  */
+#line 12 "beancount/parser/grammar.y"
+
+
+#include <stdio.h>
+#include <assert.h>
+#include "parser.h"
+
+/* Extend default location type with file name information. */
+typedef struct YYLTYPE {
+    int first_line;
+    int first_column;
+    int last_line;
+    int last_column;
+    const char* file_name;
+} YYLTYPE;
+
+#define YYLTYPE_IS_DECLARED 1
+
+/* Extend defult location action to copy file name over. */
+#define YYLLOC_DEFAULT(current, rhs, N)                                 \
+    do {                                                                \
+        if (N) {                                                        \
+            (current).first_line   = YYRHSLOC(rhs, 1).first_line;       \
+            (current).first_column = YYRHSLOC(rhs, 1).first_column;     \
+            (current).last_line    = YYRHSLOC(rhs, N).last_line;        \
+            (current).last_column  = YYRHSLOC(rhs, N).last_column;      \
+            (current).file_name    = YYRHSLOC(rhs, N).file_name;        \
+        } else {                                                        \
+            (current).first_line   = (current).last_line =              \
+                YYRHSLOC(rhs, 0).last_line;                             \
+            (current).first_column = (current).last_column =            \
+                YYRHSLOC(rhs, 0).last_column;                           \
+            (current).file_name    = YYRHSLOC(rhs, 0).file_name;        \
+        }                                                               \
+    } while (0)
+
+
+#line 237 "beancount/parser/grammar.c"
 
 /* Token kinds.  */
 #ifndef YYTOKENTYPE
@@ -275,7 +306,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 126 "beancount/parser/grammar.y"
+#line 156 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -285,7 +316,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 289 "beancount/parser/grammar.c"
+#line 320 "beancount/parser/grammar.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -801,20 +832,20 @@ static const yytype_int8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   260,   260,   263,   267,   271,   275,   280,   281,   285,
-     286,   287,   288,   294,   298,   303,   308,   313,   318,   323,
-     327,   332,   337,   342,   349,   357,   362,   368,   374,   378,
-     382,   386,   388,   393,   398,   403,   408,   414,   420,   425,
-     426,   427,   428,   429,   430,   431,   432,   433,   437,   443,
-     448,   452,   457,   462,   468,   473,   479,   484,   489,   495,
-     501,   507,   516,   522,   529,   533,   539,   545,   551,   557,
-     563,   569,   577,   584,   589,   594,   599,   604,   609,   614,
-     621,   627,   632,   637,   643,   648,   653,   659,   663,   667,
-     671,   678,   684,   690,   696,   702,   704,   711,   716,   721,
-     726,   731,   736,   746,   751,   757,   764,   765,   766,   767,
-     768,   769,   770,   771,   772,   773,   774,   775,   780,   786,
-     792,   797,   803,   804,   805,   806,   807,   808,   809,   810,
-     813,   817,   822,   840,   847
+       0,   290,   290,   293,   297,   301,   305,   310,   311,   315,
+     316,   317,   318,   324,   328,   333,   338,   343,   348,   353,
+     357,   362,   367,   372,   379,   387,   392,   398,   404,   408,
+     412,   416,   418,   423,   428,   433,   438,   444,   450,   455,
+     456,   457,   458,   459,   460,   461,   462,   463,   467,   473,
+     478,   482,   487,   492,   498,   503,   509,   514,   519,   525,
+     531,   537,   546,   552,   559,   563,   569,   575,   581,   587,
+     593,   599,   607,   614,   619,   624,   629,   634,   639,   644,
+     651,   657,   662,   667,   673,   678,   683,   689,   693,   697,
+     701,   708,   714,   720,   726,   732,   734,   741,   746,   751,
+     756,   761,   766,   776,   781,   787,   794,   795,   796,   797,
+     798,   799,   800,   801,   802,   803,   804,   805,   810,   816,
+     822,   827,   833,   834,   835,   836,   837,   838,   839,   840,
+     843,   847,   852,   870,   877
 };
 #endif
 
@@ -1954,136 +1985,136 @@ yyreduce:
   switch (yyn)
     {
   case 3:
-#line 264 "beancount/parser/grammar.y"
+#line 294 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1962 "beancount/parser/grammar.c"
+#line 1993 "beancount/parser/grammar.c"
     break;
 
   case 4:
-#line 268 "beancount/parser/grammar.y"
+#line 298 "beancount/parser/grammar.y"
     {
         (yyval.character) = (yyvsp[0].character);
     }
-#line 1970 "beancount/parser/grammar.c"
+#line 2001 "beancount/parser/grammar.c"
     break;
 
   case 5:
-#line 272 "beancount/parser/grammar.y"
+#line 302 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1978 "beancount/parser/grammar.c"
+#line 2009 "beancount/parser/grammar.c"
     break;
 
   case 6:
-#line 276 "beancount/parser/grammar.y"
+#line 306 "beancount/parser/grammar.y"
     {
         (yyval.character) = '#';
     }
-#line 1986 "beancount/parser/grammar.c"
+#line 2017 "beancount/parser/grammar.c"
     break;
 
   case 13:
-#line 295 "beancount/parser/grammar.y"
+#line 325 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1994 "beancount/parser/grammar.c"
+#line 2025 "beancount/parser/grammar.c"
     break;
 
   case 14:
-#line 299 "beancount/parser/grammar.y"
+#line 329 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Add((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2003 "beancount/parser/grammar.c"
+#line 2034 "beancount/parser/grammar.c"
     break;
 
   case 15:
-#line 304 "beancount/parser/grammar.y"
+#line 334 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Subtract((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2012 "beancount/parser/grammar.c"
+#line 2043 "beancount/parser/grammar.c"
     break;
 
   case 16:
-#line 309 "beancount/parser/grammar.y"
+#line 339 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Multiply((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2021 "beancount/parser/grammar.c"
+#line 2052 "beancount/parser/grammar.c"
     break;
 
   case 17:
-#line 314 "beancount/parser/grammar.y"
+#line 344 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_TrueDivide((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2030 "beancount/parser/grammar.c"
+#line 2061 "beancount/parser/grammar.c"
     break;
 
   case 18:
-#line 319 "beancount/parser/grammar.y"
+#line 349 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Negative((yyvsp[0].pyobj));
                 DECREF1((yyvsp[0].pyobj));
             }
-#line 2039 "beancount/parser/grammar.c"
+#line 2070 "beancount/parser/grammar.c"
     break;
 
   case 19:
-#line 324 "beancount/parser/grammar.y"
+#line 354 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2047 "beancount/parser/grammar.c"
+#line 2078 "beancount/parser/grammar.c"
     break;
 
   case 20:
-#line 328 "beancount/parser/grammar.y"
+#line 358 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 2055 "beancount/parser/grammar.c"
+#line 2086 "beancount/parser/grammar.c"
     break;
 
   case 21:
-#line 333 "beancount/parser/grammar.y"
+#line 363 "beancount/parser/grammar.y"
             {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2064 "beancount/parser/grammar.c"
+#line 2095 "beancount/parser/grammar.c"
     break;
 
   case 22:
-#line 338 "beancount/parser/grammar.y"
+#line 368 "beancount/parser/grammar.y"
             {
                 BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
             }
-#line 2073 "beancount/parser/grammar.c"
+#line 2104 "beancount/parser/grammar.c"
     break;
 
   case 23:
-#line 343 "beancount/parser/grammar.y"
+#line 373 "beancount/parser/grammar.y"
             {
                 BUILDY(,
                        (yyval.pyobj), "pipe_deprecated_error", "");
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 2083 "beancount/parser/grammar.c"
+#line 2114 "beancount/parser/grammar.c"
     break;
 
   case 24:
-#line 350 "beancount/parser/grammar.y"
+#line 380 "beancount/parser/grammar.y"
            {
                /* Note: We're passing a bogus value here in order to avoid
                 * having to declare a second macro just for this one special
@@ -2091,247 +2122,247 @@ yyreduce:
                BUILDY(,
                       (yyval.pyobj), "tag_link_new", "O", Py_None);
            }
-#line 2095 "beancount/parser/grammar.c"
+#line 2126 "beancount/parser/grammar.c"
     break;
 
   case 25:
-#line 358 "beancount/parser/grammar.y"
+#line 388 "beancount/parser/grammar.y"
            {
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 2104 "beancount/parser/grammar.c"
+#line 2135 "beancount/parser/grammar.c"
     break;
 
   case 26:
-#line 363 "beancount/parser/grammar.y"
+#line 393 "beancount/parser/grammar.y"
            {
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 2113 "beancount/parser/grammar.c"
+#line 2144 "beancount/parser/grammar.c"
     break;
 
   case 27:
-#line 369 "beancount/parser/grammar.y"
+#line 399 "beancount/parser/grammar.y"
             {
                 BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "transaction", "ObOOO", (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2122 "beancount/parser/grammar.c"
+#line 2153 "beancount/parser/grammar.c"
     break;
 
   case 28:
-#line 375 "beancount/parser/grammar.y"
+#line 405 "beancount/parser/grammar.y"
         {
             (yyval.character) = '\0';
         }
-#line 2130 "beancount/parser/grammar.c"
+#line 2161 "beancount/parser/grammar.c"
     break;
 
   case 29:
-#line 379 "beancount/parser/grammar.y"
+#line 409 "beancount/parser/grammar.y"
         {
             (yyval.character) = '*';
         }
-#line 2138 "beancount/parser/grammar.c"
+#line 2169 "beancount/parser/grammar.c"
     break;
 
   case 30:
-#line 383 "beancount/parser/grammar.y"
+#line 413 "beancount/parser/grammar.y"
         {
             (yyval.character) = '#';
         }
-#line 2146 "beancount/parser/grammar.c"
+#line 2177 "beancount/parser/grammar.c"
     break;
 
   case 32:
-#line 389 "beancount/parser/grammar.y"
+#line 419 "beancount/parser/grammar.y"
                  {
                      (yyval.pyobj) = (yyvsp[0].pyobj);
                  }
-#line 2154 "beancount/parser/grammar.c"
+#line 2185 "beancount/parser/grammar.c"
     break;
 
   case 33:
-#line 394 "beancount/parser/grammar.y"
+#line 424 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
         }
-#line 2163 "beancount/parser/grammar.c"
+#line 2194 "beancount/parser/grammar.c"
     break;
 
   case 34:
-#line 399 "beancount/parser/grammar.y"
+#line 429 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
         }
-#line 2172 "beancount/parser/grammar.c"
+#line 2203 "beancount/parser/grammar.c"
     break;
 
   case 35:
-#line 404 "beancount/parser/grammar.y"
+#line 434 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
         }
-#line 2181 "beancount/parser/grammar.c"
+#line 2212 "beancount/parser/grammar.c"
     break;
 
   case 36:
-#line 409 "beancount/parser/grammar.y"
+#line 439 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF1((yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-1].pyobj), missing_obj, Py_None, Py_None, Py_False, (yyvsp[-2].character));
         }
-#line 2190 "beancount/parser/grammar.c"
+#line 2221 "beancount/parser/grammar.c"
     break;
 
   case 37:
-#line 415 "beancount/parser/grammar.y"
+#line 445 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
           }
-#line 2199 "beancount/parser/grammar.c"
+#line 2230 "beancount/parser/grammar.c"
     break;
 
   case 38:
-#line 421 "beancount/parser/grammar.y"
+#line 451 "beancount/parser/grammar.y"
                {
                    (yyval.pyobj) = (yyvsp[-1].pyobj);
                }
-#line 2207 "beancount/parser/grammar.c"
+#line 2238 "beancount/parser/grammar.c"
     break;
 
   case 47:
-#line 434 "beancount/parser/grammar.y"
+#line 464 "beancount/parser/grammar.y"
                 {
                     (yyval.pyobj) = (yyvsp[0].pyobj);
                 }
-#line 2215 "beancount/parser/grammar.c"
+#line 2246 "beancount/parser/grammar.c"
     break;
 
   case 48:
-#line 438 "beancount/parser/grammar.y"
+#line 468 "beancount/parser/grammar.y"
                 {
                     Py_INCREF(Py_None);
                     (yyval.pyobj) = Py_None;
                 }
-#line 2224 "beancount/parser/grammar.c"
+#line 2255 "beancount/parser/grammar.c"
     break;
 
   case 49:
-#line 444 "beancount/parser/grammar.y"
+#line 474 "beancount/parser/grammar.y"
                    {
                        Py_INCREF(Py_None);
                        (yyval.pyobj) = Py_None;
                    }
-#line 2233 "beancount/parser/grammar.c"
+#line 2264 "beancount/parser/grammar.c"
     break;
 
   case 50:
-#line 449 "beancount/parser/grammar.y"
+#line 479 "beancount/parser/grammar.y"
                    {
                        (yyval.pyobj) = (yyvsp[-3].pyobj);
                    }
-#line 2241 "beancount/parser/grammar.c"
+#line 2272 "beancount/parser/grammar.c"
     break;
 
   case 51:
-#line 453 "beancount/parser/grammar.y"
+#line 483 "beancount/parser/grammar.y"
                    {
                        BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
                    }
-#line 2250 "beancount/parser/grammar.c"
+#line 2281 "beancount/parser/grammar.c"
     break;
 
   case 52:
-#line 458 "beancount/parser/grammar.y"
+#line 488 "beancount/parser/grammar.y"
                    {
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2259 "beancount/parser/grammar.c"
+#line 2290 "beancount/parser/grammar.c"
     break;
 
   case 53:
-#line 463 "beancount/parser/grammar.y"
+#line 493 "beancount/parser/grammar.y"
                    {
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2268 "beancount/parser/grammar.c"
+#line 2299 "beancount/parser/grammar.c"
     break;
 
   case 54:
-#line 469 "beancount/parser/grammar.y"
+#line 499 "beancount/parser/grammar.y"
                {
                    Py_INCREF(Py_None);
                    (yyval.pyobj) = Py_None;
                }
-#line 2277 "beancount/parser/grammar.c"
+#line 2308 "beancount/parser/grammar.c"
     break;
 
   case 55:
-#line 474 "beancount/parser/grammar.y"
+#line 504 "beancount/parser/grammar.y"
                {
                    BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                }
-#line 2286 "beancount/parser/grammar.c"
+#line 2317 "beancount/parser/grammar.c"
     break;
 
   case 56:
-#line 480 "beancount/parser/grammar.y"
+#line 510 "beancount/parser/grammar.y"
               {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
               }
-#line 2295 "beancount/parser/grammar.c"
+#line 2326 "beancount/parser/grammar.c"
     break;
 
   case 57:
-#line 485 "beancount/parser/grammar.y"
+#line 515 "beancount/parser/grammar.y"
               {
                   BUILDY(DECREF1((yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
               }
-#line 2304 "beancount/parser/grammar.c"
+#line 2335 "beancount/parser/grammar.c"
     break;
 
   case 58:
-#line 490 "beancount/parser/grammar.y"
+#line 520 "beancount/parser/grammar.y"
               {
                   BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
               }
-#line 2313 "beancount/parser/grammar.c"
+#line 2344 "beancount/parser/grammar.c"
     break;
 
   case 59:
-#line 496 "beancount/parser/grammar.y"
+#line 526 "beancount/parser/grammar.y"
          {
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
          }
-#line 2322 "beancount/parser/grammar.c"
+#line 2353 "beancount/parser/grammar.c"
     break;
 
   case 60:
-#line 502 "beancount/parser/grammar.y"
+#line 532 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
        }
-#line 2331 "beancount/parser/grammar.c"
+#line 2362 "beancount/parser/grammar.c"
     break;
 
   case 61:
-#line 508 "beancount/parser/grammar.y"
+#line 538 "beancount/parser/grammar.y"
          {
              /* Note: key_value is a tuple, Py_BuildValue() won't wrap it up
               * within a tuple, so expand in the method (it receives two
@@ -2339,92 +2370,92 @@ yyreduce:
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
          }
-#line 2343 "beancount/parser/grammar.c"
+#line 2374 "beancount/parser/grammar.c"
     break;
 
   case 62:
-#line 517 "beancount/parser/grammar.y"
+#line 547 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF1((yyvsp[-2].pyobj)),
                    (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
         }
-#line 2352 "beancount/parser/grammar.c"
+#line 2383 "beancount/parser/grammar.c"
     break;
 
   case 63:
-#line 523 "beancount/parser/grammar.y"
+#line 553 "beancount/parser/grammar.y"
      {
          BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                 (yyval.pyobj), "open", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          ;
      }
-#line 2362 "beancount/parser/grammar.c"
+#line 2393 "beancount/parser/grammar.c"
     break;
 
   case 64:
-#line 530 "beancount/parser/grammar.y"
+#line 560 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2370 "beancount/parser/grammar.c"
+#line 2401 "beancount/parser/grammar.c"
     break;
 
   case 65:
-#line 534 "beancount/parser/grammar.y"
+#line 564 "beancount/parser/grammar.y"
             {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2379 "beancount/parser/grammar.c"
+#line 2410 "beancount/parser/grammar.c"
     break;
 
   case 66:
-#line 540 "beancount/parser/grammar.y"
+#line 570 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "close", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2388 "beancount/parser/grammar.c"
+#line 2419 "beancount/parser/grammar.c"
     break;
 
   case 67:
-#line 546 "beancount/parser/grammar.y"
+#line 576 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "commodity", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
           }
-#line 2397 "beancount/parser/grammar.c"
+#line 2428 "beancount/parser/grammar.c"
     break;
 
   case 68:
-#line 552 "beancount/parser/grammar.y"
+#line 582 "beancount/parser/grammar.y"
     {
         BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "pad", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
     }
-#line 2406 "beancount/parser/grammar.c"
+#line 2437 "beancount/parser/grammar.c"
     break;
 
   case 69:
-#line 558 "beancount/parser/grammar.y"
+#line 588 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
                    (yyval.pyobj), "balance", "OOOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
         }
-#line 2415 "beancount/parser/grammar.c"
+#line 2446 "beancount/parser/grammar.c"
     break;
 
   case 70:
-#line 564 "beancount/parser/grammar.y"
+#line 594 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
        }
-#line 2424 "beancount/parser/grammar.c"
+#line 2455 "beancount/parser/grammar.c"
     break;
 
   case 71:
-#line 570 "beancount/parser/grammar.y"
+#line 600 "beancount/parser/grammar.y"
                  {
                      BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
@@ -2432,269 +2463,269 @@ yyreduce:
                      Py_INCREF(Py_None);
                      ;
                  }
-#line 2436 "beancount/parser/grammar.c"
+#line 2467 "beancount/parser/grammar.c"
     break;
 
   case 72:
-#line 578 "beancount/parser/grammar.y"
+#line 608 "beancount/parser/grammar.y"
                  {
                      BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = (yyvsp[-1].pyobj);
                  }
-#line 2446 "beancount/parser/grammar.c"
+#line 2477 "beancount/parser/grammar.c"
     break;
 
   case 73:
-#line 585 "beancount/parser/grammar.y"
+#line 615 "beancount/parser/grammar.y"
              {
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2455 "beancount/parser/grammar.c"
+#line 2486 "beancount/parser/grammar.c"
     break;
 
   case 74:
-#line 590 "beancount/parser/grammar.y"
+#line 620 "beancount/parser/grammar.y"
              {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2463 "beancount/parser/grammar.c"
+#line 2494 "beancount/parser/grammar.c"
     break;
 
   case 75:
-#line 595 "beancount/parser/grammar.y"
+#line 625 "beancount/parser/grammar.y"
              {
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2472 "beancount/parser/grammar.c"
+#line 2503 "beancount/parser/grammar.c"
     break;
 
   case 76:
-#line 600 "beancount/parser/grammar.y"
+#line 630 "beancount/parser/grammar.y"
              {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2480 "beancount/parser/grammar.c"
+#line 2511 "beancount/parser/grammar.c"
     break;
 
   case 77:
-#line 605 "beancount/parser/grammar.y"
+#line 635 "beancount/parser/grammar.y"
                 {
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2489 "beancount/parser/grammar.c"
+#line 2520 "beancount/parser/grammar.c"
     break;
 
   case 78:
-#line 610 "beancount/parser/grammar.y"
+#line 640 "beancount/parser/grammar.y"
                 {
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2498 "beancount/parser/grammar.c"
+#line 2529 "beancount/parser/grammar.c"
     break;
 
   case 79:
-#line 615 "beancount/parser/grammar.y"
+#line 645 "beancount/parser/grammar.y"
                 {
                     BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                     ;
                 }
-#line 2508 "beancount/parser/grammar.c"
+#line 2539 "beancount/parser/grammar.c"
     break;
 
   case 80:
-#line 622 "beancount/parser/grammar.y"
+#line 652 "beancount/parser/grammar.y"
                   {
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                  }
-#line 2517 "beancount/parser/grammar.c"
+#line 2548 "beancount/parser/grammar.c"
     break;
 
   case 81:
-#line 628 "beancount/parser/grammar.y"
+#line 658 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
           }
-#line 2526 "beancount/parser/grammar.c"
+#line 2557 "beancount/parser/grammar.c"
     break;
 
   case 82:
-#line 633 "beancount/parser/grammar.y"
+#line 663 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
           }
-#line 2535 "beancount/parser/grammar.c"
+#line 2566 "beancount/parser/grammar.c"
     break;
 
   case 83:
-#line 638 "beancount/parser/grammar.y"
+#line 668 "beancount/parser/grammar.y"
           {
               Py_INCREF(Py_None);
               (yyval.pyobj) = Py_None;
           }
-#line 2544 "beancount/parser/grammar.c"
+#line 2575 "beancount/parser/grammar.c"
     break;
 
   case 84:
-#line 644 "beancount/parser/grammar.y"
+#line 674 "beancount/parser/grammar.y"
                {
                    /* We indicate that there was a cost if there */
                    (yyval.pyobj) = PyList_New(0);
                }
-#line 2553 "beancount/parser/grammar.c"
+#line 2584 "beancount/parser/grammar.c"
     break;
 
   case 85:
-#line 649 "beancount/parser/grammar.y"
+#line 679 "beancount/parser/grammar.y"
                {
                    BUILDY(DECREF1((yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
                }
-#line 2562 "beancount/parser/grammar.c"
+#line 2593 "beancount/parser/grammar.c"
     break;
 
   case 86:
-#line 654 "beancount/parser/grammar.y"
+#line 684 "beancount/parser/grammar.y"
                {
                    BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                }
-#line 2571 "beancount/parser/grammar.c"
+#line 2602 "beancount/parser/grammar.c"
     break;
 
   case 87:
-#line 660 "beancount/parser/grammar.y"
+#line 690 "beancount/parser/grammar.y"
           {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2579 "beancount/parser/grammar.c"
+#line 2610 "beancount/parser/grammar.c"
     break;
 
   case 88:
-#line 664 "beancount/parser/grammar.y"
+#line 694 "beancount/parser/grammar.y"
           {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2587 "beancount/parser/grammar.c"
+#line 2618 "beancount/parser/grammar.c"
     break;
 
   case 89:
-#line 668 "beancount/parser/grammar.y"
+#line 698 "beancount/parser/grammar.y"
           {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2595 "beancount/parser/grammar.c"
+#line 2626 "beancount/parser/grammar.c"
     break;
 
   case 90:
-#line 672 "beancount/parser/grammar.y"
+#line 702 "beancount/parser/grammar.y"
           {
               BUILDY(,
                      (yyval.pyobj), "cost_merge", "O", Py_None);
           }
-#line 2604 "beancount/parser/grammar.c"
+#line 2635 "beancount/parser/grammar.c"
     break;
 
   case 91:
-#line 679 "beancount/parser/grammar.y"
+#line 709 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "price", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2613 "beancount/parser/grammar.c"
+#line 2644 "beancount/parser/grammar.c"
     break;
 
   case 92:
-#line 685 "beancount/parser/grammar.y"
+#line 715 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "event", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2622 "beancount/parser/grammar.c"
+#line 2653 "beancount/parser/grammar.c"
     break;
 
   case 93:
-#line 691 "beancount/parser/grammar.y"
+#line 721 "beancount/parser/grammar.y"
          {
              BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "query", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2631 "beancount/parser/grammar.c"
+#line 2662 "beancount/parser/grammar.c"
     break;
 
   case 94:
-#line 697 "beancount/parser/grammar.y"
+#line 727 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "note", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2640 "beancount/parser/grammar.c"
+#line 2671 "beancount/parser/grammar.c"
     break;
 
   case 96:
-#line 705 "beancount/parser/grammar.y"
+#line 735 "beancount/parser/grammar.y"
          {
              BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "document", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2649 "beancount/parser/grammar.c"
+#line 2680 "beancount/parser/grammar.c"
     break;
 
   case 97:
-#line 712 "beancount/parser/grammar.y"
+#line 742 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2658 "beancount/parser/grammar.c"
+#line 2689 "beancount/parser/grammar.c"
     break;
 
   case 98:
-#line 717 "beancount/parser/grammar.y"
+#line 747 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2667 "beancount/parser/grammar.c"
+#line 2698 "beancount/parser/grammar.c"
     break;
 
   case 99:
-#line 722 "beancount/parser/grammar.y"
+#line 752 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2676 "beancount/parser/grammar.c"
+#line 2707 "beancount/parser/grammar.c"
     break;
 
   case 100:
-#line 727 "beancount/parser/grammar.y"
+#line 757 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2685 "beancount/parser/grammar.c"
+#line 2716 "beancount/parser/grammar.c"
     break;
 
   case 101:
-#line 732 "beancount/parser/grammar.y"
+#line 762 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2694 "beancount/parser/grammar.c"
+#line 2725 "beancount/parser/grammar.c"
     break;
 
   case 102:
-#line 737 "beancount/parser/grammar.y"
+#line 767 "beancount/parser/grammar.y"
              {
                  /* Obtain beancount.core.account.TYPE */
                  PyObject* module = PyImport_ImportModule("beancount.core.account");
@@ -2703,99 +2734,99 @@ yyreduce:
                  BUILDY(DECREF2((yyvsp[0].pyobj), dtype),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
              }
-#line 2707 "beancount/parser/grammar.c"
+#line 2738 "beancount/parser/grammar.c"
     break;
 
   case 103:
-#line 747 "beancount/parser/grammar.y"
+#line 777 "beancount/parser/grammar.y"
                   {
                       Py_INCREF(Py_None);
                       (yyval.pyobj) = Py_None;
                   }
-#line 2716 "beancount/parser/grammar.c"
+#line 2747 "beancount/parser/grammar.c"
     break;
 
   case 104:
-#line 752 "beancount/parser/grammar.y"
+#line 782 "beancount/parser/grammar.y"
                   {
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                   }
-#line 2725 "beancount/parser/grammar.c"
+#line 2756 "beancount/parser/grammar.c"
     break;
 
   case 105:
-#line 758 "beancount/parser/grammar.y"
+#line 788 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "custom", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
        }
-#line 2734 "beancount/parser/grammar.c"
+#line 2765 "beancount/parser/grammar.c"
     break;
 
   case 117:
-#line 776 "beancount/parser/grammar.y"
+#line 806 "beancount/parser/grammar.y"
       {
           (yyval.pyobj) = (yyvsp[0].pyobj);
       }
-#line 2742 "beancount/parser/grammar.c"
+#line 2773 "beancount/parser/grammar.c"
     break;
 
   case 118:
-#line 781 "beancount/parser/grammar.y"
+#line 811 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "option", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2751 "beancount/parser/grammar.c"
+#line 2782 "beancount/parser/grammar.c"
     break;
 
   case 119:
-#line 787 "beancount/parser/grammar.y"
+#line 817 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "include", "O", (yyvsp[-1].pyobj));
        }
-#line 2760 "beancount/parser/grammar.c"
+#line 2791 "beancount/parser/grammar.c"
     break;
 
   case 120:
-#line 793 "beancount/parser/grammar.y"
+#line 823 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "OO", (yyvsp[-1].pyobj), Py_None);
        }
-#line 2769 "beancount/parser/grammar.c"
+#line 2800 "beancount/parser/grammar.c"
     break;
 
   case 121:
-#line 798 "beancount/parser/grammar.y"
+#line 828 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2778 "beancount/parser/grammar.c"
+#line 2809 "beancount/parser/grammar.c"
     break;
 
   case 130:
-#line 814 "beancount/parser/grammar.y"
+#line 844 "beancount/parser/grammar.y"
              {
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2786 "beancount/parser/grammar.c"
+#line 2817 "beancount/parser/grammar.c"
     break;
 
   case 131:
-#line 818 "beancount/parser/grammar.y"
+#line 848 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
              }
-#line 2795 "beancount/parser/grammar.c"
+#line 2826 "beancount/parser/grammar.c"
     break;
 
   case 132:
-#line 823 "beancount/parser/grammar.y"
+#line 853 "beancount/parser/grammar.y"
              {
                  /*
                   * Ignore the error and continue reducing ({3d95e55b654e}).
@@ -2813,29 +2844,29 @@ yyreduce:
                   */
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2817 "beancount/parser/grammar.c"
+#line 2848 "beancount/parser/grammar.c"
     break;
 
   case 133:
-#line 841 "beancount/parser/grammar.y"
+#line 871 "beancount/parser/grammar.y"
              {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
              }
-#line 2826 "beancount/parser/grammar.c"
+#line 2857 "beancount/parser/grammar.c"
     break;
 
   case 134:
-#line 848 "beancount/parser/grammar.y"
+#line 878 "beancount/parser/grammar.y"
      {
          BUILDY(DECREF1((yyvsp[0].pyobj)),
                 (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2835 "beancount/parser/grammar.c"
+#line 2866 "beancount/parser/grammar.c"
     break;
 
 
-#line 2839 "beancount/parser/grammar.c"
+#line 2870 "beancount/parser/grammar.c"
 
       default: break;
     }
@@ -3065,7 +3096,7 @@ yyreturn:
   return yyresult;
 }
 
-#line 856 "beancount/parser/grammar.y"
+#line 886 "beancount/parser/grammar.y"
 
 
 /* A function that will convert a token name to a string, used in debugging. */

--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -84,15 +84,16 @@ extern YY_DECL;
  * reduced rule. {05bb0fb60e86}
  */
 #define BUILDY(clean, target, method_name, format, ...)                         \
-    target = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);    \
+    target = PyObject_CallMethod(builder, method_name, "si" format,             \
+                                 FILENAME, LINENO, ## __VA_ARGS__);             \
     clean;                                                                      \
     if (target == NULL) {                                                       \
         build_grammar_error_from_exception(scanner);                            \
         YYERROR;                                                                \
     }
 
-#define FILE_LINE_ARGS  yyget_filename(scanner), ((yyloc).first_line + yyget_firstline(scanner))
-
+#define FILENAME yyget_filename(scanner)
+#define LINENO ((yyloc).first_line + yyget_firstline(scanner))
 
 /* Build a grammar error from the exception context. */
 void build_grammar_error_from_exception(yyscan_t scanner)
@@ -168,7 +169,7 @@ const char* getTokenName(int token);
 #define DECREF6(x1, x2, x3, x4, x5, x6)    DECREF5(x1, x2, x3, x4, x5); Py_DECREF(x6);
 
 
-#line 172 "beancount/parser/grammar.c"
+#line 173 "beancount/parser/grammar.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -274,7 +275,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 125 "beancount/parser/grammar.y"
+#line 126 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -284,7 +285,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 288 "beancount/parser/grammar.c"
+#line 289 "beancount/parser/grammar.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -800,20 +801,20 @@ static const yytype_int8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   259,   259,   262,   266,   270,   274,   279,   280,   284,
-     285,   286,   287,   293,   297,   302,   307,   312,   317,   322,
-     326,   331,   336,   341,   348,   356,   361,   367,   373,   377,
-     381,   385,   387,   392,   397,   402,   407,   413,   419,   424,
-     425,   426,   427,   428,   429,   430,   431,   432,   436,   442,
-     447,   451,   456,   461,   467,   472,   478,   483,   488,   494,
-     500,   506,   515,   521,   528,   532,   538,   544,   550,   556,
-     562,   568,   576,   583,   588,   593,   598,   603,   608,   613,
-     620,   626,   631,   636,   642,   647,   652,   658,   662,   666,
-     670,   677,   683,   689,   695,   701,   703,   710,   715,   720,
-     725,   730,   735,   745,   750,   756,   763,   764,   765,   766,
-     767,   768,   769,   770,   771,   772,   773,   774,   779,   785,
-     791,   796,   802,   803,   804,   805,   806,   807,   808,   809,
-     812,   816,   821,   839,   846
+       0,   260,   260,   263,   267,   271,   275,   280,   281,   285,
+     286,   287,   288,   294,   298,   303,   308,   313,   318,   323,
+     327,   332,   337,   342,   349,   357,   362,   368,   374,   378,
+     382,   386,   388,   393,   398,   403,   408,   414,   420,   425,
+     426,   427,   428,   429,   430,   431,   432,   433,   437,   443,
+     448,   452,   457,   462,   468,   473,   479,   484,   489,   495,
+     501,   507,   516,   522,   529,   533,   539,   545,   551,   557,
+     563,   569,   577,   584,   589,   594,   599,   604,   609,   614,
+     621,   627,   632,   637,   643,   648,   653,   659,   663,   667,
+     671,   678,   684,   690,   696,   702,   704,   711,   716,   721,
+     726,   731,   736,   746,   751,   757,   764,   765,   766,   767,
+     768,   769,   770,   771,   772,   773,   774,   775,   780,   786,
+     792,   797,   803,   804,   805,   806,   807,   808,   809,   810,
+     813,   817,   822,   840,   847
 };
 #endif
 
@@ -1953,136 +1954,136 @@ yyreduce:
   switch (yyn)
     {
   case 3:
-#line 263 "beancount/parser/grammar.y"
+#line 264 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1961 "beancount/parser/grammar.c"
+#line 1962 "beancount/parser/grammar.c"
     break;
 
   case 4:
-#line 267 "beancount/parser/grammar.y"
+#line 268 "beancount/parser/grammar.y"
     {
         (yyval.character) = (yyvsp[0].character);
     }
-#line 1969 "beancount/parser/grammar.c"
+#line 1970 "beancount/parser/grammar.c"
     break;
 
   case 5:
-#line 271 "beancount/parser/grammar.y"
+#line 272 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1977 "beancount/parser/grammar.c"
+#line 1978 "beancount/parser/grammar.c"
     break;
 
   case 6:
-#line 275 "beancount/parser/grammar.y"
+#line 276 "beancount/parser/grammar.y"
     {
         (yyval.character) = '#';
     }
-#line 1985 "beancount/parser/grammar.c"
+#line 1986 "beancount/parser/grammar.c"
     break;
 
   case 13:
-#line 294 "beancount/parser/grammar.y"
+#line 295 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 1993 "beancount/parser/grammar.c"
+#line 1994 "beancount/parser/grammar.c"
     break;
 
   case 14:
-#line 298 "beancount/parser/grammar.y"
+#line 299 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Add((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2002 "beancount/parser/grammar.c"
+#line 2003 "beancount/parser/grammar.c"
     break;
 
   case 15:
-#line 303 "beancount/parser/grammar.y"
+#line 304 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Subtract((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2011 "beancount/parser/grammar.c"
+#line 2012 "beancount/parser/grammar.c"
     break;
 
   case 16:
-#line 308 "beancount/parser/grammar.y"
+#line 309 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Multiply((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2020 "beancount/parser/grammar.c"
+#line 2021 "beancount/parser/grammar.c"
     break;
 
   case 17:
-#line 313 "beancount/parser/grammar.y"
+#line 314 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_TrueDivide((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2029 "beancount/parser/grammar.c"
+#line 2030 "beancount/parser/grammar.c"
     break;
 
   case 18:
-#line 318 "beancount/parser/grammar.y"
+#line 319 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Negative((yyvsp[0].pyobj));
                 DECREF1((yyvsp[0].pyobj));
             }
-#line 2038 "beancount/parser/grammar.c"
+#line 2039 "beancount/parser/grammar.c"
     break;
 
   case 19:
-#line 323 "beancount/parser/grammar.y"
+#line 324 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2046 "beancount/parser/grammar.c"
+#line 2047 "beancount/parser/grammar.c"
     break;
 
   case 20:
-#line 327 "beancount/parser/grammar.y"
+#line 328 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 2054 "beancount/parser/grammar.c"
+#line 2055 "beancount/parser/grammar.c"
     break;
 
   case 21:
-#line 332 "beancount/parser/grammar.y"
+#line 333 "beancount/parser/grammar.y"
             {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2063 "beancount/parser/grammar.c"
+#line 2064 "beancount/parser/grammar.c"
     break;
 
   case 22:
-#line 337 "beancount/parser/grammar.y"
+#line 338 "beancount/parser/grammar.y"
             {
                 BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
             }
-#line 2072 "beancount/parser/grammar.c"
+#line 2073 "beancount/parser/grammar.c"
     break;
 
   case 23:
-#line 342 "beancount/parser/grammar.y"
+#line 343 "beancount/parser/grammar.y"
             {
                 BUILDY(,
-                       (yyval.pyobj), "pipe_deprecated_error", "si", FILE_LINE_ARGS);
+                       (yyval.pyobj), "pipe_deprecated_error", "");
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 2082 "beancount/parser/grammar.c"
+#line 2083 "beancount/parser/grammar.c"
     break;
 
   case 24:
-#line 349 "beancount/parser/grammar.y"
+#line 350 "beancount/parser/grammar.y"
            {
                /* Note: We're passing a bogus value here in order to avoid
                 * having to declare a second macro just for this one special
@@ -2090,247 +2091,247 @@ yyreduce:
                BUILDY(,
                       (yyval.pyobj), "tag_link_new", "O", Py_None);
            }
-#line 2094 "beancount/parser/grammar.c"
+#line 2095 "beancount/parser/grammar.c"
     break;
 
   case 25:
-#line 357 "beancount/parser/grammar.y"
+#line 358 "beancount/parser/grammar.y"
            {
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 2103 "beancount/parser/grammar.c"
+#line 2104 "beancount/parser/grammar.c"
     break;
 
   case 26:
-#line 362 "beancount/parser/grammar.y"
+#line 363 "beancount/parser/grammar.y"
            {
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 2112 "beancount/parser/grammar.c"
+#line 2113 "beancount/parser/grammar.c"
     break;
 
   case 27:
-#line 368 "beancount/parser/grammar.y"
+#line 369 "beancount/parser/grammar.y"
             {
                 BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                       (yyval.pyobj), "transaction", "siObOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                       (yyval.pyobj), "transaction", "ObOOO", (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2121 "beancount/parser/grammar.c"
+#line 2122 "beancount/parser/grammar.c"
     break;
 
   case 28:
-#line 374 "beancount/parser/grammar.y"
+#line 375 "beancount/parser/grammar.y"
         {
             (yyval.character) = '\0';
         }
-#line 2129 "beancount/parser/grammar.c"
+#line 2130 "beancount/parser/grammar.c"
     break;
 
   case 29:
-#line 378 "beancount/parser/grammar.y"
+#line 379 "beancount/parser/grammar.y"
         {
             (yyval.character) = '*';
         }
-#line 2137 "beancount/parser/grammar.c"
+#line 2138 "beancount/parser/grammar.c"
     break;
 
   case 30:
-#line 382 "beancount/parser/grammar.y"
+#line 383 "beancount/parser/grammar.y"
         {
             (yyval.character) = '#';
         }
-#line 2145 "beancount/parser/grammar.c"
+#line 2146 "beancount/parser/grammar.c"
     break;
 
   case 32:
-#line 388 "beancount/parser/grammar.y"
+#line 389 "beancount/parser/grammar.y"
                  {
                      (yyval.pyobj) = (yyvsp[0].pyobj);
                  }
-#line 2153 "beancount/parser/grammar.c"
+#line 2154 "beancount/parser/grammar.c"
     break;
 
   case 33:
-#line 393 "beancount/parser/grammar.y"
+#line 394 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
-                   (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
+                   (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
         }
-#line 2162 "beancount/parser/grammar.c"
+#line 2163 "beancount/parser/grammar.c"
     break;
 
   case 34:
-#line 398 "beancount/parser/grammar.y"
+#line 399 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
-                   (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
+                   (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
         }
-#line 2171 "beancount/parser/grammar.c"
+#line 2172 "beancount/parser/grammar.c"
     break;
 
   case 35:
-#line 403 "beancount/parser/grammar.y"
+#line 404 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
-                   (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
+                   (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
         }
-#line 2180 "beancount/parser/grammar.c"
+#line 2181 "beancount/parser/grammar.c"
     break;
 
   case 36:
-#line 408 "beancount/parser/grammar.y"
+#line 409 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF1((yyvsp[-1].pyobj)),
-                   (yyval.pyobj), "posting", "siOOOOOb", FILE_LINE_ARGS, (yyvsp[-1].pyobj), missing_obj, Py_None, Py_None, Py_False, (yyvsp[-2].character));
+                   (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-1].pyobj), missing_obj, Py_None, Py_None, Py_False, (yyvsp[-2].character));
         }
-#line 2189 "beancount/parser/grammar.c"
+#line 2190 "beancount/parser/grammar.c"
     break;
 
   case 37:
-#line 414 "beancount/parser/grammar.y"
+#line 415 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
           }
-#line 2198 "beancount/parser/grammar.c"
+#line 2199 "beancount/parser/grammar.c"
     break;
 
   case 38:
-#line 420 "beancount/parser/grammar.y"
+#line 421 "beancount/parser/grammar.y"
                {
                    (yyval.pyobj) = (yyvsp[-1].pyobj);
                }
-#line 2206 "beancount/parser/grammar.c"
+#line 2207 "beancount/parser/grammar.c"
     break;
 
   case 47:
-#line 433 "beancount/parser/grammar.y"
+#line 434 "beancount/parser/grammar.y"
                 {
                     (yyval.pyobj) = (yyvsp[0].pyobj);
                 }
-#line 2214 "beancount/parser/grammar.c"
+#line 2215 "beancount/parser/grammar.c"
     break;
 
   case 48:
-#line 437 "beancount/parser/grammar.y"
+#line 438 "beancount/parser/grammar.y"
                 {
                     Py_INCREF(Py_None);
                     (yyval.pyobj) = Py_None;
                 }
-#line 2223 "beancount/parser/grammar.c"
+#line 2224 "beancount/parser/grammar.c"
     break;
 
   case 49:
-#line 443 "beancount/parser/grammar.y"
+#line 444 "beancount/parser/grammar.y"
                    {
                        Py_INCREF(Py_None);
                        (yyval.pyobj) = Py_None;
                    }
-#line 2232 "beancount/parser/grammar.c"
+#line 2233 "beancount/parser/grammar.c"
     break;
 
   case 50:
-#line 448 "beancount/parser/grammar.y"
+#line 449 "beancount/parser/grammar.y"
                    {
                        (yyval.pyobj) = (yyvsp[-3].pyobj);
                    }
-#line 2240 "beancount/parser/grammar.c"
+#line 2241 "beancount/parser/grammar.c"
     break;
 
   case 51:
-#line 452 "beancount/parser/grammar.y"
+#line 453 "beancount/parser/grammar.y"
                    {
                        BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
                    }
-#line 2249 "beancount/parser/grammar.c"
+#line 2250 "beancount/parser/grammar.c"
     break;
 
   case 52:
-#line 457 "beancount/parser/grammar.y"
+#line 458 "beancount/parser/grammar.y"
                    {
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2258 "beancount/parser/grammar.c"
+#line 2259 "beancount/parser/grammar.c"
     break;
 
   case 53:
-#line 462 "beancount/parser/grammar.y"
+#line 463 "beancount/parser/grammar.y"
                    {
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2267 "beancount/parser/grammar.c"
+#line 2268 "beancount/parser/grammar.c"
     break;
 
   case 54:
-#line 468 "beancount/parser/grammar.y"
+#line 469 "beancount/parser/grammar.y"
                {
                    Py_INCREF(Py_None);
                    (yyval.pyobj) = Py_None;
                }
-#line 2276 "beancount/parser/grammar.c"
+#line 2277 "beancount/parser/grammar.c"
     break;
 
   case 55:
-#line 473 "beancount/parser/grammar.y"
+#line 474 "beancount/parser/grammar.y"
                {
                    BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                }
-#line 2285 "beancount/parser/grammar.c"
+#line 2286 "beancount/parser/grammar.c"
     break;
 
   case 56:
-#line 479 "beancount/parser/grammar.y"
+#line 480 "beancount/parser/grammar.y"
               {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
               }
-#line 2294 "beancount/parser/grammar.c"
+#line 2295 "beancount/parser/grammar.c"
     break;
 
   case 57:
-#line 484 "beancount/parser/grammar.y"
+#line 485 "beancount/parser/grammar.y"
               {
                   BUILDY(DECREF1((yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
               }
-#line 2303 "beancount/parser/grammar.c"
+#line 2304 "beancount/parser/grammar.c"
     break;
 
   case 58:
-#line 489 "beancount/parser/grammar.y"
+#line 490 "beancount/parser/grammar.y"
               {
                   BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
               }
-#line 2312 "beancount/parser/grammar.c"
+#line 2313 "beancount/parser/grammar.c"
     break;
 
   case 59:
-#line 495 "beancount/parser/grammar.y"
+#line 496 "beancount/parser/grammar.y"
          {
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
          }
-#line 2321 "beancount/parser/grammar.c"
+#line 2322 "beancount/parser/grammar.c"
     break;
 
   case 60:
-#line 501 "beancount/parser/grammar.y"
+#line 502 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
        }
-#line 2330 "beancount/parser/grammar.c"
+#line 2331 "beancount/parser/grammar.c"
     break;
 
   case 61:
-#line 507 "beancount/parser/grammar.y"
+#line 508 "beancount/parser/grammar.y"
          {
              /* Note: key_value is a tuple, Py_BuildValue() won't wrap it up
               * within a tuple, so expand in the method (it receives two
@@ -2338,92 +2339,92 @@ yyreduce:
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
          }
-#line 2342 "beancount/parser/grammar.c"
+#line 2343 "beancount/parser/grammar.c"
     break;
 
   case 62:
-#line 516 "beancount/parser/grammar.y"
+#line 517 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF1((yyvsp[-2].pyobj)),
                    (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
         }
-#line 2351 "beancount/parser/grammar.c"
+#line 2352 "beancount/parser/grammar.c"
     break;
 
   case 63:
-#line 522 "beancount/parser/grammar.y"
+#line 523 "beancount/parser/grammar.y"
      {
          BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                (yyval.pyobj), "open", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                (yyval.pyobj), "open", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          ;
      }
-#line 2361 "beancount/parser/grammar.c"
+#line 2362 "beancount/parser/grammar.c"
     break;
 
   case 64:
-#line 529 "beancount/parser/grammar.y"
+#line 530 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2369 "beancount/parser/grammar.c"
+#line 2370 "beancount/parser/grammar.c"
     break;
 
   case 65:
-#line 533 "beancount/parser/grammar.y"
+#line 534 "beancount/parser/grammar.y"
             {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2378 "beancount/parser/grammar.c"
+#line 2379 "beancount/parser/grammar.c"
     break;
 
   case 66:
-#line 539 "beancount/parser/grammar.y"
+#line 540 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                 (yyval.pyobj), "close", "siOOO", FILE_LINE_ARGS, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                 (yyval.pyobj), "close", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2387 "beancount/parser/grammar.c"
+#line 2388 "beancount/parser/grammar.c"
     break;
 
   case 67:
-#line 545 "beancount/parser/grammar.y"
+#line 546 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                     (yyval.pyobj), "commodity", "siOOO", FILE_LINE_ARGS, (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                     (yyval.pyobj), "commodity", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
           }
-#line 2396 "beancount/parser/grammar.c"
+#line 2397 "beancount/parser/grammar.c"
     break;
 
   case 68:
-#line 551 "beancount/parser/grammar.y"
+#line 552 "beancount/parser/grammar.y"
     {
         BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-               (yyval.pyobj), "pad", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+               (yyval.pyobj), "pad", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
     }
-#line 2405 "beancount/parser/grammar.c"
+#line 2406 "beancount/parser/grammar.c"
     break;
 
   case 69:
-#line 557 "beancount/parser/grammar.y"
+#line 558 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
-                   (yyval.pyobj), "balance", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
+                   (yyval.pyobj), "balance", "OOOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
         }
-#line 2414 "beancount/parser/grammar.c"
+#line 2415 "beancount/parser/grammar.c"
     break;
 
   case 70:
-#line 563 "beancount/parser/grammar.y"
+#line 564 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
        }
-#line 2423 "beancount/parser/grammar.c"
+#line 2424 "beancount/parser/grammar.c"
     break;
 
   case 71:
-#line 569 "beancount/parser/grammar.y"
+#line 570 "beancount/parser/grammar.y"
                  {
                      BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
@@ -2431,269 +2432,269 @@ yyreduce:
                      Py_INCREF(Py_None);
                      ;
                  }
-#line 2435 "beancount/parser/grammar.c"
+#line 2436 "beancount/parser/grammar.c"
     break;
 
   case 72:
-#line 577 "beancount/parser/grammar.y"
+#line 578 "beancount/parser/grammar.y"
                  {
                      BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = (yyvsp[-1].pyobj);
                  }
-#line 2445 "beancount/parser/grammar.c"
+#line 2446 "beancount/parser/grammar.c"
     break;
 
   case 73:
-#line 584 "beancount/parser/grammar.y"
+#line 585 "beancount/parser/grammar.y"
              {
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2454 "beancount/parser/grammar.c"
+#line 2455 "beancount/parser/grammar.c"
     break;
 
   case 74:
-#line 589 "beancount/parser/grammar.y"
+#line 590 "beancount/parser/grammar.y"
              {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2462 "beancount/parser/grammar.c"
+#line 2463 "beancount/parser/grammar.c"
     break;
 
   case 75:
-#line 594 "beancount/parser/grammar.y"
+#line 595 "beancount/parser/grammar.y"
              {
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2471 "beancount/parser/grammar.c"
+#line 2472 "beancount/parser/grammar.c"
     break;
 
   case 76:
-#line 599 "beancount/parser/grammar.y"
+#line 600 "beancount/parser/grammar.y"
              {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2479 "beancount/parser/grammar.c"
+#line 2480 "beancount/parser/grammar.c"
     break;
 
   case 77:
-#line 604 "beancount/parser/grammar.y"
+#line 605 "beancount/parser/grammar.y"
                 {
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2488 "beancount/parser/grammar.c"
+#line 2489 "beancount/parser/grammar.c"
     break;
 
   case 78:
-#line 609 "beancount/parser/grammar.y"
+#line 610 "beancount/parser/grammar.y"
                 {
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2497 "beancount/parser/grammar.c"
+#line 2498 "beancount/parser/grammar.c"
     break;
 
   case 79:
-#line 614 "beancount/parser/grammar.y"
+#line 615 "beancount/parser/grammar.y"
                 {
                     BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                     ;
                 }
-#line 2507 "beancount/parser/grammar.c"
+#line 2508 "beancount/parser/grammar.c"
     break;
 
   case 80:
-#line 621 "beancount/parser/grammar.y"
+#line 622 "beancount/parser/grammar.y"
                   {
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                  }
-#line 2516 "beancount/parser/grammar.c"
+#line 2517 "beancount/parser/grammar.c"
     break;
 
   case 81:
-#line 627 "beancount/parser/grammar.y"
+#line 628 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
           }
-#line 2525 "beancount/parser/grammar.c"
+#line 2526 "beancount/parser/grammar.c"
     break;
 
   case 82:
-#line 632 "beancount/parser/grammar.y"
+#line 633 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
           }
-#line 2534 "beancount/parser/grammar.c"
+#line 2535 "beancount/parser/grammar.c"
     break;
 
   case 83:
-#line 637 "beancount/parser/grammar.y"
+#line 638 "beancount/parser/grammar.y"
           {
               Py_INCREF(Py_None);
               (yyval.pyobj) = Py_None;
           }
-#line 2543 "beancount/parser/grammar.c"
+#line 2544 "beancount/parser/grammar.c"
     break;
 
   case 84:
-#line 643 "beancount/parser/grammar.y"
+#line 644 "beancount/parser/grammar.y"
                {
                    /* We indicate that there was a cost if there */
                    (yyval.pyobj) = PyList_New(0);
                }
-#line 2552 "beancount/parser/grammar.c"
+#line 2553 "beancount/parser/grammar.c"
     break;
 
   case 85:
-#line 648 "beancount/parser/grammar.y"
+#line 649 "beancount/parser/grammar.y"
                {
                    BUILDY(DECREF1((yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
                }
-#line 2561 "beancount/parser/grammar.c"
+#line 2562 "beancount/parser/grammar.c"
     break;
 
   case 86:
-#line 653 "beancount/parser/grammar.y"
+#line 654 "beancount/parser/grammar.y"
                {
                    BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                }
-#line 2570 "beancount/parser/grammar.c"
+#line 2571 "beancount/parser/grammar.c"
     break;
 
   case 87:
-#line 659 "beancount/parser/grammar.y"
+#line 660 "beancount/parser/grammar.y"
           {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2578 "beancount/parser/grammar.c"
+#line 2579 "beancount/parser/grammar.c"
     break;
 
   case 88:
-#line 663 "beancount/parser/grammar.y"
+#line 664 "beancount/parser/grammar.y"
           {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2586 "beancount/parser/grammar.c"
+#line 2587 "beancount/parser/grammar.c"
     break;
 
   case 89:
-#line 667 "beancount/parser/grammar.y"
+#line 668 "beancount/parser/grammar.y"
           {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2594 "beancount/parser/grammar.c"
+#line 2595 "beancount/parser/grammar.c"
     break;
 
   case 90:
-#line 671 "beancount/parser/grammar.y"
+#line 672 "beancount/parser/grammar.y"
           {
               BUILDY(,
                      (yyval.pyobj), "cost_merge", "O", Py_None);
           }
-#line 2603 "beancount/parser/grammar.c"
+#line 2604 "beancount/parser/grammar.c"
     break;
 
   case 91:
-#line 678 "beancount/parser/grammar.y"
+#line 679 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                 (yyval.pyobj), "price", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                 (yyval.pyobj), "price", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2612 "beancount/parser/grammar.c"
+#line 2613 "beancount/parser/grammar.c"
     break;
 
   case 92:
-#line 684 "beancount/parser/grammar.y"
+#line 685 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                 (yyval.pyobj), "event", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                 (yyval.pyobj), "event", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2621 "beancount/parser/grammar.c"
+#line 2622 "beancount/parser/grammar.c"
     break;
 
   case 93:
-#line 690 "beancount/parser/grammar.y"
+#line 691 "beancount/parser/grammar.y"
          {
              BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                    (yyval.pyobj), "query", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                    (yyval.pyobj), "query", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2630 "beancount/parser/grammar.c"
+#line 2631 "beancount/parser/grammar.c"
     break;
 
   case 94:
-#line 696 "beancount/parser/grammar.y"
+#line 697 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                 (yyval.pyobj), "note", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                 (yyval.pyobj), "note", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2639 "beancount/parser/grammar.c"
+#line 2640 "beancount/parser/grammar.c"
     break;
 
   case 96:
-#line 704 "beancount/parser/grammar.y"
+#line 705 "beancount/parser/grammar.y"
          {
              BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                    (yyval.pyobj), "document", "siOOOOO", FILE_LINE_ARGS, (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                    (yyval.pyobj), "document", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2648 "beancount/parser/grammar.c"
+#line 2649 "beancount/parser/grammar.c"
     break;
 
   case 97:
-#line 711 "beancount/parser/grammar.y"
+#line 712 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2657 "beancount/parser/grammar.c"
+#line 2658 "beancount/parser/grammar.c"
     break;
 
   case 98:
-#line 716 "beancount/parser/grammar.y"
+#line 717 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2666 "beancount/parser/grammar.c"
+#line 2667 "beancount/parser/grammar.c"
     break;
 
   case 99:
-#line 721 "beancount/parser/grammar.y"
+#line 722 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2675 "beancount/parser/grammar.c"
+#line 2676 "beancount/parser/grammar.c"
     break;
 
   case 100:
-#line 726 "beancount/parser/grammar.y"
+#line 727 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2684 "beancount/parser/grammar.c"
+#line 2685 "beancount/parser/grammar.c"
     break;
 
   case 101:
-#line 731 "beancount/parser/grammar.y"
+#line 732 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2693 "beancount/parser/grammar.c"
+#line 2694 "beancount/parser/grammar.c"
     break;
 
   case 102:
-#line 736 "beancount/parser/grammar.y"
+#line 737 "beancount/parser/grammar.y"
              {
                  /* Obtain beancount.core.account.TYPE */
                  PyObject* module = PyImport_ImportModule("beancount.core.account");
@@ -2702,99 +2703,99 @@ yyreduce:
                  BUILDY(DECREF2((yyvsp[0].pyobj), dtype),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
              }
-#line 2706 "beancount/parser/grammar.c"
+#line 2707 "beancount/parser/grammar.c"
     break;
 
   case 103:
-#line 746 "beancount/parser/grammar.y"
+#line 747 "beancount/parser/grammar.y"
                   {
                       Py_INCREF(Py_None);
                       (yyval.pyobj) = Py_None;
                   }
-#line 2715 "beancount/parser/grammar.c"
+#line 2716 "beancount/parser/grammar.c"
     break;
 
   case 104:
-#line 751 "beancount/parser/grammar.y"
+#line 752 "beancount/parser/grammar.y"
                   {
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                   }
-#line 2724 "beancount/parser/grammar.c"
+#line 2725 "beancount/parser/grammar.c"
     break;
 
   case 105:
-#line 757 "beancount/parser/grammar.y"
+#line 758 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
-                  (yyval.pyobj), "custom", "siOOOO", FILE_LINE_ARGS, (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
+                  (yyval.pyobj), "custom", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
        }
-#line 2733 "beancount/parser/grammar.c"
+#line 2734 "beancount/parser/grammar.c"
     break;
 
   case 117:
-#line 775 "beancount/parser/grammar.y"
+#line 776 "beancount/parser/grammar.y"
       {
           (yyval.pyobj) = (yyvsp[0].pyobj);
       }
-#line 2741 "beancount/parser/grammar.c"
+#line 2742 "beancount/parser/grammar.c"
     break;
 
   case 118:
-#line 780 "beancount/parser/grammar.y"
+#line 781 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
-                  (yyval.pyobj), "option", "siOO", FILE_LINE_ARGS, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
+                  (yyval.pyobj), "option", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2750 "beancount/parser/grammar.c"
+#line 2751 "beancount/parser/grammar.c"
     break;
 
   case 119:
-#line 786 "beancount/parser/grammar.y"
+#line 787 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
-                  (yyval.pyobj), "include", "siO", FILE_LINE_ARGS, (yyvsp[-1].pyobj));
+                  (yyval.pyobj), "include", "O", (yyvsp[-1].pyobj));
        }
-#line 2759 "beancount/parser/grammar.c"
+#line 2760 "beancount/parser/grammar.c"
     break;
 
   case 120:
-#line 792 "beancount/parser/grammar.y"
+#line 793 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
-                  (yyval.pyobj), "plugin", "siOO", FILE_LINE_ARGS, (yyvsp[-1].pyobj), Py_None);
+                  (yyval.pyobj), "plugin", "OO", (yyvsp[-1].pyobj), Py_None);
        }
-#line 2768 "beancount/parser/grammar.c"
+#line 2769 "beancount/parser/grammar.c"
     break;
 
   case 121:
-#line 797 "beancount/parser/grammar.y"
+#line 798 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
-                  (yyval.pyobj), "plugin", "siOO", FILE_LINE_ARGS, (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
+                  (yyval.pyobj), "plugin", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2777 "beancount/parser/grammar.c"
+#line 2778 "beancount/parser/grammar.c"
     break;
 
   case 130:
-#line 813 "beancount/parser/grammar.y"
+#line 814 "beancount/parser/grammar.y"
              {
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2785 "beancount/parser/grammar.c"
+#line 2786 "beancount/parser/grammar.c"
     break;
 
   case 131:
-#line 817 "beancount/parser/grammar.y"
+#line 818 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
              }
-#line 2794 "beancount/parser/grammar.c"
+#line 2795 "beancount/parser/grammar.c"
     break;
 
   case 132:
-#line 822 "beancount/parser/grammar.y"
+#line 823 "beancount/parser/grammar.y"
              {
                  /*
                   * Ignore the error and continue reducing ({3d95e55b654e}).
@@ -2812,29 +2813,29 @@ yyreduce:
                   */
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2816 "beancount/parser/grammar.c"
+#line 2817 "beancount/parser/grammar.c"
     break;
 
   case 133:
-#line 840 "beancount/parser/grammar.y"
+#line 841 "beancount/parser/grammar.y"
              {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
              }
-#line 2825 "beancount/parser/grammar.c"
+#line 2826 "beancount/parser/grammar.c"
     break;
 
   case 134:
-#line 847 "beancount/parser/grammar.y"
+#line 848 "beancount/parser/grammar.y"
      {
          BUILDY(DECREF1((yyvsp[0].pyobj)),
                 (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2834 "beancount/parser/grammar.c"
+#line 2835 "beancount/parser/grammar.c"
     break;
 
 
-#line 2838 "beancount/parser/grammar.c"
+#line 2839 "beancount/parser/grammar.c"
 
       default: break;
     }
@@ -3064,7 +3065,7 @@ yyreturn:
   return yyresult;
 }
 
-#line 855 "beancount/parser/grammar.y"
+#line 856 "beancount/parser/grammar.y"
 
 
 /* A function that will convert a token name to a string, used in debugging. */

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -44,6 +44,45 @@
 #if YYDEBUG
 extern int yydebug;
 #endif
+/* "%code requires" blocks.  */
+#line 12 "beancount/parser/grammar.y"
+
+
+#include <stdio.h>
+#include <assert.h>
+#include "parser.h"
+
+/* Extend default location type with file name information. */
+typedef struct YYLTYPE {
+    int first_line;
+    int first_column;
+    int last_line;
+    int last_column;
+    const char* file_name;
+} YYLTYPE;
+
+#define YYLTYPE_IS_DECLARED 1
+
+/* Extend defult location action to copy file name over. */
+#define YYLLOC_DEFAULT(current, rhs, N)                                 \
+    do {                                                                \
+        if (N) {                                                        \
+            (current).first_line   = YYRHSLOC(rhs, 1).first_line;       \
+            (current).first_column = YYRHSLOC(rhs, 1).first_column;     \
+            (current).last_line    = YYRHSLOC(rhs, N).last_line;        \
+            (current).last_column  = YYRHSLOC(rhs, N).last_column;      \
+            (current).file_name    = YYRHSLOC(rhs, N).file_name;        \
+        } else {                                                        \
+            (current).first_line   = (current).last_line =              \
+                YYRHSLOC(rhs, 0).last_line;                             \
+            (current).first_column = (current).last_column =            \
+                YYRHSLOC(rhs, 0).last_column;                           \
+            (current).file_name    = YYRHSLOC(rhs, 0).file_name;        \
+        }                                                               \
+    } while (0)
+
+
+#line 86 "beancount/parser/grammar.h"
 
 /* Token kinds.  */
 #ifndef YYTOKENTYPE
@@ -116,7 +155,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 126 "beancount/parser/grammar.y"
+#line 156 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -126,7 +165,7 @@ union YYSTYPE
         PyObject* pyobj2;
     } pairobj;
 
-#line 130 "beancount/parser/grammar.h"
+#line 169 "beancount/parser/grammar.h"
 
 };
 typedef union YYSTYPE YYSTYPE;

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -116,7 +116,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 125 "beancount/parser/grammar.y"
+#line 126 "beancount/parser/grammar.y"
 
     char character;
     const char* string;

--- a/beancount/parser/grammar_test.py
+++ b/beancount/parser/grammar_test.py
@@ -18,6 +18,7 @@ from beancount.core.number import MISSING
 from beancount.core.amount import from_string as A
 from beancount.core.amount import Amount
 from beancount.core.position import CostSpec
+from beancount.parser import grammar
 from beancount.parser import parser
 from beancount.parser import lexer
 from beancount.core import data
@@ -2537,6 +2538,21 @@ class TestDocument(unittest.TestCase):
         """
         check_list(self, entries, [data.Document])
         self.assertEqual({'something'}, entries[0].links)
+
+
+class TestMethodsSignature(unittest.TestCase):
+
+    def test_signatures(self):
+        # Enforce that all "public" methods of the Builder class have
+        # 'filename' and 'lineno' as the first two arguments.
+        for name, func in inspect.getmembers(grammar.Builder, inspect.isfunction):
+            if (name.isupper() or
+                name.startswith('_') or
+                name.startswith('get_') or
+                name == 'finalize'):
+                continue
+            parameters = inspect.signature(func).parameters.keys()
+            self.assertEqual(list(parameters)[:3], ['self', 'filename', 'lineno'])
 
 
 if __name__ == '__main__':

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -1,4 +1,4 @@
-#line 2 "beancount/parser/lexer.c"
+#line 1 "beancount/parser/lexer.c"
 
 #include "parser.h"
 
@@ -10,13 +10,7 @@ void yylex_initialize(const char* filename, int firstline, const char* encoding,
 /* Free scanner private data */
 void yylex_finalize(yyscan_t yyscanner);
 
-/* Get the current filename from the scanner state. */
-const char* yyget_filename(yyscan_t *scanner);
-
-/* Get the first line from the scanner state. */
-int yyget_firstline(yyscan_t *scanner);
-
-#line 20 "beancount/parser/lexer.c"
+#line 13 "beancount/parser/lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -969,13 +963,11 @@ static const flex_int32_t yy_rule_can_match_eol[63] =
 /* Top Code. This is included in the FLex generated header file. */
 
 /* Definitions. */
-#line 41 "beancount/parser/lexer.l"
+#line 35 "beancount/parser/lexer.l"
 
-/* Includes. */
 #include <math.h>
 #include <stdlib.h>
 
-#include "parser.h"
 #include "grammar.h"
 
 struct buffer {
@@ -1049,11 +1041,11 @@ static inline void buffer_begin(struct buffer* b)
 #define yy_encoding yyget_extra(yyscanner)->encoding
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(const char* string, size_t length);
+void build_lexer_error(YYLTYPE* loc, const char* string, size_t length);
 
 /* Build and accumulate an error on the builder object using the current
  * exception state. */
-void build_lexer_error_from_exception(void);
+void build_lexer_error_from_exception(YYLTYPE* loc);
 
 int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
 
@@ -1065,22 +1057,25 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
     yylval->pyobj = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);     \
     /* Handle a Python exception raised by the handler {3cfb2739349a} */                \
     if (yylval->pyobj == NULL) {                                                        \
-       build_lexer_error_from_exception();                                              \
-       return LEX_ERROR;                                                                \
+	build_lexer_error_from_exception(yylloc);			                \
+	return LEX_ERROR;						                \
     }                                                                                   \
     /* Lexer builder methods should never return None, check for it. */                 \
     else if (yylval->pyobj == Py_None) {                                                \
         Py_DECREF(Py_None);                                                             \
-        build_lexer_error("Unexpected None result from lexer", 34);                     \
+        build_lexer_error(yylloc, "Unexpected None result from lexer", 34);             \
         return LEX_ERROR;                                                               \
     }
 
-#define YY_USER_ACTION {                                        \
-        yy_line_tokens++;                                       \
-        yylloc->first_line = yylloc->last_line = yylineno;      \
-        yylloc->first_column = yycolumn;                        \
-        yylloc->last_column = yycolumn+yyleng-1;                \
-        yycolumn += yyleng;                                     \
+#define YY_USER_ACTION                                                  \
+    {                                                                   \
+        yy_line_tokens++;                                               \
+        yylloc->first_line = yylineno + yy_firstline;                   \
+        yylloc->last_line = yylloc->first_line;                         \
+        yylloc->first_column = yycolumn;                                \
+        yylloc->last_column = yycolumn + yyleng - 1;                    \
+        yylloc->file_name = yy_filename;                                \
+        yycolumn += yyleng;                                             \
     }
 
 /* Skip the rest of the input line.  This needs to be implemented as a
@@ -1103,12 +1098,12 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
 
-#line 1107 "beancount/parser/lexer.c"
+#line 1101 "beancount/parser/lexer.c"
 /* A start condition for chomping an invalid token. */
 
 /* Exclusive start condition for parsing escape sequences in string literals. */
 
-#line 1112 "beancount/parser/lexer.c"
+#line 1106 "beancount/parser/lexer.c"
 
 #define INITIAL 0
 #define INVALID 1
@@ -1392,12 +1387,12 @@ YY_DECL
 		}
 
 	{
-#line 195 "beancount/parser/lexer.l"
+#line 190 "beancount/parser/lexer.l"
 
 
-#line 198 "beancount/parser/lexer.l"
+#line 193 "beancount/parser/lexer.l"
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
-#line 1401 "beancount/parser/lexer.c"
+#line 1395 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1465,7 +1460,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 199 "beancount/parser/lexer.l"
+#line 194 "beancount/parser/lexer.l"
 {
     yy_line_tokens = 0;
     yycolumn = 1;
@@ -1478,7 +1473,7 @@ YY_RULE_SETUP
     the grammar. */
 case 2:
 YY_RULE_SETUP
-#line 209 "beancount/parser/lexer.l"
+#line 204 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens == 1) {
         /* If the next character completes the line, skip it. */
@@ -1496,79 +1491,79 @@ YY_RULE_SETUP
 /* Characters with special meanings have their own tokens. */
 case 3:
 YY_RULE_SETUP
-#line 224 "beancount/parser/lexer.l"
+#line 219 "beancount/parser/lexer.l"
 { return PIPE; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 225 "beancount/parser/lexer.l"
+#line 220 "beancount/parser/lexer.l"
 { return ATAT; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 226 "beancount/parser/lexer.l"
+#line 221 "beancount/parser/lexer.l"
 { return AT; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 227 "beancount/parser/lexer.l"
+#line 222 "beancount/parser/lexer.l"
 { return LCURLCURL; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 228 "beancount/parser/lexer.l"
+#line 223 "beancount/parser/lexer.l"
 { return RCURLCURL; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 229 "beancount/parser/lexer.l"
+#line 224 "beancount/parser/lexer.l"
 { return LCURL; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 230 "beancount/parser/lexer.l"
+#line 225 "beancount/parser/lexer.l"
 { return RCURL; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 231 "beancount/parser/lexer.l"
+#line 226 "beancount/parser/lexer.l"
 { return COMMA; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 232 "beancount/parser/lexer.l"
+#line 227 "beancount/parser/lexer.l"
 { return TILDE; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 233 "beancount/parser/lexer.l"
+#line 228 "beancount/parser/lexer.l"
 { return PLUS; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 234 "beancount/parser/lexer.l"
+#line 229 "beancount/parser/lexer.l"
 { return MINUS; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 235 "beancount/parser/lexer.l"
+#line 230 "beancount/parser/lexer.l"
 { return SLASH; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 236 "beancount/parser/lexer.l"
+#line 231 "beancount/parser/lexer.l"
 { return LPAREN; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 237 "beancount/parser/lexer.l"
+#line 232 "beancount/parser/lexer.l"
 { return RPAREN; }
 	YY_BREAK
 /* Special handling for characters beginning a line to be ignored.
   * I'd like to improve how this is handled. Needs own lexer, really. */
 case 17:
 YY_RULE_SETUP
-#line 241 "beancount/parser/lexer.l"
+#line 236 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens != 1) {
         return HASH;
@@ -1582,7 +1577,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 252 "beancount/parser/lexer.l"
+#line 247 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens != 1) {
         return ASTERISK;
@@ -1596,7 +1591,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 263 "beancount/parser/lexer.l"
+#line 258 "beancount/parser/lexer.l"
 {
   if (yy_line_tokens != 1) {
     return COLON;
@@ -1611,7 +1606,7 @@ YY_RULE_SETUP
 /* Skip commented output (but not the accompanying newline). */
 case 20:
 YY_RULE_SETUP
-#line 275 "beancount/parser/lexer.l"
+#line 270 "beancount/parser/lexer.l"
 {
     /* yy_skip_line(); */
     return COMMENT;
@@ -1627,7 +1622,7 @@ YY_RULE_SETUP
     */
 case 21:
 YY_RULE_SETUP
-#line 288 "beancount/parser/lexer.l"
+#line 283 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens != 1) {
         yylval->character = yytext[0];
@@ -1642,103 +1637,103 @@ YY_RULE_SETUP
 /* Keywords. */
 case 22:
 YY_RULE_SETUP
-#line 300 "beancount/parser/lexer.l"
+#line 295 "beancount/parser/lexer.l"
 { return TXN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 301 "beancount/parser/lexer.l"
+#line 296 "beancount/parser/lexer.l"
 { return BALANCE; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 302 "beancount/parser/lexer.l"
+#line 297 "beancount/parser/lexer.l"
 { return OPEN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 303 "beancount/parser/lexer.l"
+#line 298 "beancount/parser/lexer.l"
 { return CLOSE; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 304 "beancount/parser/lexer.l"
+#line 299 "beancount/parser/lexer.l"
 { return COMMODITY; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 305 "beancount/parser/lexer.l"
+#line 300 "beancount/parser/lexer.l"
 { return PAD; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 306 "beancount/parser/lexer.l"
+#line 301 "beancount/parser/lexer.l"
 { return EVENT; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 307 "beancount/parser/lexer.l"
+#line 302 "beancount/parser/lexer.l"
 { return QUERY; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 308 "beancount/parser/lexer.l"
+#line 303 "beancount/parser/lexer.l"
 { return CUSTOM; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 309 "beancount/parser/lexer.l"
+#line 304 "beancount/parser/lexer.l"
 { return PRICE; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 310 "beancount/parser/lexer.l"
+#line 305 "beancount/parser/lexer.l"
 { return NOTE; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 311 "beancount/parser/lexer.l"
+#line 306 "beancount/parser/lexer.l"
 { return DOCUMENT; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 312 "beancount/parser/lexer.l"
+#line 307 "beancount/parser/lexer.l"
 { return PUSHTAG; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 313 "beancount/parser/lexer.l"
+#line 308 "beancount/parser/lexer.l"
 { return POPTAG; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 314 "beancount/parser/lexer.l"
+#line 309 "beancount/parser/lexer.l"
 { return PUSHMETA; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 315 "beancount/parser/lexer.l"
+#line 310 "beancount/parser/lexer.l"
 { return POPMETA; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 316 "beancount/parser/lexer.l"
+#line 311 "beancount/parser/lexer.l"
 { return OPTION; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 317 "beancount/parser/lexer.l"
+#line 312 "beancount/parser/lexer.l"
 { return PLUGIN; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 318 "beancount/parser/lexer.l"
+#line 313 "beancount/parser/lexer.l"
 { return INCLUDE; }
 	YY_BREAK
 /* Boolean values. */
 case 41:
 YY_RULE_SETUP
-#line 321 "beancount/parser/lexer.l"
+#line 316 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_True;
     Py_INCREF(Py_True);
@@ -1747,7 +1742,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 327 "beancount/parser/lexer.l"
+#line 322 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_False;
     Py_INCREF(Py_False);
@@ -1756,7 +1751,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 333 "beancount/parser/lexer.l"
+#line 328 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_None;
     Py_INCREF(Py_None);
@@ -1766,7 +1761,7 @@ YY_RULE_SETUP
 /* Dates. */
 case 44:
 YY_RULE_SETUP
-#line 340 "beancount/parser/lexer.l"
+#line 335 "beancount/parser/lexer.l"
 {
     const char* year_str;
     const char* month_str;
@@ -1791,7 +1786,7 @@ YY_RULE_SETUP
 /* Account names. */
 case 45:
 YY_RULE_SETUP
-#line 362 "beancount/parser/lexer.l"
+#line 357 "beancount/parser/lexer.l"
 {
     BUILD_LEX("ACCOUNT", "s", yytext);
     return ACCOUNT;
@@ -1801,7 +1796,7 @@ YY_RULE_SETUP
   * syntax. This is kept in sync with beancount.core.amount.CURRENCY_RE. */
 case 46:
 YY_RULE_SETUP
-#line 369 "beancount/parser/lexer.l"
+#line 364 "beancount/parser/lexer.l"
 {
     BUILD_LEX("CURRENCY", "s", yytext);
     return CURRENCY;
@@ -1812,7 +1807,7 @@ YY_RULE_SETUP
     See section "Start Conditions" in the GNU Flex manual. */
 case 47:
 YY_RULE_SETUP
-#line 377 "beancount/parser/lexer.l"
+#line 372 "beancount/parser/lexer.l"
 {
     buffer_begin(strbuf);
     BEGIN(STRLIT);
@@ -1822,13 +1817,13 @@ YY_RULE_SETUP
 /* Saw closing quote - all done. */
 case 48:
 YY_RULE_SETUP
-#line 385 "beancount/parser/lexer.l"
+#line 380 "beancount/parser/lexer.l"
 {
         BEGIN(INITIAL);
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
                                          yy_encoding, "ignore");
         if (!str) {
-            build_lexer_error_from_exception();
+            build_lexer_error_from_exception(yylloc);
             yylval->pyobj = Py_None;
             Py_INCREF(Py_None);
             return LEX_ERROR;
@@ -1841,47 +1836,47 @@ YY_RULE_SETUP
 /* Escape sequences. */
 case 49:
 YY_RULE_SETUP
-#line 401 "beancount/parser/lexer.l"
+#line 396 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\n');
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 402 "beancount/parser/lexer.l"
+#line 397 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\t');
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 403 "beancount/parser/lexer.l"
+#line 398 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\r');
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 404 "beancount/parser/lexer.l"
+#line 399 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\b');
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 405 "beancount/parser/lexer.l"
+#line 400 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\f');
 	YY_BREAK
 case 54:
 /* rule 54 can match eol */
 YY_RULE_SETUP
-#line 406 "beancount/parser/lexer.l"
+#line 401 "beancount/parser/lexer.l"
 buffer_push(strbuf, yytext[1]);
 	YY_BREAK
 /* All other characters. */
 case 55:
 /* rule 55 can match eol */
 YY_RULE_SETUP
-#line 409 "beancount/parser/lexer.l"
+#line 404 "beancount/parser/lexer.l"
 buffer_append(strbuf, yytext, yyleng);
 	YY_BREAK
 
 /* Numbers */
 case 56:
 YY_RULE_SETUP
-#line 413 "beancount/parser/lexer.l"
+#line 408 "beancount/parser/lexer.l"
 {
     BUILD_LEX("NUMBER", "s", yytext);
     return NUMBER;
@@ -1890,7 +1885,7 @@ YY_RULE_SETUP
 /* Tags */
 case 57:
 YY_RULE_SETUP
-#line 419 "beancount/parser/lexer.l"
+#line 414 "beancount/parser/lexer.l"
 {
     BUILD_LEX("TAG", "s", &(yytext[1]));
     return TAG;
@@ -1899,7 +1894,7 @@ YY_RULE_SETUP
 /* Links */
 case 58:
 YY_RULE_SETUP
-#line 425 "beancount/parser/lexer.l"
+#line 420 "beancount/parser/lexer.l"
 {
     BUILD_LEX("LINK", "s", &(yytext[1]));
     return LINK;
@@ -1908,7 +1903,7 @@ YY_RULE_SETUP
 /* Key */
 case 59:
 YY_RULE_SETUP
-#line 431 "beancount/parser/lexer.l"
+#line 426 "beancount/parser/lexer.l"
 {
     BUILD_LEX("KEY", "s#", yytext, (Py_ssize_t)(yyleng-1));
     unput(':');
@@ -1918,7 +1913,7 @@ YY_RULE_SETUP
 /* Default rule. {bf253a29a820} */
 case 60:
 YY_RULE_SETUP
-#line 438 "beancount/parser/lexer.l"
+#line 433 "beancount/parser/lexer.l"
 {
     unput(*yytext);
     BEGIN(INVALID);
@@ -1929,14 +1924,15 @@ YY_RULE_SETUP
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(INVALID):
 case YY_STATE_EOF(STRLIT):
-#line 445 "beancount/parser/lexer.l"
+#line 440 "beancount/parser/lexer.l"
 {
-  if (yy_eof_times == 0) {
-    yy_eof_times = 1;
-    yylloc->first_line = yylineno;
-    return EOL;
-  }
-  return 0;
+    if (yy_eof_times == 0) {
+	yy_eof_times = 1;
+	/* Ensure location data is populated. */
+	YY_USER_ACTION;
+	return EOL;
+    }
+    return 0;
 }
 	YY_BREAK
 /* Note: We use a subparser here because if we set a default rule to chomp this
@@ -1945,21 +1941,21 @@ case YY_STATE_EOF(STRLIT):
     this and more. {bba169a1d35a} */
 case 61:
 YY_RULE_SETUP
-#line 458 "beancount/parser/lexer.l"
+#line 454 "beancount/parser/lexer.l"
 {
     char buffer[256];
     size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
-    build_lexer_error(buffer, length);
+    build_lexer_error(yylloc, buffer, length);
     BEGIN(INITIAL);
     return LEX_ERROR;
 }
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 467 "beancount/parser/lexer.l"
+#line 463 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1963 "beancount/parser/lexer.c"
+#line 1958 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3162,7 +3158,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 467 "beancount/parser/lexer.l"
+#line 463 "beancount/parser/lexer.l"
 
 
 void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner)
@@ -3181,16 +3177,6 @@ void yylex_finalize(yyscan_t yyscanner)
 {
     buffer_free(strbuf);
     free(yyget_extra(yyscanner));
-}
-
-const char* yyget_filename(yyscan_t *scanner)
-{
-    return yyget_extra(scanner)->filename;
-}
-
-int yyget_firstline(yyscan_t *scanner)
-{
-    return yyget_extra(scanner)->line;
 }
 
 static void buffer_init(struct buffer* b, size_t size)
@@ -3237,13 +3223,14 @@ int strtonl(const char* buf, size_t nchars)
 }
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(const char* string, size_t length)
+void build_lexer_error(YYLTYPE* loc, const char* string, size_t length)
 {
     TRACE_ERROR("Invalid Token");
 
     /* Build and accumulate a new error object. {27d1d459c5cd} */
-    PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error",
-                                       "s#", string, (Py_ssize_t)length);
+    PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "sis#",
+				       loc->file_name, loc->first_line,
+				       string, (Py_ssize_t)length);
     if (rv == NULL) {
         PyErr_SetString(PyExc_RuntimeError,
                         "Internal error: Building exception from default rule");
@@ -3251,7 +3238,7 @@ void build_lexer_error(const char* string, size_t length)
     Py_XDECREF(rv);
 }
 
-void build_lexer_error_from_exception()
+void build_lexer_error_from_exception(YYLTYPE* loc)
 {
     TRACE_ERROR("Lexer Builder Exception");
 
@@ -3267,8 +3254,9 @@ void build_lexer_error_from_exception()
 
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
-        PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error",
-                                           "OO", pvalue, ptype);
+        PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "siOO",
+					   loc->file_name, loc->first_line,
+					   pvalue, ptype);
         Py_XDECREF(ptype);
         Py_XDECREF(pvalue);
         Py_XDECREF(ptraceback);

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -2,7 +2,7 @@
 #define yyHEADER_H 1
 #define yyIN_HEADER 1
 
-#line 6 "beancount/parser/lexer.h"
+#line 5 "beancount/parser/lexer.h"
 
 #include "parser.h"
 
@@ -14,13 +14,7 @@ void yylex_initialize(const char* filename, int firstline, const char* encoding,
 /* Free scanner private data */
 void yylex_finalize(yyscan_t yyscanner);
 
-/* Get the current filename from the scanner state. */
-const char* yyget_filename(yyscan_t *scanner);
-
-/* Get the first line from the scanner state. */
-int yyget_firstline(yyscan_t *scanner);
-
-#line 24 "beancount/parser/lexer.h"
+#line 17 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -534,9 +528,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 467 "beancount/parser/lexer.l"
+#line 463 "beancount/parser/lexer.l"
 
 
-#line 541 "beancount/parser/lexer.h"
+#line 534 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -28,22 +28,14 @@ void yylex_initialize(const char* filename, int firstline, const char* encoding,
 /* Free scanner private data */
 void yylex_finalize(yyscan_t yyscanner);
 
-/* Get the current filename from the scanner state. */
-const char* yyget_filename(yyscan_t *scanner);
-
-/* Get the first line from the scanner state. */
-int yyget_firstline(yyscan_t *scanner);
-
 }
 
 /* Definitions. */
 %{
 
-/* Includes. */
 #include <math.h>
 #include <stdlib.h>
 
-#include "parser.h"
 #include "grammar.h"
 
 struct buffer {
@@ -117,11 +109,11 @@ static inline void buffer_begin(struct buffer* b)
 #define yy_encoding yyget_extra(yyscanner)->encoding
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(const char* string, size_t length);
+void build_lexer_error(YYLTYPE* loc, const char* string, size_t length);
 
 /* Build and accumulate an error on the builder object using the current
  * exception state. */
-void build_lexer_error_from_exception(void);
+void build_lexer_error_from_exception(YYLTYPE* loc);
 
 int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
 
@@ -133,22 +125,25 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
     yylval->pyobj = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);     \
     /* Handle a Python exception raised by the handler {3cfb2739349a} */                \
     if (yylval->pyobj == NULL) {                                                        \
-       build_lexer_error_from_exception();                                              \
-       return LEX_ERROR;                                                                \
+	build_lexer_error_from_exception(yylloc);			                \
+	return LEX_ERROR;						                \
     }                                                                                   \
     /* Lexer builder methods should never return None, check for it. */                 \
     else if (yylval->pyobj == Py_None) {                                                \
         Py_DECREF(Py_None);                                                             \
-        build_lexer_error("Unexpected None result from lexer", 34);                     \
+        build_lexer_error(yylloc, "Unexpected None result from lexer", 34);             \
         return LEX_ERROR;                                                               \
     }
 
-#define YY_USER_ACTION {                                        \
-        yy_line_tokens++;                                       \
-        yylloc->first_line = yylloc->last_line = yylineno;      \
-        yylloc->first_column = yycolumn;                        \
-        yylloc->last_column = yycolumn+yyleng-1;                \
-        yycolumn += yyleng;                                     \
+#define YY_USER_ACTION                                                  \
+    {                                                                   \
+        yy_line_tokens++;                                               \
+        yylloc->first_line = yylineno + yy_firstline;                   \
+        yylloc->last_line = yylloc->first_line;                         \
+        yylloc->first_column = yycolumn;                                \
+        yylloc->last_column = yycolumn + yyleng - 1;                    \
+        yylloc->file_name = yy_filename;                                \
+        yycolumn += yyleng;                                             \
     }
 
 /* Skip the rest of the input line.  This needs to be implemented as a
@@ -386,7 +381,7 @@ NULL		{
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
                                          yy_encoding, "ignore");
         if (!str) {
-            build_lexer_error_from_exception();
+            build_lexer_error_from_exception(yylloc);
             yylval->pyobj = Py_None;
             Py_INCREF(Py_None);
             return LEX_ERROR;
@@ -442,12 +437,13 @@ NULL		{
  /* Fake an EOL at the end of file, to ensure that files without a final newline
   * will process postings right. */
 <<EOF>>     		{
-  if (yy_eof_times == 0) {
-    yy_eof_times = 1;
-    yylloc->first_line = yylineno;
-    return EOL;
-  }
-  return 0;
+    if (yy_eof_times == 0) {
+	yy_eof_times = 1;
+	/* Ensure location data is populated. */
+	YY_USER_ACTION;
+	return EOL;
+    }
+    return 0;
 }
 
  /* Note: We use a subparser here because if we set a default rule to chomp this
@@ -457,7 +453,7 @@ NULL		{
 <INVALID>[^ \t\n\r]+     {
     char buffer[256];
     size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
-    build_lexer_error(buffer, length);
+    build_lexer_error(yylloc, buffer, length);
     BEGIN(INITIAL);
     return LEX_ERROR;
 }
@@ -481,16 +477,6 @@ void yylex_finalize(yyscan_t yyscanner)
 {
     buffer_free(strbuf);
     free(yyget_extra(yyscanner));
-}
-
-const char* yyget_filename(yyscan_t *scanner)
-{
-    return yyget_extra(scanner)->filename;
-}
-
-int yyget_firstline(yyscan_t *scanner)
-{
-    return yyget_extra(scanner)->line;
 }
 
 static void buffer_init(struct buffer* b, size_t size)
@@ -537,13 +523,14 @@ int strtonl(const char* buf, size_t nchars)
 }
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(const char* string, size_t length)
+void build_lexer_error(YYLTYPE* loc, const char* string, size_t length)
 {
     TRACE_ERROR("Invalid Token");
 
     /* Build and accumulate a new error object. {27d1d459c5cd} */
-    PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error",
-                                       "s#", string, (Py_ssize_t)length);
+    PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "sis#",
+				       loc->file_name, loc->first_line,
+				       string, (Py_ssize_t)length);
     if (rv == NULL) {
         PyErr_SetString(PyExc_RuntimeError,
                         "Internal error: Building exception from default rule");
@@ -551,7 +538,7 @@ void build_lexer_error(const char* string, size_t length)
     Py_XDECREF(rv);
 }
 
-void build_lexer_error_from_exception()
+void build_lexer_error_from_exception(YYLTYPE* loc)
 {
     TRACE_ERROR("Lexer Builder Exception");
 
@@ -567,8 +554,9 @@ void build_lexer_error_from_exception()
 
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
-        PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error",
-                                           "OO", pvalue, ptype);
+        PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "siOO",
+					   loc->file_name, loc->first_line,
+					   pvalue, ptype);
         Py_XDECREF(ptype);
         Py_XDECREF(pvalue);
         Py_XDECREF(ptraceback);

--- a/beancount/parser/lexer.py
+++ b/beancount/parser/lexer.py
@@ -9,7 +9,7 @@ import io
 import re
 from decimal import Decimal
 
-from beancount.core import data
+from beancount.core.data import new_metadata
 from beancount.core import account
 from beancount.parser import _parser
 
@@ -58,13 +58,9 @@ class LexBuilder:
         """
         return 'Equity:InvalidAccountName'
 
-    def get_lexer_location(self):
-        return data.new_metadata(_parser.get_yyfilename(),
-                                 _parser.get_yylineno())
-
     # Note: We could simplify the code by removing this if we could find a good
     # way to have the lexer communicate the error contents to the parser.
-    def build_lexer_error(self, message, exc_type=None): # {0e31aeca3363}
+    def build_lexer_error(self, filename, lineno, message, exc_type=None): # {0e31aeca3363}
         """Build a lexer error and appends it to the list of pending errors.
 
         Args:
@@ -76,7 +72,7 @@ class LexBuilder:
         if exc_type is not None:
             message = '{}: {}'.format(exc_type.__name__, message)
         self.errors.append(
-            LexerError(self.get_lexer_location(), message, None))
+            LexerError(new_metadata(filename, lineno), message, None))
 
     def DATE(self, year, month, day):
         """Process a DATE token.

--- a/beancount/parser/lexer_test.py
+++ b/beancount/parser/lexer_test.py
@@ -767,7 +767,7 @@ class TestLexerMisc(unittest.TestCase):
         """
         self.assertEqual(1, len(errors))
         self.assertEqual([
-            ('NUMBER', 1, '452,34.00', D('45234.00')),
+            ('LEX_ERROR', 1, '452,34.00', None),
             ('EOL', 2, '\n', None),
             ('EOL', 2, '\x00', None),
         ], tokens)

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -100,16 +100,6 @@ PyObject* parse_file(PyObject *self, PyObject *args, PyObject* kwds)
     return handle_yyparse_result(result);
 }
 
-PyObject* get_yyfilename(PyObject *self, PyObject *args)
-{
-    return PyUnicode_FromString(yyget_filename(_scanner));
-}
-
-PyObject* get_yylineno(PyObject *self, PyObject *args)
-{
-    return PyLong_FromLong(yyget_lineno(_scanner) + yyget_firstline(_scanner));
-}
-
 /* Inititalize the lexer to start running in debug mode. */
 PyObject* lexer_initialize(PyObject *self, PyObject *args, PyObject *kwds)
 {
@@ -204,8 +194,6 @@ PyObject* lexer_next(PyObject *self, PyObject *args)
 
 static PyMethodDef module_functions[] = {
     {"parse_file", (PyCFunction)parse_file, METH_VARARGS|METH_KEYWORDS, parse_file_doc},
-    {"get_yyfilename", (PyCFunction)get_yyfilename, METH_VARARGS, NULL},
-    {"get_yylineno", (PyCFunction)get_yylineno, METH_VARARGS, NULL},
     {"lexer_initialize", (PyCFunction)lexer_initialize, METH_VARARGS|METH_KEYWORDS, NULL},
     {"lexer_next", lexer_next, METH_VARARGS, NULL},
     {"lexer_finalize", lexer_finalize, METH_VARARGS, NULL},


### PR DESCRIPTION
This set of patches ("parser: Modify builder methods calling convention", "parser: Simplify error handling in the lexer", "parser: Extend location tracking") introduces some preparatory work to make the parser reentrant. The intent is to decouple the scanner, the grammar, and the builder classes. The only patch that introduces changes in behavior is "parser: Simplify error handling in the lexer" which changes slightly the lexer output in case of error.