### PR TITLE
Reentrant parser part 2

### DIFF
--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -85,7 +85,7 @@ extern YY_DECL;
                                  FILENAME, LINENO, ## __VA_ARGS__);             \
     clean;                                                                      \
     if (target == NULL) {                                                       \
-        build_grammar_error_from_exception(&yyloc);                             \
+        build_grammar_error_from_exception(&yyloc, builder);                    \
         YYERROR;                                                                \
     }
 
@@ -93,7 +93,7 @@ extern YY_DECL;
 #define LINENO (yyloc).first_line
 
 /* Build a grammar error from the exception context. */
-void build_grammar_error_from_exception(YYLTYPE* loc)
+void build_grammar_error_from_exception(YYLTYPE* loc, PyObject* builder)
 {
     TRACE_ERROR("Grammar Builder Exception");
 
@@ -129,7 +129,7 @@ void build_grammar_error_from_exception(YYLTYPE* loc)
 }
 
 /* Error-handling function. {ca6aab8b9748} */
-void yyerror(YYLTYPE* loc, yyscan_t scanner, char const* message)
+void yyerror(YYLTYPE* loc, yyscan_t scanner, PyObject* builder, char const* message)
 {
     /* Skip lex errors: they have already been registered the lexer itself. */
     if (strstr(message, "LEX_ERROR") != NULL) {
@@ -306,7 +306,7 @@ typedef struct YYLTYPE {
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 156 "beancount/parser/grammar.y"
+#line 157 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -340,7 +340,7 @@ struct YYLTYPE
 
 
 
-int yyparse (yyscan_t scanner);
+int yyparse (yyscan_t scanner, PyObject* builder);
 
 #endif /* !YY_YY_BEANCOUNT_PARSER_GRAMMAR_H_INCLUDED  */
 /* Symbol kind.  */
@@ -832,20 +832,20 @@ static const yytype_int8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   290,   290,   293,   297,   301,   305,   310,   311,   315,
-     316,   317,   318,   324,   328,   333,   338,   343,   348,   353,
-     357,   362,   367,   372,   379,   387,   392,   398,   404,   408,
-     412,   416,   418,   423,   428,   433,   438,   444,   450,   455,
-     456,   457,   458,   459,   460,   461,   462,   463,   467,   473,
-     478,   482,   487,   492,   498,   503,   509,   514,   519,   525,
-     531,   537,   546,   552,   559,   563,   569,   575,   581,   587,
-     593,   599,   607,   614,   619,   624,   629,   634,   639,   644,
-     651,   657,   662,   667,   673,   678,   683,   689,   693,   697,
-     701,   708,   714,   720,   726,   732,   734,   741,   746,   751,
-     756,   761,   766,   776,   781,   787,   794,   795,   796,   797,
-     798,   799,   800,   801,   802,   803,   804,   805,   810,   816,
-     822,   827,   833,   834,   835,   836,   837,   838,   839,   840,
-     843,   847,   852,   870,   877
+       0,   291,   291,   294,   298,   302,   306,   311,   312,   316,
+     317,   318,   319,   325,   329,   334,   339,   344,   349,   354,
+     358,   363,   368,   373,   380,   388,   393,   399,   405,   409,
+     413,   417,   419,   424,   429,   434,   439,   445,   451,   456,
+     457,   458,   459,   460,   461,   462,   463,   464,   468,   474,
+     479,   483,   488,   493,   499,   504,   510,   515,   520,   526,
+     532,   538,   547,   553,   560,   564,   570,   576,   582,   588,
+     594,   600,   608,   615,   620,   625,   630,   635,   640,   645,
+     652,   658,   663,   668,   674,   679,   684,   690,   694,   698,
+     702,   709,   715,   721,   727,   733,   735,   742,   747,   752,
+     757,   762,   767,   777,   782,   788,   795,   796,   797,   798,
+     799,   800,   801,   802,   803,   804,   805,   806,   811,   817,
+     823,   828,   834,   835,   836,   837,   838,   839,   840,   841,
+     844,   848,   853,   871,   878
 };
 #endif
 
@@ -1154,7 +1154,7 @@ enum { YYENOMEM = -2 };
       }                                                           \
     else                                                          \
       {                                                           \
-        yyerror (&yylloc, scanner, YY_("syntax error: cannot back up")); \
+        yyerror (&yylloc, scanner, builder, YY_("syntax error: cannot back up")); \
         YYERROR;                                                  \
       }                                                           \
   while (0)
@@ -1255,7 +1255,7 @@ do {                                                                      \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Kind, Value, Location, scanner); \
+                  Kind, Value, Location, scanner, builder); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -1267,12 +1267,13 @@ do {                                                                      \
 
 static void
 yy_symbol_value_print (FILE *yyo,
-                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner)
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner, PyObject* builder)
 {
   FILE *yyoutput = yyo;
   YYUSE (yyoutput);
   YYUSE (yylocationp);
   YYUSE (scanner);
+  YYUSE (builder);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
@@ -1291,14 +1292,14 @@ yy_symbol_value_print (FILE *yyo,
 
 static void
 yy_symbol_print (FILE *yyo,
-                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner)
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t scanner, PyObject* builder)
 {
   YYFPRINTF (yyo, "%s %s (",
              yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
   YY_LOCATION_PRINT (yyo, *yylocationp);
   YYFPRINTF (yyo, ": ");
-  yy_symbol_value_print (yyo, yykind, yyvaluep, yylocationp, scanner);
+  yy_symbol_value_print (yyo, yykind, yyvaluep, yylocationp, scanner, builder);
   YYFPRINTF (yyo, ")");
 }
 
@@ -1332,7 +1333,7 @@ do {                                                            \
 
 static void
 yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp,
-                 int yyrule, yyscan_t scanner)
+                 int yyrule, yyscan_t scanner, PyObject* builder)
 {
   int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -1346,7 +1347,7 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp,
       yy_symbol_print (stderr,
                        YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
                        &yyvsp[(yyi + 1) - (yynrhs)],
-                       &(yylsp[(yyi + 1) - (yynrhs)]), scanner);
+                       &(yylsp[(yyi + 1) - (yynrhs)]), scanner, builder);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -1354,7 +1355,7 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp,
 # define YY_REDUCE_PRINT(Rule)          \
 do {                                    \
   if (yydebug)                          \
-    yy_reduce_print (yyssp, yyvsp, yylsp, Rule, scanner); \
+    yy_reduce_print (yyssp, yyvsp, yylsp, Rule, scanner, builder); \
 } while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
@@ -1663,11 +1664,12 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
 
 static void
 yydestruct (const char *yymsg,
-            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, yyscan_t scanner)
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, yyscan_t scanner, PyObject* builder)
 {
   YYUSE (yyvaluep);
   YYUSE (yylocationp);
   YYUSE (scanner);
+  YYUSE (builder);
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
@@ -1687,7 +1689,7 @@ yydestruct (const char *yymsg,
 `----------*/
 
 int
-yyparse (yyscan_t scanner)
+yyparse (yyscan_t scanner, PyObject* builder)
 {
 /* The lookahead symbol.  */
 int yychar;
@@ -1893,7 +1895,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token\n"));
-      yychar = yylex (&yylval, &yylloc, scanner);
+      yychar = yylex (&yylval, &yylloc, scanner, builder);
     }
 
   if (yychar <= YYEOF)
@@ -1985,136 +1987,136 @@ yyreduce:
   switch (yyn)
     {
   case 3:
-#line 294 "beancount/parser/grammar.y"
+#line 295 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 1993 "beancount/parser/grammar.c"
+#line 1995 "beancount/parser/grammar.c"
     break;
 
   case 4:
-#line 298 "beancount/parser/grammar.y"
+#line 299 "beancount/parser/grammar.y"
     {
         (yyval.character) = (yyvsp[0].character);
     }
-#line 2001 "beancount/parser/grammar.c"
+#line 2003 "beancount/parser/grammar.c"
     break;
 
   case 5:
-#line 302 "beancount/parser/grammar.y"
+#line 303 "beancount/parser/grammar.y"
     {
         (yyval.character) = '*';
     }
-#line 2009 "beancount/parser/grammar.c"
+#line 2011 "beancount/parser/grammar.c"
     break;
 
   case 6:
-#line 306 "beancount/parser/grammar.y"
+#line 307 "beancount/parser/grammar.y"
     {
         (yyval.character) = '#';
     }
-#line 2017 "beancount/parser/grammar.c"
+#line 2019 "beancount/parser/grammar.c"
     break;
 
   case 13:
-#line 325 "beancount/parser/grammar.y"
+#line 326 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2025 "beancount/parser/grammar.c"
+#line 2027 "beancount/parser/grammar.c"
     break;
 
   case 14:
-#line 329 "beancount/parser/grammar.y"
+#line 330 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Add((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2034 "beancount/parser/grammar.c"
+#line 2036 "beancount/parser/grammar.c"
     break;
 
   case 15:
-#line 334 "beancount/parser/grammar.y"
+#line 335 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Subtract((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2043 "beancount/parser/grammar.c"
+#line 2045 "beancount/parser/grammar.c"
     break;
 
   case 16:
-#line 339 "beancount/parser/grammar.y"
+#line 340 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Multiply((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2052 "beancount/parser/grammar.c"
+#line 2054 "beancount/parser/grammar.c"
     break;
 
   case 17:
-#line 344 "beancount/parser/grammar.y"
+#line 345 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_TrueDivide((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                 DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2061 "beancount/parser/grammar.c"
+#line 2063 "beancount/parser/grammar.c"
     break;
 
   case 18:
-#line 349 "beancount/parser/grammar.y"
+#line 350 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = PyNumber_Negative((yyvsp[0].pyobj));
                 DECREF1((yyvsp[0].pyobj));
             }
-#line 2070 "beancount/parser/grammar.c"
+#line 2072 "beancount/parser/grammar.c"
     break;
 
   case 19:
-#line 354 "beancount/parser/grammar.y"
+#line 355 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2078 "beancount/parser/grammar.c"
+#line 2080 "beancount/parser/grammar.c"
     break;
 
   case 20:
-#line 358 "beancount/parser/grammar.y"
+#line 359 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 2086 "beancount/parser/grammar.c"
+#line 2088 "beancount/parser/grammar.c"
     break;
 
   case 21:
-#line 363 "beancount/parser/grammar.y"
+#line 364 "beancount/parser/grammar.y"
             {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2095 "beancount/parser/grammar.c"
+#line 2097 "beancount/parser/grammar.c"
     break;
 
   case 22:
-#line 368 "beancount/parser/grammar.y"
+#line 369 "beancount/parser/grammar.y"
             {
                 BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
             }
-#line 2104 "beancount/parser/grammar.c"
+#line 2106 "beancount/parser/grammar.c"
     break;
 
   case 23:
-#line 373 "beancount/parser/grammar.y"
+#line 374 "beancount/parser/grammar.y"
             {
                 BUILDY(,
                        (yyval.pyobj), "pipe_deprecated_error", "");
                 (yyval.pyobj) = (yyvsp[-1].pyobj);
             }
-#line 2114 "beancount/parser/grammar.c"
+#line 2116 "beancount/parser/grammar.c"
     break;
 
   case 24:
-#line 380 "beancount/parser/grammar.y"
+#line 381 "beancount/parser/grammar.y"
            {
                /* Note: We're passing a bogus value here in order to avoid
                 * having to declare a second macro just for this one special
@@ -2122,247 +2124,247 @@ yyreduce:
                BUILDY(,
                       (yyval.pyobj), "tag_link_new", "O", Py_None);
            }
-#line 2126 "beancount/parser/grammar.c"
+#line 2128 "beancount/parser/grammar.c"
     break;
 
   case 25:
-#line 388 "beancount/parser/grammar.y"
+#line 389 "beancount/parser/grammar.y"
            {
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_LINK", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 2135 "beancount/parser/grammar.c"
+#line 2137 "beancount/parser/grammar.c"
     break;
 
   case 26:
-#line 393 "beancount/parser/grammar.y"
+#line 394 "beancount/parser/grammar.y"
            {
                BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                       (yyval.pyobj), "tag_link_TAG", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
            }
-#line 2144 "beancount/parser/grammar.c"
+#line 2146 "beancount/parser/grammar.c"
     break;
 
   case 27:
-#line 399 "beancount/parser/grammar.y"
+#line 400 "beancount/parser/grammar.y"
             {
                 BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                        (yyval.pyobj), "transaction", "ObOOO", (yyvsp[-5].pyobj), (yyvsp[-4].character), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
             }
-#line 2153 "beancount/parser/grammar.c"
+#line 2155 "beancount/parser/grammar.c"
     break;
 
   case 28:
-#line 405 "beancount/parser/grammar.y"
+#line 406 "beancount/parser/grammar.y"
         {
             (yyval.character) = '\0';
         }
-#line 2161 "beancount/parser/grammar.c"
+#line 2163 "beancount/parser/grammar.c"
     break;
 
   case 29:
-#line 409 "beancount/parser/grammar.y"
+#line 410 "beancount/parser/grammar.y"
         {
             (yyval.character) = '*';
         }
-#line 2169 "beancount/parser/grammar.c"
+#line 2171 "beancount/parser/grammar.c"
     break;
 
   case 30:
-#line 413 "beancount/parser/grammar.y"
+#line 414 "beancount/parser/grammar.y"
         {
             (yyval.character) = '#';
         }
-#line 2177 "beancount/parser/grammar.c"
+#line 2179 "beancount/parser/grammar.c"
     break;
 
   case 32:
-#line 419 "beancount/parser/grammar.y"
+#line 420 "beancount/parser/grammar.y"
                  {
                      (yyval.pyobj) = (yyvsp[0].pyobj);
                  }
-#line 2185 "beancount/parser/grammar.c"
+#line 2187 "beancount/parser/grammar.c"
     break;
 
   case 33:
-#line 424 "beancount/parser/grammar.y"
+#line 425 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[-1].pyobj), Py_None, Py_False, (yyvsp[-4].character));
         }
-#line 2194 "beancount/parser/grammar.c"
+#line 2196 "beancount/parser/grammar.c"
     break;
 
   case 34:
-#line 429 "beancount/parser/grammar.y"
+#line 430 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_False, (yyvsp[-6].character));
         }
-#line 2203 "beancount/parser/grammar.c"
+#line 2205 "beancount/parser/grammar.c"
     break;
 
   case 35:
-#line 434 "beancount/parser/grammar.y"
+#line 435 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-5].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), Py_True, (yyvsp[-6].character));
         }
-#line 2212 "beancount/parser/grammar.c"
+#line 2214 "beancount/parser/grammar.c"
     break;
 
   case 36:
-#line 439 "beancount/parser/grammar.y"
+#line 440 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF1((yyvsp[-1].pyobj)),
                    (yyval.pyobj), "posting", "OOOOOb", (yyvsp[-1].pyobj), missing_obj, Py_None, Py_None, Py_False, (yyvsp[-2].character));
         }
-#line 2221 "beancount/parser/grammar.c"
+#line 2223 "beancount/parser/grammar.c"
     break;
 
   case 37:
-#line 445 "beancount/parser/grammar.y"
+#line 446 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF2((yyvsp[-1].string), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "key_value", "OO", (yyvsp[-1].string), (yyvsp[0].pyobj));
           }
-#line 2230 "beancount/parser/grammar.c"
+#line 2232 "beancount/parser/grammar.c"
     break;
 
   case 38:
-#line 451 "beancount/parser/grammar.y"
+#line 452 "beancount/parser/grammar.y"
                {
                    (yyval.pyobj) = (yyvsp[-1].pyobj);
                }
-#line 2238 "beancount/parser/grammar.c"
+#line 2240 "beancount/parser/grammar.c"
     break;
 
   case 47:
-#line 464 "beancount/parser/grammar.y"
+#line 465 "beancount/parser/grammar.y"
                 {
                     (yyval.pyobj) = (yyvsp[0].pyobj);
                 }
-#line 2246 "beancount/parser/grammar.c"
+#line 2248 "beancount/parser/grammar.c"
     break;
 
   case 48:
-#line 468 "beancount/parser/grammar.y"
+#line 469 "beancount/parser/grammar.y"
                 {
                     Py_INCREF(Py_None);
                     (yyval.pyobj) = Py_None;
                 }
-#line 2255 "beancount/parser/grammar.c"
+#line 2257 "beancount/parser/grammar.c"
     break;
 
   case 49:
-#line 474 "beancount/parser/grammar.y"
+#line 475 "beancount/parser/grammar.y"
                    {
                        Py_INCREF(Py_None);
                        (yyval.pyobj) = Py_None;
                    }
-#line 2264 "beancount/parser/grammar.c"
+#line 2266 "beancount/parser/grammar.c"
     break;
 
   case 50:
-#line 479 "beancount/parser/grammar.y"
+#line 480 "beancount/parser/grammar.y"
                    {
                        (yyval.pyobj) = (yyvsp[-3].pyobj);
                    }
-#line 2272 "beancount/parser/grammar.c"
+#line 2274 "beancount/parser/grammar.c"
     break;
 
   case 51:
-#line 483 "beancount/parser/grammar.y"
+#line 484 "beancount/parser/grammar.y"
                    {
                        BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[-1].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj));
                    }
-#line 2281 "beancount/parser/grammar.c"
+#line 2283 "beancount/parser/grammar.c"
     break;
 
   case 52:
-#line 488 "beancount/parser/grammar.y"
+#line 489 "beancount/parser/grammar.y"
                    {
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2290 "beancount/parser/grammar.c"
+#line 2292 "beancount/parser/grammar.c"
     break;
 
   case 53:
-#line 493 "beancount/parser/grammar.y"
+#line 494 "beancount/parser/grammar.y"
                    {
                        BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                               (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                    }
-#line 2299 "beancount/parser/grammar.c"
+#line 2301 "beancount/parser/grammar.c"
     break;
 
   case 54:
-#line 499 "beancount/parser/grammar.y"
+#line 500 "beancount/parser/grammar.y"
                {
                    Py_INCREF(Py_None);
                    (yyval.pyobj) = Py_None;
                }
-#line 2308 "beancount/parser/grammar.c"
+#line 2310 "beancount/parser/grammar.c"
     break;
 
   case 55:
-#line 504 "beancount/parser/grammar.y"
+#line 505 "beancount/parser/grammar.y"
                {
                    BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                }
-#line 2317 "beancount/parser/grammar.c"
+#line 2319 "beancount/parser/grammar.c"
     break;
 
   case 56:
-#line 510 "beancount/parser/grammar.y"
+#line 511 "beancount/parser/grammar.y"
               {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
               }
-#line 2326 "beancount/parser/grammar.c"
+#line 2328 "beancount/parser/grammar.c"
     break;
 
   case 57:
-#line 515 "beancount/parser/grammar.y"
+#line 516 "beancount/parser/grammar.y"
               {
                   BUILDY(DECREF1((yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
               }
-#line 2335 "beancount/parser/grammar.c"
+#line 2337 "beancount/parser/grammar.c"
     break;
 
   case 58:
-#line 520 "beancount/parser/grammar.y"
+#line 521 "beancount/parser/grammar.y"
               {
                   BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                          (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
               }
-#line 2344 "beancount/parser/grammar.c"
+#line 2346 "beancount/parser/grammar.c"
     break;
 
   case 59:
-#line 526 "beancount/parser/grammar.y"
+#line 527 "beancount/parser/grammar.y"
          {
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushtag", "O", (yyvsp[-1].pyobj));
          }
-#line 2353 "beancount/parser/grammar.c"
+#line 2355 "beancount/parser/grammar.c"
     break;
 
   case 60:
-#line 532 "beancount/parser/grammar.y"
+#line 533 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "poptag", "O", (yyvsp[-1].pyobj));
        }
-#line 2362 "beancount/parser/grammar.c"
+#line 2364 "beancount/parser/grammar.c"
     break;
 
   case 61:
-#line 538 "beancount/parser/grammar.y"
+#line 539 "beancount/parser/grammar.y"
          {
              /* Note: key_value is a tuple, Py_BuildValue() won't wrap it up
               * within a tuple, so expand in the method (it receives two
@@ -2370,92 +2372,92 @@ yyreduce:
              BUILDY(DECREF1((yyvsp[-1].pyobj)),
                     (yyval.pyobj), "pushmeta", "O", (yyvsp[-1].pyobj));
          }
-#line 2374 "beancount/parser/grammar.c"
+#line 2376 "beancount/parser/grammar.c"
     break;
 
   case 62:
-#line 547 "beancount/parser/grammar.y"
+#line 548 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF1((yyvsp[-2].pyobj)),
                    (yyval.pyobj), "popmeta", "O", (yyvsp[-2].pyobj));
         }
-#line 2383 "beancount/parser/grammar.c"
+#line 2385 "beancount/parser/grammar.c"
     break;
 
   case 63:
-#line 553 "beancount/parser/grammar.y"
+#line 554 "beancount/parser/grammar.y"
      {
          BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                 (yyval.pyobj), "open", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          ;
      }
-#line 2393 "beancount/parser/grammar.c"
+#line 2395 "beancount/parser/grammar.c"
     break;
 
   case 64:
-#line 560 "beancount/parser/grammar.y"
+#line 561 "beancount/parser/grammar.y"
             {
                 (yyval.pyobj) = (yyvsp[0].pyobj);
             }
-#line 2401 "beancount/parser/grammar.c"
+#line 2403 "beancount/parser/grammar.c"
     break;
 
   case 65:
-#line 564 "beancount/parser/grammar.y"
+#line 565 "beancount/parser/grammar.y"
             {
                 Py_INCREF(Py_None);
                 (yyval.pyobj) = Py_None;
             }
-#line 2410 "beancount/parser/grammar.c"
+#line 2412 "beancount/parser/grammar.c"
     break;
 
   case 66:
-#line 570 "beancount/parser/grammar.y"
+#line 571 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "close", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2419 "beancount/parser/grammar.c"
+#line 2421 "beancount/parser/grammar.c"
     break;
 
   case 67:
-#line 576 "beancount/parser/grammar.y"
+#line 577 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF3((yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                      (yyval.pyobj), "commodity", "OOO", (yyvsp[-4].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
           }
-#line 2428 "beancount/parser/grammar.c"
+#line 2430 "beancount/parser/grammar.c"
     break;
 
   case 68:
-#line 582 "beancount/parser/grammar.y"
+#line 583 "beancount/parser/grammar.y"
     {
         BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                (yyval.pyobj), "pad", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
     }
-#line 2437 "beancount/parser/grammar.c"
+#line 2439 "beancount/parser/grammar.c"
     break;
 
   case 69:
-#line 588 "beancount/parser/grammar.y"
+#line 589 "beancount/parser/grammar.y"
         {
             BUILDY(DECREF5((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[0].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2),
                    (yyval.pyobj), "balance", "OOOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pairobj).pyobj1, (yyvsp[-2].pairobj).pyobj2, (yyvsp[0].pyobj));
         }
-#line 2446 "beancount/parser/grammar.c"
+#line 2448 "beancount/parser/grammar.c"
     break;
 
   case 70:
-#line 594 "beancount/parser/grammar.y"
+#line 595 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
        }
-#line 2455 "beancount/parser/grammar.c"
+#line 2457 "beancount/parser/grammar.c"
     break;
 
   case 71:
-#line 600 "beancount/parser/grammar.y"
+#line 601 "beancount/parser/grammar.y"
                  {
                      BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
@@ -2463,269 +2465,269 @@ yyreduce:
                      Py_INCREF(Py_None);
                      ;
                  }
-#line 2467 "beancount/parser/grammar.c"
+#line 2469 "beancount/parser/grammar.c"
     break;
 
   case 72:
-#line 608 "beancount/parser/grammar.y"
+#line 609 "beancount/parser/grammar.y"
                  {
                      BUILDY(DECREF2((yyvsp[-3].pyobj), (yyvsp[0].pyobj)),
                             (yyval.pairobj).pyobj1, "amount", "OO", (yyvsp[-3].pyobj), (yyvsp[0].pyobj));
                      (yyval.pairobj).pyobj2 = (yyvsp[-1].pyobj);
                  }
-#line 2477 "beancount/parser/grammar.c"
+#line 2479 "beancount/parser/grammar.c"
     break;
 
   case 73:
-#line 615 "beancount/parser/grammar.y"
+#line 616 "beancount/parser/grammar.y"
              {
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2486 "beancount/parser/grammar.c"
+#line 2488 "beancount/parser/grammar.c"
     break;
 
   case 74:
-#line 620 "beancount/parser/grammar.y"
+#line 621 "beancount/parser/grammar.y"
              {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2494 "beancount/parser/grammar.c"
+#line 2496 "beancount/parser/grammar.c"
     break;
 
   case 75:
-#line 625 "beancount/parser/grammar.y"
+#line 626 "beancount/parser/grammar.y"
              {
                  Py_INCREF(missing_obj);
                  (yyval.pyobj) = missing_obj;
              }
-#line 2503 "beancount/parser/grammar.c"
+#line 2505 "beancount/parser/grammar.c"
     break;
 
   case 76:
-#line 630 "beancount/parser/grammar.y"
+#line 631 "beancount/parser/grammar.y"
              {
                  (yyval.pyobj) = (yyvsp[0].pyobj);
              }
-#line 2511 "beancount/parser/grammar.c"
+#line 2513 "beancount/parser/grammar.c"
     break;
 
   case 77:
-#line 635 "beancount/parser/grammar.y"
+#line 636 "beancount/parser/grammar.y"
                 {
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2520 "beancount/parser/grammar.c"
+#line 2522 "beancount/parser/grammar.c"
     break;
 
   case 78:
-#line 640 "beancount/parser/grammar.y"
+#line 641 "beancount/parser/grammar.y"
                 {
                     BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-1].pyobj), Py_None, (yyvsp[0].pyobj));
                 }
-#line 2529 "beancount/parser/grammar.c"
+#line 2531 "beancount/parser/grammar.c"
     break;
 
   case 79:
-#line 645 "beancount/parser/grammar.y"
+#line 646 "beancount/parser/grammar.y"
                 {
                     BUILDY(DECREF3((yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                            (yyval.pyobj), "compound_amount", "OOO", (yyvsp[-3].pyobj), (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                     ;
                 }
-#line 2539 "beancount/parser/grammar.c"
+#line 2541 "beancount/parser/grammar.c"
     break;
 
   case 80:
-#line 652 "beancount/parser/grammar.y"
+#line 653 "beancount/parser/grammar.y"
                   {
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "amount", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                  }
-#line 2548 "beancount/parser/grammar.c"
+#line 2550 "beancount/parser/grammar.c"
     break;
 
   case 81:
-#line 658 "beancount/parser/grammar.y"
+#line 659 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_False);
           }
-#line 2557 "beancount/parser/grammar.c"
+#line 2559 "beancount/parser/grammar.c"
     break;
 
   case 82:
-#line 663 "beancount/parser/grammar.y"
+#line 664 "beancount/parser/grammar.y"
           {
               BUILDY(DECREF1((yyvsp[-1].pyobj)),
                      (yyval.pyobj), "cost_spec", "OO", (yyvsp[-1].pyobj), Py_True);
           }
-#line 2566 "beancount/parser/grammar.c"
+#line 2568 "beancount/parser/grammar.c"
     break;
 
   case 83:
-#line 668 "beancount/parser/grammar.y"
+#line 669 "beancount/parser/grammar.y"
           {
               Py_INCREF(Py_None);
               (yyval.pyobj) = Py_None;
           }
-#line 2575 "beancount/parser/grammar.c"
+#line 2577 "beancount/parser/grammar.c"
     break;
 
   case 84:
-#line 674 "beancount/parser/grammar.y"
+#line 675 "beancount/parser/grammar.y"
                {
                    /* We indicate that there was a cost if there */
                    (yyval.pyobj) = PyList_New(0);
                }
-#line 2584 "beancount/parser/grammar.c"
+#line 2586 "beancount/parser/grammar.c"
     break;
 
   case 85:
-#line 679 "beancount/parser/grammar.y"
+#line 680 "beancount/parser/grammar.y"
                {
                    BUILDY(DECREF1((yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", Py_None, (yyvsp[0].pyobj));
                }
-#line 2593 "beancount/parser/grammar.c"
+#line 2595 "beancount/parser/grammar.c"
     break;
 
   case 86:
-#line 684 "beancount/parser/grammar.y"
+#line 685 "beancount/parser/grammar.y"
                {
                    BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                           (yyval.pyobj), "handle_list", "OO", (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
                }
-#line 2602 "beancount/parser/grammar.c"
+#line 2604 "beancount/parser/grammar.c"
     break;
 
   case 87:
-#line 690 "beancount/parser/grammar.y"
+#line 691 "beancount/parser/grammar.y"
           {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2610 "beancount/parser/grammar.c"
+#line 2612 "beancount/parser/grammar.c"
     break;
 
   case 88:
-#line 694 "beancount/parser/grammar.y"
+#line 695 "beancount/parser/grammar.y"
           {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2618 "beancount/parser/grammar.c"
+#line 2620 "beancount/parser/grammar.c"
     break;
 
   case 89:
-#line 698 "beancount/parser/grammar.y"
+#line 699 "beancount/parser/grammar.y"
           {
               (yyval.pyobj) = (yyvsp[0].pyobj);
           }
-#line 2626 "beancount/parser/grammar.c"
+#line 2628 "beancount/parser/grammar.c"
     break;
 
   case 90:
-#line 702 "beancount/parser/grammar.y"
+#line 703 "beancount/parser/grammar.y"
           {
               BUILDY(,
                      (yyval.pyobj), "cost_merge", "O", Py_None);
           }
-#line 2635 "beancount/parser/grammar.c"
+#line 2637 "beancount/parser/grammar.c"
     break;
 
   case 91:
-#line 709 "beancount/parser/grammar.y"
+#line 710 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "price", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2644 "beancount/parser/grammar.c"
+#line 2646 "beancount/parser/grammar.c"
     break;
 
   case 92:
-#line 715 "beancount/parser/grammar.y"
+#line 716 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "event", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2653 "beancount/parser/grammar.c"
+#line 2655 "beancount/parser/grammar.c"
     break;
 
   case 93:
-#line 721 "beancount/parser/grammar.y"
+#line 722 "beancount/parser/grammar.y"
          {
              BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "query", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2662 "beancount/parser/grammar.c"
+#line 2664 "beancount/parser/grammar.c"
     break;
 
   case 94:
-#line 727 "beancount/parser/grammar.y"
+#line 728 "beancount/parser/grammar.y"
       {
           BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                  (yyval.pyobj), "note", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
       }
-#line 2671 "beancount/parser/grammar.c"
+#line 2673 "beancount/parser/grammar.c"
     break;
 
   case 96:
-#line 735 "beancount/parser/grammar.y"
+#line 736 "beancount/parser/grammar.y"
          {
              BUILDY(DECREF5((yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                     (yyval.pyobj), "document", "OOOOO", (yyvsp[-6].pyobj), (yyvsp[-4].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
          }
-#line 2680 "beancount/parser/grammar.c"
+#line 2682 "beancount/parser/grammar.c"
     break;
 
   case 97:
-#line 742 "beancount/parser/grammar.y"
+#line 743 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2689 "beancount/parser/grammar.c"
+#line 2691 "beancount/parser/grammar.c"
     break;
 
   case 98:
-#line 747 "beancount/parser/grammar.y"
+#line 748 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2698 "beancount/parser/grammar.c"
+#line 2700 "beancount/parser/grammar.c"
     break;
 
   case 99:
-#line 752 "beancount/parser/grammar.y"
+#line 753 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2707 "beancount/parser/grammar.c"
+#line 2709 "beancount/parser/grammar.c"
     break;
 
   case 100:
-#line 757 "beancount/parser/grammar.y"
+#line 758 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2716 "beancount/parser/grammar.c"
+#line 2718 "beancount/parser/grammar.c"
     break;
 
   case 101:
-#line 762 "beancount/parser/grammar.y"
+#line 763 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF1((yyvsp[0].pyobj)),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), Py_None);
              }
-#line 2725 "beancount/parser/grammar.c"
+#line 2727 "beancount/parser/grammar.c"
     break;
 
   case 102:
-#line 767 "beancount/parser/grammar.y"
+#line 768 "beancount/parser/grammar.y"
              {
                  /* Obtain beancount.core.account.TYPE */
                  PyObject* module = PyImport_ImportModule("beancount.core.account");
@@ -2734,99 +2736,99 @@ yyreduce:
                  BUILDY(DECREF2((yyvsp[0].pyobj), dtype),
                         (yyval.pyobj), "custom_value", "OO", (yyvsp[0].pyobj), dtype);
              }
-#line 2738 "beancount/parser/grammar.c"
+#line 2740 "beancount/parser/grammar.c"
     break;
 
   case 103:
-#line 777 "beancount/parser/grammar.y"
+#line 778 "beancount/parser/grammar.y"
                   {
                       Py_INCREF(Py_None);
                       (yyval.pyobj) = Py_None;
                   }
-#line 2747 "beancount/parser/grammar.c"
+#line 2749 "beancount/parser/grammar.c"
     break;
 
   case 104:
-#line 782 "beancount/parser/grammar.y"
+#line 783 "beancount/parser/grammar.y"
                   {
                       BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                              (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
                   }
-#line 2756 "beancount/parser/grammar.c"
+#line 2758 "beancount/parser/grammar.c"
     break;
 
   case 105:
-#line 788 "beancount/parser/grammar.y"
+#line 789 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF4((yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj)),
                   (yyval.pyobj), "custom", "OOOO", (yyvsp[-5].pyobj), (yyvsp[-3].pyobj), (yyvsp[-2].pyobj), (yyvsp[0].pyobj));
        }
-#line 2765 "beancount/parser/grammar.c"
+#line 2767 "beancount/parser/grammar.c"
     break;
 
   case 117:
-#line 806 "beancount/parser/grammar.y"
+#line 807 "beancount/parser/grammar.y"
       {
           (yyval.pyobj) = (yyvsp[0].pyobj);
       }
-#line 2773 "beancount/parser/grammar.c"
+#line 2775 "beancount/parser/grammar.c"
     break;
 
   case 118:
-#line 811 "beancount/parser/grammar.y"
+#line 812 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "option", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2782 "beancount/parser/grammar.c"
+#line 2784 "beancount/parser/grammar.c"
     break;
 
   case 119:
-#line 817 "beancount/parser/grammar.y"
+#line 818 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "include", "O", (yyvsp[-1].pyobj));
        }
-#line 2791 "beancount/parser/grammar.c"
+#line 2793 "beancount/parser/grammar.c"
     break;
 
   case 120:
-#line 823 "beancount/parser/grammar.y"
+#line 824 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF1((yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "OO", (yyvsp[-1].pyobj), Py_None);
        }
-#line 2800 "beancount/parser/grammar.c"
+#line 2802 "beancount/parser/grammar.c"
     break;
 
   case 121:
-#line 828 "beancount/parser/grammar.y"
+#line 829 "beancount/parser/grammar.y"
        {
            BUILDY(DECREF2((yyvsp[-2].pyobj), (yyvsp[-1].pyobj)),
                   (yyval.pyobj), "plugin", "OO", (yyvsp[-2].pyobj), (yyvsp[-1].pyobj));
        }
-#line 2809 "beancount/parser/grammar.c"
+#line 2811 "beancount/parser/grammar.c"
     break;
 
   case 130:
-#line 844 "beancount/parser/grammar.y"
+#line 845 "beancount/parser/grammar.y"
              {
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2817 "beancount/parser/grammar.c"
+#line 2819 "beancount/parser/grammar.c"
     break;
 
   case 131:
-#line 848 "beancount/parser/grammar.y"
+#line 849 "beancount/parser/grammar.y"
              {
                  BUILDY(DECREF2((yyvsp[-1].pyobj), (yyvsp[0].pyobj)),
                         (yyval.pyobj), "handle_list", "OO", (yyvsp[-1].pyobj), (yyvsp[0].pyobj));
              }
-#line 2826 "beancount/parser/grammar.c"
+#line 2828 "beancount/parser/grammar.c"
     break;
 
   case 132:
-#line 853 "beancount/parser/grammar.y"
+#line 854 "beancount/parser/grammar.y"
              {
                  /*
                   * Ignore the error and continue reducing ({3d95e55b654e}).
@@ -2844,29 +2846,29 @@ yyreduce:
                   */
                  (yyval.pyobj) = (yyvsp[-1].pyobj);
              }
-#line 2848 "beancount/parser/grammar.c"
+#line 2850 "beancount/parser/grammar.c"
     break;
 
   case 133:
-#line 871 "beancount/parser/grammar.y"
+#line 872 "beancount/parser/grammar.y"
              {
                   Py_INCREF(Py_None);
                   (yyval.pyobj) = Py_None;
              }
-#line 2857 "beancount/parser/grammar.c"
+#line 2859 "beancount/parser/grammar.c"
     break;
 
   case 134:
-#line 878 "beancount/parser/grammar.y"
+#line 879 "beancount/parser/grammar.y"
      {
          BUILDY(DECREF1((yyvsp[0].pyobj)),
                 (yyval.pyobj), "store_result", "O", (yyvsp[0].pyobj));
      }
-#line 2866 "beancount/parser/grammar.c"
+#line 2868 "beancount/parser/grammar.c"
     break;
 
 
-#line 2870 "beancount/parser/grammar.c"
+#line 2872 "beancount/parser/grammar.c"
 
       default: break;
     }
@@ -2941,7 +2943,7 @@ yyerrlab:
                 yysyntax_error_status = YYENOMEM;
               }
           }
-        yyerror (&yylloc, scanner, yymsgp);
+        yyerror (&yylloc, scanner, builder, yymsgp);
         if (yysyntax_error_status == YYENOMEM)
           goto yyexhaustedlab;
       }
@@ -2962,7 +2964,7 @@ yyerrlab:
       else
         {
           yydestruct ("Error: discarding",
-                      yytoken, &yylval, &yylloc, scanner);
+                      yytoken, &yylval, &yylloc, scanner, builder);
           yychar = YYEMPTY;
         }
     }
@@ -3017,7 +3019,7 @@ yyerrlab1:
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp, scanner);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp, scanner, builder);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -3059,7 +3061,7 @@ yyabortlab:
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
 yyexhaustedlab:
-  yyerror (&yylloc, scanner, YY_("memory exhausted"));
+  yyerror (&yylloc, scanner, builder, YY_("memory exhausted"));
   yyresult = 2;
   /* Fall through.  */
 #endif
@@ -3075,7 +3077,7 @@ yyreturn:
          user semantic actions for why this is necessary.  */
       yytoken = YYTRANSLATE (yychar);
       yydestruct ("Cleanup: discarding lookahead",
-                  yytoken, &yylval, &yylloc, scanner);
+                  yytoken, &yylval, &yylloc, scanner, builder);
     }
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
@@ -3084,7 +3086,7 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp, scanner);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp, scanner, builder);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -3096,7 +3098,7 @@ yyreturn:
   return yyresult;
 }
 
-#line 886 "beancount/parser/grammar.y"
+#line 887 "beancount/parser/grammar.y"
 
 
 /* A function that will convert a token name to a string, used in debugging. */

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -155,7 +155,7 @@ typedef struct YYLTYPE {
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 156 "beancount/parser/grammar.y"
+#line 157 "beancount/parser/grammar.y"
 
     char character;
     const char* string;
@@ -189,6 +189,6 @@ struct YYLTYPE
 
 
 
-int yyparse (yyscan_t scanner);
+int yyparse (yyscan_t scanner, PyObject* builder);
 
 #endif /* !YY_YY_BEANCOUNT_PARSER_GRAMMAR_H_INCLUDED  */

--- a/beancount/parser/grammar.y
+++ b/beancount/parser/grammar.y
@@ -63,7 +63,7 @@ extern YY_DECL;
                                  FILENAME, LINENO, ## __VA_ARGS__);             \
     clean;                                                                      \
     if (target == NULL) {                                                       \
-        build_grammar_error_from_exception(&yyloc);                             \
+        build_grammar_error_from_exception(&yyloc, builder);                    \
         YYERROR;                                                                \
     }
 
@@ -71,7 +71,7 @@ extern YY_DECL;
 #define LINENO (yyloc).first_line
 
 /* Build a grammar error from the exception context. */
-void build_grammar_error_from_exception(YYLTYPE* loc)
+void build_grammar_error_from_exception(YYLTYPE* loc, PyObject* builder)
 {
     TRACE_ERROR("Grammar Builder Exception");
 
@@ -107,7 +107,7 @@ void build_grammar_error_from_exception(YYLTYPE* loc)
 }
 
 /* Error-handling function. {ca6aab8b9748} */
-void yyerror(YYLTYPE* loc, yyscan_t scanner, char const* message)
+void yyerror(YYLTYPE* loc, yyscan_t scanner, PyObject* builder, char const* message)
 {
     /* Skip lex errors: they have already been registered the lexer itself. */
     if (strstr(message, "LEX_ERROR") != NULL) {
@@ -151,6 +151,7 @@ const char* getTokenName(int token);
 %locations
 %define api.pure full
 %param {yyscan_t scanner}
+%param {PyObject* builder}
 
 /* Collection of value types. */
 %union {

--- a/beancount/parser/grammar_test.py
+++ b/beancount/parser/grammar_test.py
@@ -294,7 +294,7 @@ class TestUglyBugs(unittest.TestCase):
             ';; End of file',
         ])
 
-        entries, errors, _ = parser.parse_string(input_, yydebug=0)
+        entries, errors, _ = parser.parse_string(input_)
         check_list(self, entries, [data.Transaction])
         check_list(self, errors, [])
 

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -1,4 +1,4 @@
-#line 2 "beancount/parser/lexer.c"
+#line 1 "beancount/parser/lexer.c"
 
 #include "parser.h"
 
@@ -10,7 +10,7 @@ void yylex_initialize(const char* filename, int firstline, const char* encoding,
 /* Free scanner private data */
 void yylex_finalize(yyscan_t yyscanner);
 
-#line 14 "beancount/parser/lexer.c"
+#line 13 "beancount/parser/lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1041,11 +1041,11 @@ static inline void buffer_begin(struct buffer* b)
 #define yy_encoding yyget_extra(yyscanner)->encoding
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(YYLTYPE* loc, const char* string, size_t length);
+void build_lexer_error(YYLTYPE* loc, PyObject* builder, const char* string, size_t length);
 
 /* Build and accumulate an error on the builder object using the current
  * exception state. */
-void build_lexer_error_from_exception(YYLTYPE* loc);
+void build_lexer_error_from_exception(YYLTYPE* loc, PyObject* builder);
 
 int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
 
@@ -1057,13 +1057,13 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
     yylval->pyobj = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);     \
     /* Handle a Python exception raised by the driver {3cfb2739349a} */                 \
     if (yylval->pyobj == NULL) {                                                        \
-	build_lexer_error_from_exception(yylloc);			                \
+	build_lexer_error_from_exception(yylloc, builder);		                \
 	return LEX_ERROR;						                \
     }                                                                                   \
     /* Lexer builder methods should never return None, check for it. */                 \
     else if (yylval->pyobj == Py_None) {                                                \
         Py_DECREF(Py_None);                                                             \
-        build_lexer_error(yylloc, "Unexpected None result from lexer", 34);             \
+        build_lexer_error(yylloc, builder, "Unexpected None result from lexer", 34);    \
         return LEX_ERROR;                                                               \
     }
 
@@ -1098,12 +1098,12 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
 
-#line 1102 "beancount/parser/lexer.c"
+#line 1101 "beancount/parser/lexer.c"
 /* A start condition for chomping an invalid token. */
 
 /* Exclusive start condition for parsing escape sequences in string literals. */
 
-#line 1107 "beancount/parser/lexer.c"
+#line 1106 "beancount/parser/lexer.c"
 
 #define INITIAL 0
 #define INVALID 1
@@ -1392,7 +1392,7 @@ YY_DECL
 
 #line 193 "beancount/parser/lexer.l"
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
-#line 1396 "beancount/parser/lexer.c"
+#line 1395 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1823,7 +1823,7 @@ YY_RULE_SETUP
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
                                          yy_encoding, "ignore");
         if (!str) {
-            build_lexer_error_from_exception(yylloc);
+            build_lexer_error_from_exception(yylloc, builder);
             yylval->pyobj = Py_None;
             Py_INCREF(Py_None);
             return LEX_ERROR;
@@ -1945,7 +1945,7 @@ YY_RULE_SETUP
 {
     char buffer[256];
     size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
-    build_lexer_error(yylloc, buffer, length);
+    build_lexer_error(yylloc, builder, buffer, length);
     BEGIN(INITIAL);
     return LEX_ERROR;
 }
@@ -1955,7 +1955,7 @@ YY_RULE_SETUP
 #line 463 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1959 "beancount/parser/lexer.c"
+#line 1958 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3223,7 +3223,7 @@ int strtonl(const char* buf, size_t nchars)
 }
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(YYLTYPE* loc, const char* string, size_t length)
+void build_lexer_error(YYLTYPE* loc, PyObject* builder, const char* string, size_t length)
 {
     TRACE_ERROR("Invalid Token");
 
@@ -3235,7 +3235,7 @@ void build_lexer_error(YYLTYPE* loc, const char* string, size_t length)
     Py_XDECREF(rv);
 }
 
-void build_lexer_error_from_exception(YYLTYPE* loc)
+void build_lexer_error_from_exception(YYLTYPE* loc, PyObject* builder)
 {
     TRACE_ERROR("Lexer Builder Exception");
 

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -2,7 +2,7 @@
 #define yyHEADER_H 1
 #define yyIN_HEADER 1
 
-#line 6 "beancount/parser/lexer.h"
+#line 5 "beancount/parser/lexer.h"
 
 #include "parser.h"
 
@@ -14,7 +14,7 @@ void yylex_initialize(const char* filename, int firstline, const char* encoding,
 /* Free scanner private data */
 void yylex_finalize(yyscan_t yyscanner);
 
-#line 18 "beancount/parser/lexer.h"
+#line 17 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -531,6 +531,6 @@ extern int yylex \
 #line 463 "beancount/parser/lexer.l"
 
 
-#line 535 "beancount/parser/lexer.h"
+#line 534 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -109,11 +109,11 @@ static inline void buffer_begin(struct buffer* b)
 #define yy_encoding yyget_extra(yyscanner)->encoding
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(YYLTYPE* loc, const char* string, size_t length);
+void build_lexer_error(YYLTYPE* loc, PyObject* builder, const char* string, size_t length);
 
 /* Build and accumulate an error on the builder object using the current
  * exception state. */
-void build_lexer_error_from_exception(YYLTYPE* loc);
+void build_lexer_error_from_exception(YYLTYPE* loc, PyObject* builder);
 
 int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
 
@@ -125,13 +125,13 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
     yylval->pyobj = PyObject_CallMethod(builder, method_name, format, __VA_ARGS__);     \
     /* Handle a Python exception raised by the driver {3cfb2739349a} */                 \
     if (yylval->pyobj == NULL) {                                                        \
-	build_lexer_error_from_exception(yylloc);			                \
+	build_lexer_error_from_exception(yylloc, builder);		                \
 	return LEX_ERROR;						                \
     }                                                                                   \
     /* Lexer builder methods should never return None, check for it. */                 \
     else if (yylval->pyobj == Py_None) {                                                \
         Py_DECREF(Py_None);                                                             \
-        build_lexer_error(yylloc, "Unexpected None result from lexer", 34);             \
+        build_lexer_error(yylloc, builder, "Unexpected None result from lexer", 34);    \
         return LEX_ERROR;                                                               \
     }
 
@@ -381,7 +381,7 @@ NULL		{
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
                                          yy_encoding, "ignore");
         if (!str) {
-            build_lexer_error_from_exception(yylloc);
+            build_lexer_error_from_exception(yylloc, builder);
             yylval->pyobj = Py_None;
             Py_INCREF(Py_None);
             return LEX_ERROR;
@@ -453,7 +453,7 @@ NULL		{
 <INVALID>[^ \t\n\r]+     {
     char buffer[256];
     size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
-    build_lexer_error(yylloc, buffer, length);
+    build_lexer_error(yylloc, builder, buffer, length);
     BEGIN(INITIAL);
     return LEX_ERROR;
 }
@@ -523,7 +523,7 @@ int strtonl(const char* buf, size_t nchars)
 }
 
 /* Build and accumulate an error on the builder object. */
-void build_lexer_error(YYLTYPE* loc, const char* string, size_t length)
+void build_lexer_error(YYLTYPE* loc, PyObject* builder, const char* string, size_t length)
 {
     TRACE_ERROR("Invalid Token");
 
@@ -535,7 +535,7 @@ void build_lexer_error(YYLTYPE* loc, const char* string, size_t length)
     Py_XDECREF(rv);
 }
 
-void build_lexer_error_from_exception(YYLTYPE* loc)
+void build_lexer_error_from_exception(YYLTYPE* loc, PyObject* builder)
 {
     TRACE_ERROR("Lexer Builder Exception");
 

--- a/beancount/parser/lexer.py
+++ b/beancount/parser/lexer.py
@@ -219,15 +219,8 @@ def lex_iter(file, builder=None, encoding=None):
         file = open(file, 'rb')
     if builder is None:
         builder = LexBuilder()
-    _parser.lexer_initialize(file, builder, encoding=encoding)
-    try:
-        while 1:
-            token_tuple = _parser.lexer_next()
-            if token_tuple is None:
-                break
-            yield token_tuple
-    finally:
-        _parser.lexer_finalize()
+    parser = _parser.Parser(builder)
+    yield from parser.lex(file, encoding=encoding)
 
 
 def lex_iter_string(string, builder=None, encoding=None):
@@ -241,7 +234,7 @@ def lex_iter_string(string, builder=None, encoding=None):
     Returns:
       A iterator on the string. See lex_iter() for details.
     """
-    if isinstance(string, str):
-        string = string.encode('utf-8')
+    if not isinstance(string, bytes):
+        string = string.encode('utf8')
     file = io.BytesIO(string)
-    return lex_iter(file, builder, encoding)
+    yield from lex_iter(file, builder, encoding)

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -54,10 +54,10 @@ static PyObject* parser_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 
 static int parser_init(Parser* self, PyObject* args, PyObject* kwds)
 {
-    static char* kwlist[] = {"builder", NULL};
+    static char* kwlist[] = {"builder", "debug", NULL};
     PyObject* builder;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &builder)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|p", kwlist, &builder, &yydebug)) {
         return -1;
     }
 

--- a/beancount/parser/parser.h
+++ b/beancount/parser/parser.h
@@ -4,17 +4,16 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-extern PyObject* builder;
-extern PyObject* missing_obj;
-
 /* This typedef is included in the Flex generated lexer.h header, but
  * it is needed in the Bison generated header grammar.h that needs to
  * be included before lexer.h. Repeat it here and make sure to include
  * the headers in the right order. */
 typedef void* yyscan_t;
 
-/* Lexer interface required by Bison. */
-#define YY_DECL int yylex(YYSTYPE * yylval_param, YYLTYPE * yylloc_param, yyscan_t yyscanner)
+#define YY_DECL int yylex(YYSTYPE* yylval_param, YYLTYPE* yylloc_param, \
+                          yyscan_t yyscanner, PyObject* builder)
+
+extern PyObject* missing_obj;
 
 /* #define DO_TRACE_ERRORS   1 */
 

--- a/beancount/parser/parser.py
+++ b/beancount/parser/parser.py
@@ -179,12 +179,12 @@ def is_entry_incomplete(entry):
     return False
 
 
-def parse_file(file, report_filename=None, **kw):
+def parse_file(file, report_filename=None, report_firstline=0, **kw):
     """Parse a beancount input file and return Ledger with the list of
     transactions and tree of accounts.
 
     Args:
-      filename: the name of the file to be parsed.
+      file: file object or path to the file to be parsed.
       kw: a dict of keywords to be applied to the C parser.
     Returns:
       A tuple of (
@@ -200,7 +200,8 @@ def parse_file(file, report_filename=None, **kw):
     elif not isinstance(file, io.IOBase):
         file = open(file, 'rb')
     builder = grammar.Builder(report_filename or file.name)
-    _parser.parse_file(file, builder, report_filename=report_filename, **kw)
+    parser = _parser.Parser(builder)
+    parser.parse(file, filename=report_filename, lineno=report_firstline, **kw)
     return builder.finalize()
 
 


### PR DESCRIPTION
This concludes the refactoring of the parser code to make it reentrant. It builds on #485. I'll rebase this PR once that is merged. After these I have a few more cleanup and small improvement patches and the conversion most of `lexer.LexBuilder` into compiled code.

Commit "parser: Step 3 toward a reentrant parser" is mechanical and straightforward. Most of the work is done in commit "parser: Step 4 toward a reentrant parser", which completely changes how the C parser is exposed to Python code. I think it is a nice improvements (especially cleaning up the interface to the lexer to be a proper iterator). I don't understand the UTF-16 tests, thus commit "parser: Mark UTF-16 lexer tests as known fail". @blais , if you can explain what is the expected behavior, I can implement it. I doubt it is what the tests are testing for. Commit "parser: Allow to enable Bison debugging facility" brings back functionality that was present before and that got lost in the large refactoring. It could be squashed into "parser: Step 4..."