### PR TITLE
Reentrant parser fixes

### DIFF
--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -81,7 +81,7 @@ extern YY_DECL;
  * reduced rule. {05bb0fb60e86}
  */
 #define BUILDY(clean, target, method_name, format, ...)                         \
-    target = PyObject_CallMethod(builder, method_name, "si" format,             \
+    target = PyObject_CallMethod(builder, method_name, "Oi" format,             \
                                  FILENAME, LINENO, ## __VA_ARGS__);             \
     clean;                                                                      \
     if (target == NULL) {                                                       \
@@ -109,7 +109,7 @@ void build_grammar_error_from_exception(YYLTYPE* loc, PyObject* builder)
 
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
-        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "siOOO",
+        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "OiOOO",
                                            loc->file_name, loc->first_line,
                                            pvalue, ptype, ptraceback);
         if (rv == NULL) {
@@ -137,7 +137,7 @@ void yyerror(YYLTYPE* loc, yyscan_t scanner, PyObject* builder, char const* mess
     }
     else {
         /* Register a syntax error with the builder. */
-        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "sis",
+        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "Ois",
                                            loc->file_name, loc->first_line,
                                            message);
         if (rv == NULL) {
@@ -209,7 +209,7 @@ typedef struct YYLTYPE {
     int first_column;
     int last_line;
     int last_column;
-    const char* file_name;
+    PyObject* file_name;
 } YYLTYPE;
 
 #define YYLTYPE_IS_DECLARED 1

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -58,7 +58,7 @@ typedef struct YYLTYPE {
     int first_column;
     int last_line;
     int last_column;
-    const char* file_name;
+    PyObject* file_name;
 } YYLTYPE;
 
 #define YYLTYPE_IS_DECLARED 1

--- a/beancount/parser/grammar.py
+++ b/beancount/parser/grammar.py
@@ -112,7 +112,7 @@ class Builder(lexer.LexBuilder):
     """A builder used by the lexer and grammar parser as callbacks to create
     the data objects corresponding to rules parsed from the input file."""
 
-    def __init__(self, filename):
+    def __init__(self):
         lexer.LexBuilder.__init__(self)
 
         # A stack of the current active tags.
@@ -126,9 +126,6 @@ class Builder(lexer.LexBuilder):
 
         # Accumulated and unprocessed options.
         self.options = copy.deepcopy(options.OPTIONS_DEFAULTS)
-
-        # Set the filename we're processing.
-        self.options['filename'] = filename
 
         # Make the account regexp more restrictive than the default: check
         # types. Warning: This overrides the value in the base class.
@@ -219,6 +216,8 @@ class Builder(lexer.LexBuilder):
         """
         if entries:
             self.entries = entries
+        # Also record the name of the processed file.
+        self.options['filename'] = filename
 
     def build_grammar_error(self, filename, lineno, exc_value,
                             exc_type=None, exc_traceback=None):

--- a/beancount/parser/grammar.y
+++ b/beancount/parser/grammar.y
@@ -21,7 +21,7 @@ typedef struct YYLTYPE {
     int first_column;
     int last_line;
     int last_column;
-    const char* file_name;
+    PyObject* file_name;
 } YYLTYPE;
 
 #define YYLTYPE_IS_DECLARED 1
@@ -59,7 +59,7 @@ extern YY_DECL;
  * reduced rule. {05bb0fb60e86}
  */
 #define BUILDY(clean, target, method_name, format, ...)                         \
-    target = PyObject_CallMethod(builder, method_name, "si" format,             \
+    target = PyObject_CallMethod(builder, method_name, "Oi" format,             \
                                  FILENAME, LINENO, ## __VA_ARGS__);             \
     clean;                                                                      \
     if (target == NULL) {                                                       \
@@ -87,7 +87,7 @@ void build_grammar_error_from_exception(YYLTYPE* loc, PyObject* builder)
 
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
-        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "siOOO",
+        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "OiOOO",
                                            loc->file_name, loc->first_line,
                                            pvalue, ptype, ptraceback);
         if (rv == NULL) {
@@ -115,7 +115,7 @@ void yyerror(YYLTYPE* loc, yyscan_t scanner, PyObject* builder, char const* mess
     }
     else {
         /* Register a syntax error with the builder. */
-        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "sis",
+        PyObject* rv = PyObject_CallMethod(builder, "build_grammar_error", "Ois",
                                            loc->file_name, loc->first_line,
                                            message);
         if (rv == NULL) {

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -4,13 +4,27 @@
 
 typedef struct _yyextra_t yyextra_t;
 
-/* Initialize scanner private data. */
-void yylex_initialize(PyObject* filename, int firstline, const char* encoding, yyscan_t yyscanner);
+/**
+ * Allocate and initialize scanner private data.
+ *
+ * Setup @scanner to read from the Python file-like object @file. Set
+ * the reported file name to @filename, if not NULL and not None.
+ * Otherwise try to obtain the file name from the @name attribute of
+ * the @file object. If this fails, use the empty string. @encoding is
+ * used to decode strings read from the input file, if not NULL,
+ * otherwise the default UTF-8 encoding is used. Python objects
+ * references are incremented.
+ */
+void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char* encoding, yyscan_t scanner);
 
-/* Free scanner private data */
-void yylex_finalize(yyscan_t yyscanner);
+/**
+ * Free scanner private data.
+ *
+ * Python objects references stored in the @scanner are decremented.
+ */
+void yylex_finalize(yyscan_t scanner);
 
-#line 13 "beancount/parser/lexer.c"
+#line 27 "beancount/parser/lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -963,7 +977,7 @@ static const flex_int32_t yy_rule_can_match_eol[63] =
 /* Top Code. This is included in the FLex generated header file. */
 
 /* Definitions. */
-#line 35 "beancount/parser/lexer.l"
+#line 49 "beancount/parser/lexer.l"
 
 #include <math.h>
 #include <stdlib.h>
@@ -987,7 +1001,7 @@ struct _yyextra_t {
     /* The filename being tokenized. */
     PyObject* filename;
 
-    /* Reporting line offset. This is used like the #line cpp macro */
+    /* Reporting line offset. This is used like the #line cpp macro. */
     int line;
 
     /* The encoding to use for converting strings. */
@@ -1098,12 +1112,12 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
 
-#line 1101 "beancount/parser/lexer.c"
+#line 1115 "beancount/parser/lexer.c"
 /* A start condition for chomping an invalid token. */
 
 /* Exclusive start condition for parsing escape sequences in string literals. */
 
-#line 1106 "beancount/parser/lexer.c"
+#line 1120 "beancount/parser/lexer.c"
 
 #define INITIAL 0
 #define INVALID 1
@@ -1387,12 +1401,12 @@ YY_DECL
 		}
 
 	{
-#line 190 "beancount/parser/lexer.l"
+#line 204 "beancount/parser/lexer.l"
 
 
-#line 193 "beancount/parser/lexer.l"
+#line 207 "beancount/parser/lexer.l"
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
-#line 1395 "beancount/parser/lexer.c"
+#line 1409 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1460,7 +1474,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 194 "beancount/parser/lexer.l"
+#line 208 "beancount/parser/lexer.l"
 {
     yy_line_tokens = 0;
     yycolumn = 1;
@@ -1473,7 +1487,7 @@ YY_RULE_SETUP
     the grammar. */
 case 2:
 YY_RULE_SETUP
-#line 204 "beancount/parser/lexer.l"
+#line 218 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens == 1) {
         /* If the next character completes the line, skip it. */
@@ -1491,79 +1505,79 @@ YY_RULE_SETUP
 /* Characters with special meanings have their own tokens. */
 case 3:
 YY_RULE_SETUP
-#line 219 "beancount/parser/lexer.l"
+#line 233 "beancount/parser/lexer.l"
 { return PIPE; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 220 "beancount/parser/lexer.l"
+#line 234 "beancount/parser/lexer.l"
 { return ATAT; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 221 "beancount/parser/lexer.l"
+#line 235 "beancount/parser/lexer.l"
 { return AT; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 222 "beancount/parser/lexer.l"
+#line 236 "beancount/parser/lexer.l"
 { return LCURLCURL; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 223 "beancount/parser/lexer.l"
+#line 237 "beancount/parser/lexer.l"
 { return RCURLCURL; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 224 "beancount/parser/lexer.l"
+#line 238 "beancount/parser/lexer.l"
 { return LCURL; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 225 "beancount/parser/lexer.l"
+#line 239 "beancount/parser/lexer.l"
 { return RCURL; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 226 "beancount/parser/lexer.l"
+#line 240 "beancount/parser/lexer.l"
 { return COMMA; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 227 "beancount/parser/lexer.l"
+#line 241 "beancount/parser/lexer.l"
 { return TILDE; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 228 "beancount/parser/lexer.l"
+#line 242 "beancount/parser/lexer.l"
 { return PLUS; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 229 "beancount/parser/lexer.l"
+#line 243 "beancount/parser/lexer.l"
 { return MINUS; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 230 "beancount/parser/lexer.l"
+#line 244 "beancount/parser/lexer.l"
 { return SLASH; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 231 "beancount/parser/lexer.l"
+#line 245 "beancount/parser/lexer.l"
 { return LPAREN; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 232 "beancount/parser/lexer.l"
+#line 246 "beancount/parser/lexer.l"
 { return RPAREN; }
 	YY_BREAK
 /* Special handling for characters beginning a line to be ignored.
   * I'd like to improve how this is handled. Needs own lexer, really. */
 case 17:
 YY_RULE_SETUP
-#line 236 "beancount/parser/lexer.l"
+#line 250 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens != 1) {
         return HASH;
@@ -1577,7 +1591,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 247 "beancount/parser/lexer.l"
+#line 261 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens != 1) {
         return ASTERISK;
@@ -1591,7 +1605,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 258 "beancount/parser/lexer.l"
+#line 272 "beancount/parser/lexer.l"
 {
   if (yy_line_tokens != 1) {
     return COLON;
@@ -1606,7 +1620,7 @@ YY_RULE_SETUP
 /* Skip commented output (but not the accompanying newline). */
 case 20:
 YY_RULE_SETUP
-#line 270 "beancount/parser/lexer.l"
+#line 284 "beancount/parser/lexer.l"
 {
     /* yy_skip_line(); */
     return COMMENT;
@@ -1622,7 +1636,7 @@ YY_RULE_SETUP
     */
 case 21:
 YY_RULE_SETUP
-#line 283 "beancount/parser/lexer.l"
+#line 297 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens != 1) {
         yylval->character = yytext[0];
@@ -1637,103 +1651,103 @@ YY_RULE_SETUP
 /* Keywords. */
 case 22:
 YY_RULE_SETUP
-#line 295 "beancount/parser/lexer.l"
+#line 309 "beancount/parser/lexer.l"
 { return TXN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 296 "beancount/parser/lexer.l"
+#line 310 "beancount/parser/lexer.l"
 { return BALANCE; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 297 "beancount/parser/lexer.l"
+#line 311 "beancount/parser/lexer.l"
 { return OPEN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 298 "beancount/parser/lexer.l"
+#line 312 "beancount/parser/lexer.l"
 { return CLOSE; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 299 "beancount/parser/lexer.l"
+#line 313 "beancount/parser/lexer.l"
 { return COMMODITY; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 300 "beancount/parser/lexer.l"
+#line 314 "beancount/parser/lexer.l"
 { return PAD; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 301 "beancount/parser/lexer.l"
+#line 315 "beancount/parser/lexer.l"
 { return EVENT; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 302 "beancount/parser/lexer.l"
+#line 316 "beancount/parser/lexer.l"
 { return QUERY; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 303 "beancount/parser/lexer.l"
+#line 317 "beancount/parser/lexer.l"
 { return CUSTOM; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 304 "beancount/parser/lexer.l"
+#line 318 "beancount/parser/lexer.l"
 { return PRICE; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 305 "beancount/parser/lexer.l"
+#line 319 "beancount/parser/lexer.l"
 { return NOTE; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 306 "beancount/parser/lexer.l"
+#line 320 "beancount/parser/lexer.l"
 { return DOCUMENT; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 307 "beancount/parser/lexer.l"
+#line 321 "beancount/parser/lexer.l"
 { return PUSHTAG; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 308 "beancount/parser/lexer.l"
+#line 322 "beancount/parser/lexer.l"
 { return POPTAG; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 309 "beancount/parser/lexer.l"
+#line 323 "beancount/parser/lexer.l"
 { return PUSHMETA; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 310 "beancount/parser/lexer.l"
+#line 324 "beancount/parser/lexer.l"
 { return POPMETA; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 311 "beancount/parser/lexer.l"
+#line 325 "beancount/parser/lexer.l"
 { return OPTION; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 312 "beancount/parser/lexer.l"
+#line 326 "beancount/parser/lexer.l"
 { return PLUGIN; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 313 "beancount/parser/lexer.l"
+#line 327 "beancount/parser/lexer.l"
 { return INCLUDE; }
 	YY_BREAK
 /* Boolean values. */
 case 41:
 YY_RULE_SETUP
-#line 316 "beancount/parser/lexer.l"
+#line 330 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_True;
     Py_INCREF(Py_True);
@@ -1742,7 +1756,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 322 "beancount/parser/lexer.l"
+#line 336 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_False;
     Py_INCREF(Py_False);
@@ -1751,7 +1765,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 328 "beancount/parser/lexer.l"
+#line 342 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_None;
     Py_INCREF(Py_None);
@@ -1761,7 +1775,7 @@ YY_RULE_SETUP
 /* Dates. */
 case 44:
 YY_RULE_SETUP
-#line 335 "beancount/parser/lexer.l"
+#line 349 "beancount/parser/lexer.l"
 {
     const char* year_str;
     const char* month_str;
@@ -1786,7 +1800,7 @@ YY_RULE_SETUP
 /* Account names. */
 case 45:
 YY_RULE_SETUP
-#line 357 "beancount/parser/lexer.l"
+#line 371 "beancount/parser/lexer.l"
 {
     BUILD_LEX("ACCOUNT", "s", yytext);
     return ACCOUNT;
@@ -1796,7 +1810,7 @@ YY_RULE_SETUP
   * syntax. This is kept in sync with beancount.core.amount.CURRENCY_RE. */
 case 46:
 YY_RULE_SETUP
-#line 364 "beancount/parser/lexer.l"
+#line 378 "beancount/parser/lexer.l"
 {
     BUILD_LEX("CURRENCY", "s", yytext);
     return CURRENCY;
@@ -1807,7 +1821,7 @@ YY_RULE_SETUP
     See section "Start Conditions" in the GNU Flex manual. */
 case 47:
 YY_RULE_SETUP
-#line 372 "beancount/parser/lexer.l"
+#line 386 "beancount/parser/lexer.l"
 {
     buffer_begin(strbuf);
     BEGIN(STRLIT);
@@ -1817,7 +1831,7 @@ YY_RULE_SETUP
 /* Saw closing quote - all done. */
 case 48:
 YY_RULE_SETUP
-#line 380 "beancount/parser/lexer.l"
+#line 394 "beancount/parser/lexer.l"
 {
         BEGIN(INITIAL);
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
@@ -1836,47 +1850,47 @@ YY_RULE_SETUP
 /* Escape sequences. */
 case 49:
 YY_RULE_SETUP
-#line 396 "beancount/parser/lexer.l"
+#line 410 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\n');
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 397 "beancount/parser/lexer.l"
+#line 411 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\t');
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 398 "beancount/parser/lexer.l"
+#line 412 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\r');
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 399 "beancount/parser/lexer.l"
+#line 413 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\b');
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 400 "beancount/parser/lexer.l"
+#line 414 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\f');
 	YY_BREAK
 case 54:
 /* rule 54 can match eol */
 YY_RULE_SETUP
-#line 401 "beancount/parser/lexer.l"
+#line 415 "beancount/parser/lexer.l"
 buffer_push(strbuf, yytext[1]);
 	YY_BREAK
 /* All other characters. */
 case 55:
 /* rule 55 can match eol */
 YY_RULE_SETUP
-#line 404 "beancount/parser/lexer.l"
+#line 418 "beancount/parser/lexer.l"
 buffer_append(strbuf, yytext, yyleng);
 	YY_BREAK
 
 /* Numbers */
 case 56:
 YY_RULE_SETUP
-#line 408 "beancount/parser/lexer.l"
+#line 422 "beancount/parser/lexer.l"
 {
     BUILD_LEX("NUMBER", "s", yytext);
     return NUMBER;
@@ -1885,7 +1899,7 @@ YY_RULE_SETUP
 /* Tags */
 case 57:
 YY_RULE_SETUP
-#line 414 "beancount/parser/lexer.l"
+#line 428 "beancount/parser/lexer.l"
 {
     BUILD_LEX("TAG", "s", &(yytext[1]));
     return TAG;
@@ -1894,7 +1908,7 @@ YY_RULE_SETUP
 /* Links */
 case 58:
 YY_RULE_SETUP
-#line 420 "beancount/parser/lexer.l"
+#line 434 "beancount/parser/lexer.l"
 {
     BUILD_LEX("LINK", "s", &(yytext[1]));
     return LINK;
@@ -1903,7 +1917,7 @@ YY_RULE_SETUP
 /* Key */
 case 59:
 YY_RULE_SETUP
-#line 426 "beancount/parser/lexer.l"
+#line 440 "beancount/parser/lexer.l"
 {
     BUILD_LEX("KEY", "s#", yytext, (Py_ssize_t)(yyleng-1));
     unput(':');
@@ -1913,7 +1927,7 @@ YY_RULE_SETUP
 /* Default rule. {bf253a29a820} */
 case 60:
 YY_RULE_SETUP
-#line 433 "beancount/parser/lexer.l"
+#line 447 "beancount/parser/lexer.l"
 {
     unput(*yytext);
     BEGIN(INVALID);
@@ -1924,7 +1938,7 @@ YY_RULE_SETUP
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(INVALID):
 case YY_STATE_EOF(STRLIT):
-#line 440 "beancount/parser/lexer.l"
+#line 454 "beancount/parser/lexer.l"
 {
     if (yy_eof_times == 0) {
 	yy_eof_times = 1;
@@ -1941,7 +1955,7 @@ case YY_STATE_EOF(STRLIT):
     this and more. {bba169a1d35a} */
 case 61:
 YY_RULE_SETUP
-#line 454 "beancount/parser/lexer.l"
+#line 468 "beancount/parser/lexer.l"
 {
     char buffer[256];
     size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
@@ -1952,10 +1966,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 463 "beancount/parser/lexer.l"
+#line 477 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1958 "beancount/parser/lexer.c"
+#line 1972 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3158,27 +3172,49 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 463 "beancount/parser/lexer.l"
+#line 477 "beancount/parser/lexer.l"
 
 
-void yylex_initialize(PyObject* filename, int firstline, const char* encoding, yyscan_t yyscanner)
+void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char* encoding, yyscan_t scanner)
 {
-    yyset_extra(malloc(sizeof(yyextra_t)), yyscanner);
+    yyextra_t* extra = malloc(sizeof(yyextra_t));
+    yyset_extra(extra, scanner);
 
-    Py_XDECREF(yy_filename);
-    yy_filename = filename;
+    if (!filename || filename == Py_None) {
+        /* If a filename has not been specified, get it from the 'name'
+	 * attribute of the input file object. */
+        filename = PyObject_GetAttrString(file, "name");
+        if (!filename) {
+	    /* No 'name' attribute. */
+	    PyErr_Clear();
+            /* Use the empty string. */
+            filename = PyUnicode_FromString("");
+        }
+    } else {
+        Py_INCREF(filename);
+    }
 
-    yy_eof_times = 0;
-    yy_line_tokens = 0;
-    yy_firstline = firstline;
-    yy_encoding = encoding ? encoding : "utf-8";
-    buffer_init(strbuf, 1024);
+    extra->filename = filename;
+    extra->n_eof = 0;
+    extra->n_line_tokens = 0;
+    extra->line = lineno;
+    extra->encoding = encoding ? encoding : "utf-8";
+    buffer_init(&extra->str, 1024);
+
+    Py_XDECREF(yyget_in(scanner));
+    yyset_in((void*)file, scanner);
+    Py_INCREF(file);
 }
 
-void yylex_finalize(yyscan_t yyscanner)
+void yylex_finalize(yyscan_t scanner)
 {
-    buffer_free(strbuf);
-    free(yyget_extra(yyscanner));
+    yyextra_t* extra = yyget_extra(scanner);
+
+    Py_XDECREF(extra->filename);
+    buffer_free(&extra->str);
+    free(extra);
+
+    Py_XDECREF(yyget_in(scanner));
 }
 
 static void buffer_init(struct buffer* b, size_t size)

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -1,16 +1,16 @@
-#line 2 "beancount/parser/lexer.c"
+#line 1 "beancount/parser/lexer.c"
 
 #include "parser.h"
 
 typedef struct _yyextra_t yyextra_t;
 
 /* Initialize scanner private data. */
-void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner);
+void yylex_initialize(PyObject* filename, int firstline, const char* encoding, yyscan_t yyscanner);
 
 /* Free scanner private data */
 void yylex_finalize(yyscan_t yyscanner);
 
-#line 14 "beancount/parser/lexer.c"
+#line 13 "beancount/parser/lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -985,7 +985,7 @@ struct _yyextra_t {
     int n_line_tokens;
 
     /* The filename being tokenized. */
-    const char* filename;
+    PyObject* filename;
 
     /* Reporting line offset. This is used like the #line cpp macro */
     int line;
@@ -1098,12 +1098,12 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
 
-#line 1102 "beancount/parser/lexer.c"
+#line 1101 "beancount/parser/lexer.c"
 /* A start condition for chomping an invalid token. */
 
 /* Exclusive start condition for parsing escape sequences in string literals. */
 
-#line 1107 "beancount/parser/lexer.c"
+#line 1106 "beancount/parser/lexer.c"
 
 #define INITIAL 0
 #define INVALID 1
@@ -1392,7 +1392,7 @@ YY_DECL
 
 #line 193 "beancount/parser/lexer.l"
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
-#line 1396 "beancount/parser/lexer.c"
+#line 1395 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1955,7 +1955,7 @@ YY_RULE_SETUP
 #line 463 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1959 "beancount/parser/lexer.c"
+#line 1958 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3161,13 +3161,15 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 #line 463 "beancount/parser/lexer.l"
 
 
-void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner)
+void yylex_initialize(PyObject* filename, int firstline, const char* encoding, yyscan_t yyscanner)
 {
     yyset_extra(malloc(sizeof(yyextra_t)), yyscanner);
 
+    Py_XDECREF(yy_filename);
+    yy_filename = filename;
+
     yy_eof_times = 0;
     yy_line_tokens = 0;
-    yy_filename = filename ? filename : "";
     yy_firstline = firstline;
     yy_encoding = encoding ? encoding : "utf-8";
     buffer_init(strbuf, 1024);
@@ -3228,7 +3230,7 @@ void build_lexer_error(YYLTYPE* loc, PyObject* builder, const char* string, size
     TRACE_ERROR("Invalid Token");
 
     /* Build and accumulate a new error object. {27d1d459c5cd} */
-    PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "sis#",
+    PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "Ois#",
 				       loc->file_name, loc->first_line,
 				       string, (Py_ssize_t)length);
     /* Note: If there was an exception in the callback, let it bubble up. */
@@ -3251,7 +3253,7 @@ void build_lexer_error_from_exception(YYLTYPE* loc, PyObject* builder)
 
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
-        PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "siOO",
+        PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "OiOO",
 					   loc->file_name, loc->first_line,
 					   pvalue, ptype);
         Py_XDECREF(ptype);

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -5,6 +5,21 @@
 typedef struct _yyextra_t yyextra_t;
 
 /**
+ * Allocate a new scanner object including private data.
+ *
+ * This encapsulates the native yylex_init_extra() API.
+ */
+yyscan_t yylex_new(void);
+
+/**
+ * Free scanner object including private data.
+ *
+ * This encapsulated the native yylex_destroy() API. Python objects
+ * references stored in the @scanner are decremented.
+ */
+yyscan_t yylex_free(yyscan_t scanner);
+
+/**
  * Allocate and initialize scanner private data.
  *
  * Setup @scanner to read from the Python file-like object @file. Set
@@ -13,18 +28,11 @@ typedef struct _yyextra_t yyextra_t;
  * the @file object. If this fails, use the empty string. @encoding is
  * used to decode strings read from the input file, if not NULL,
  * otherwise the default UTF-8 encoding is used. Python objects
- * references are incremented.
+ * references are incremented. It is safe to call this multiple times.
  */
 void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char* encoding, yyscan_t scanner);
 
-/**
- * Free scanner private data.
- *
- * Python objects references stored in the @scanner are decremented.
- */
-void yylex_finalize(yyscan_t scanner);
-
-#line 27 "beancount/parser/lexer.c"
+#line 35 "beancount/parser/lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -977,7 +985,7 @@ static const flex_int32_t yy_rule_can_match_eol[63] =
 /* Top Code. This is included in the FLex generated header file. */
 
 /* Definitions. */
-#line 49 "beancount/parser/lexer.l"
+#line 57 "beancount/parser/lexer.l"
 
 #include <math.h>
 #include <stdlib.h>
@@ -1112,12 +1120,12 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
 /* Utility functions. */
 int strtonl(const char* buf, size_t nchars);
 
-#line 1115 "beancount/parser/lexer.c"
+#line 1123 "beancount/parser/lexer.c"
 /* A start condition for chomping an invalid token. */
 
 /* Exclusive start condition for parsing escape sequences in string literals. */
 
-#line 1120 "beancount/parser/lexer.c"
+#line 1128 "beancount/parser/lexer.c"
 
 #define INITIAL 0
 #define INVALID 1
@@ -1401,12 +1409,12 @@ YY_DECL
 		}
 
 	{
-#line 204 "beancount/parser/lexer.l"
+#line 212 "beancount/parser/lexer.l"
 
 
-#line 207 "beancount/parser/lexer.l"
+#line 215 "beancount/parser/lexer.l"
  /* Newlines are output as explicit tokens, because lines matter in the syntax. */
-#line 1409 "beancount/parser/lexer.c"
+#line 1417 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1474,7 +1482,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 208 "beancount/parser/lexer.l"
+#line 216 "beancount/parser/lexer.l"
 {
     yy_line_tokens = 0;
     yycolumn = 1;
@@ -1487,7 +1495,7 @@ YY_RULE_SETUP
     the grammar. */
 case 2:
 YY_RULE_SETUP
-#line 218 "beancount/parser/lexer.l"
+#line 226 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens == 1) {
         /* If the next character completes the line, skip it. */
@@ -1505,79 +1513,79 @@ YY_RULE_SETUP
 /* Characters with special meanings have their own tokens. */
 case 3:
 YY_RULE_SETUP
-#line 233 "beancount/parser/lexer.l"
+#line 241 "beancount/parser/lexer.l"
 { return PIPE; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 234 "beancount/parser/lexer.l"
+#line 242 "beancount/parser/lexer.l"
 { return ATAT; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 235 "beancount/parser/lexer.l"
+#line 243 "beancount/parser/lexer.l"
 { return AT; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 236 "beancount/parser/lexer.l"
+#line 244 "beancount/parser/lexer.l"
 { return LCURLCURL; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 237 "beancount/parser/lexer.l"
+#line 245 "beancount/parser/lexer.l"
 { return RCURLCURL; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 238 "beancount/parser/lexer.l"
+#line 246 "beancount/parser/lexer.l"
 { return LCURL; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 239 "beancount/parser/lexer.l"
+#line 247 "beancount/parser/lexer.l"
 { return RCURL; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 240 "beancount/parser/lexer.l"
+#line 248 "beancount/parser/lexer.l"
 { return COMMA; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 241 "beancount/parser/lexer.l"
+#line 249 "beancount/parser/lexer.l"
 { return TILDE; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 242 "beancount/parser/lexer.l"
+#line 250 "beancount/parser/lexer.l"
 { return PLUS; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 243 "beancount/parser/lexer.l"
+#line 251 "beancount/parser/lexer.l"
 { return MINUS; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 244 "beancount/parser/lexer.l"
+#line 252 "beancount/parser/lexer.l"
 { return SLASH; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 245 "beancount/parser/lexer.l"
+#line 253 "beancount/parser/lexer.l"
 { return LPAREN; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 246 "beancount/parser/lexer.l"
+#line 254 "beancount/parser/lexer.l"
 { return RPAREN; }
 	YY_BREAK
 /* Special handling for characters beginning a line to be ignored.
   * I'd like to improve how this is handled. Needs own lexer, really. */
 case 17:
 YY_RULE_SETUP
-#line 250 "beancount/parser/lexer.l"
+#line 258 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens != 1) {
         return HASH;
@@ -1591,7 +1599,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 261 "beancount/parser/lexer.l"
+#line 269 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens != 1) {
         return ASTERISK;
@@ -1605,7 +1613,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 272 "beancount/parser/lexer.l"
+#line 280 "beancount/parser/lexer.l"
 {
   if (yy_line_tokens != 1) {
     return COLON;
@@ -1620,7 +1628,7 @@ YY_RULE_SETUP
 /* Skip commented output (but not the accompanying newline). */
 case 20:
 YY_RULE_SETUP
-#line 284 "beancount/parser/lexer.l"
+#line 292 "beancount/parser/lexer.l"
 {
     /* yy_skip_line(); */
     return COMMENT;
@@ -1636,7 +1644,7 @@ YY_RULE_SETUP
     */
 case 21:
 YY_RULE_SETUP
-#line 297 "beancount/parser/lexer.l"
+#line 305 "beancount/parser/lexer.l"
 {
     if (yy_line_tokens != 1) {
         yylval->character = yytext[0];
@@ -1651,103 +1659,103 @@ YY_RULE_SETUP
 /* Keywords. */
 case 22:
 YY_RULE_SETUP
-#line 309 "beancount/parser/lexer.l"
+#line 317 "beancount/parser/lexer.l"
 { return TXN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 310 "beancount/parser/lexer.l"
+#line 318 "beancount/parser/lexer.l"
 { return BALANCE; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 311 "beancount/parser/lexer.l"
+#line 319 "beancount/parser/lexer.l"
 { return OPEN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 312 "beancount/parser/lexer.l"
+#line 320 "beancount/parser/lexer.l"
 { return CLOSE; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 313 "beancount/parser/lexer.l"
+#line 321 "beancount/parser/lexer.l"
 { return COMMODITY; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 314 "beancount/parser/lexer.l"
+#line 322 "beancount/parser/lexer.l"
 { return PAD; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 315 "beancount/parser/lexer.l"
+#line 323 "beancount/parser/lexer.l"
 { return EVENT; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 316 "beancount/parser/lexer.l"
+#line 324 "beancount/parser/lexer.l"
 { return QUERY; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 317 "beancount/parser/lexer.l"
+#line 325 "beancount/parser/lexer.l"
 { return CUSTOM; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 318 "beancount/parser/lexer.l"
+#line 326 "beancount/parser/lexer.l"
 { return PRICE; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 319 "beancount/parser/lexer.l"
+#line 327 "beancount/parser/lexer.l"
 { return NOTE; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 320 "beancount/parser/lexer.l"
+#line 328 "beancount/parser/lexer.l"
 { return DOCUMENT; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 321 "beancount/parser/lexer.l"
+#line 329 "beancount/parser/lexer.l"
 { return PUSHTAG; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 322 "beancount/parser/lexer.l"
+#line 330 "beancount/parser/lexer.l"
 { return POPTAG; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 323 "beancount/parser/lexer.l"
+#line 331 "beancount/parser/lexer.l"
 { return PUSHMETA; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 324 "beancount/parser/lexer.l"
+#line 332 "beancount/parser/lexer.l"
 { return POPMETA; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 325 "beancount/parser/lexer.l"
+#line 333 "beancount/parser/lexer.l"
 { return OPTION; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 326 "beancount/parser/lexer.l"
+#line 334 "beancount/parser/lexer.l"
 { return PLUGIN; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 327 "beancount/parser/lexer.l"
+#line 335 "beancount/parser/lexer.l"
 { return INCLUDE; }
 	YY_BREAK
 /* Boolean values. */
 case 41:
 YY_RULE_SETUP
-#line 330 "beancount/parser/lexer.l"
+#line 338 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_True;
     Py_INCREF(Py_True);
@@ -1756,7 +1764,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 336 "beancount/parser/lexer.l"
+#line 344 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_False;
     Py_INCREF(Py_False);
@@ -1765,7 +1773,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 342 "beancount/parser/lexer.l"
+#line 350 "beancount/parser/lexer.l"
 {
     yylval->pyobj = Py_None;
     Py_INCREF(Py_None);
@@ -1775,7 +1783,7 @@ YY_RULE_SETUP
 /* Dates. */
 case 44:
 YY_RULE_SETUP
-#line 349 "beancount/parser/lexer.l"
+#line 357 "beancount/parser/lexer.l"
 {
     const char* year_str;
     const char* month_str;
@@ -1800,7 +1808,7 @@ YY_RULE_SETUP
 /* Account names. */
 case 45:
 YY_RULE_SETUP
-#line 371 "beancount/parser/lexer.l"
+#line 379 "beancount/parser/lexer.l"
 {
     BUILD_LEX("ACCOUNT", "s", yytext);
     return ACCOUNT;
@@ -1810,7 +1818,7 @@ YY_RULE_SETUP
   * syntax. This is kept in sync with beancount.core.amount.CURRENCY_RE. */
 case 46:
 YY_RULE_SETUP
-#line 378 "beancount/parser/lexer.l"
+#line 386 "beancount/parser/lexer.l"
 {
     BUILD_LEX("CURRENCY", "s", yytext);
     return CURRENCY;
@@ -1821,7 +1829,7 @@ YY_RULE_SETUP
     See section "Start Conditions" in the GNU Flex manual. */
 case 47:
 YY_RULE_SETUP
-#line 386 "beancount/parser/lexer.l"
+#line 394 "beancount/parser/lexer.l"
 {
     buffer_begin(strbuf);
     BEGIN(STRLIT);
@@ -1831,7 +1839,7 @@ YY_RULE_SETUP
 /* Saw closing quote - all done. */
 case 48:
 YY_RULE_SETUP
-#line 394 "beancount/parser/lexer.l"
+#line 402 "beancount/parser/lexer.l"
 {
         BEGIN(INITIAL);
         PyObject* str = PyUnicode_Decode(buffer_data(strbuf), buffer_strlen(strbuf),
@@ -1850,47 +1858,47 @@ YY_RULE_SETUP
 /* Escape sequences. */
 case 49:
 YY_RULE_SETUP
-#line 410 "beancount/parser/lexer.l"
+#line 418 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\n');
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 411 "beancount/parser/lexer.l"
+#line 419 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\t');
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 412 "beancount/parser/lexer.l"
+#line 420 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\r');
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 413 "beancount/parser/lexer.l"
+#line 421 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\b');
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 414 "beancount/parser/lexer.l"
+#line 422 "beancount/parser/lexer.l"
 buffer_push(strbuf, '\f');
 	YY_BREAK
 case 54:
 /* rule 54 can match eol */
 YY_RULE_SETUP
-#line 415 "beancount/parser/lexer.l"
+#line 423 "beancount/parser/lexer.l"
 buffer_push(strbuf, yytext[1]);
 	YY_BREAK
 /* All other characters. */
 case 55:
 /* rule 55 can match eol */
 YY_RULE_SETUP
-#line 418 "beancount/parser/lexer.l"
+#line 426 "beancount/parser/lexer.l"
 buffer_append(strbuf, yytext, yyleng);
 	YY_BREAK
 
 /* Numbers */
 case 56:
 YY_RULE_SETUP
-#line 422 "beancount/parser/lexer.l"
+#line 430 "beancount/parser/lexer.l"
 {
     BUILD_LEX("NUMBER", "s", yytext);
     return NUMBER;
@@ -1899,7 +1907,7 @@ YY_RULE_SETUP
 /* Tags */
 case 57:
 YY_RULE_SETUP
-#line 428 "beancount/parser/lexer.l"
+#line 436 "beancount/parser/lexer.l"
 {
     BUILD_LEX("TAG", "s", &(yytext[1]));
     return TAG;
@@ -1908,7 +1916,7 @@ YY_RULE_SETUP
 /* Links */
 case 58:
 YY_RULE_SETUP
-#line 434 "beancount/parser/lexer.l"
+#line 442 "beancount/parser/lexer.l"
 {
     BUILD_LEX("LINK", "s", &(yytext[1]));
     return LINK;
@@ -1917,7 +1925,7 @@ YY_RULE_SETUP
 /* Key */
 case 59:
 YY_RULE_SETUP
-#line 440 "beancount/parser/lexer.l"
+#line 448 "beancount/parser/lexer.l"
 {
     BUILD_LEX("KEY", "s#", yytext, (Py_ssize_t)(yyleng-1));
     unput(':');
@@ -1927,7 +1935,7 @@ YY_RULE_SETUP
 /* Default rule. {bf253a29a820} */
 case 60:
 YY_RULE_SETUP
-#line 447 "beancount/parser/lexer.l"
+#line 455 "beancount/parser/lexer.l"
 {
     unput(*yytext);
     BEGIN(INVALID);
@@ -1938,7 +1946,7 @@ YY_RULE_SETUP
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(INVALID):
 case YY_STATE_EOF(STRLIT):
-#line 454 "beancount/parser/lexer.l"
+#line 462 "beancount/parser/lexer.l"
 {
     if (yy_eof_times == 0) {
 	yy_eof_times = 1;
@@ -1955,7 +1963,7 @@ case YY_STATE_EOF(STRLIT):
     this and more. {bba169a1d35a} */
 case 61:
 YY_RULE_SETUP
-#line 468 "beancount/parser/lexer.l"
+#line 476 "beancount/parser/lexer.l"
 {
     char buffer[256];
     size_t length = snprintf(buffer, 256, "Invalid token: '%s'", yytext);
@@ -1966,10 +1974,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 477 "beancount/parser/lexer.l"
+#line 485 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1972 "beancount/parser/lexer.c"
+#line 1980 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3172,13 +3180,56 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 477 "beancount/parser/lexer.l"
+#line 485 "beancount/parser/lexer.l"
 
+
+yyscan_t yylex_new(void)
+{
+    yyscan_t scanner;
+    yyextra_t* extra;
+
+    extra = malloc(sizeof(*extra));
+    if (!extra)
+        return NULL;
+
+    extra->filename = NULL;
+    buffer_init(&extra->str, 1024);
+
+    yylex_init_extra(extra, &scanner);
+    if (!scanner) {
+        free(extra);
+        return NULL;
+    }
+
+    return scanner;
+}
+
+yyscan_t yylex_free(yyscan_t scanner)
+{
+    yyextra_t* extra = yyget_extra(scanner);
+
+    Py_XDECREF(extra->filename);
+    buffer_free(&extra->str);
+    free(extra);
+
+    Py_XDECREF(yyget_in(scanner));
+    yylex_destroy(scanner);
+
+    return NULL;
+}
+
+/* yyrestart() does not reset the scanner back to INITIAL state and
+ * Flex does not provide a way of doing so outside a scanner
+ * rule. This function does just that accessing Flex internals. */
+static void yybegin(yyscan_t scanner)
+{
+    struct yyguts_t* yyg = (struct yyguts_t*)scanner;
+    BEGIN(INITIAL);
+}
 
 void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char* encoding, yyscan_t scanner)
 {
-    yyextra_t* extra = malloc(sizeof(yyextra_t));
-    yyset_extra(extra, scanner);
+    yyextra_t* extra = yyget_extra(scanner);
 
     if (!filename || filename == Py_None) {
         /* If a filename has not been specified, get it from the 'name'
@@ -3194,7 +3245,9 @@ void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char
         Py_INCREF(filename);
     }
 
+    Py_XDECREF(extra->filename);
     extra->filename = filename;
+
     extra->n_eof = 0;
     extra->n_line_tokens = 0;
     extra->line = lineno;
@@ -3202,19 +3255,9 @@ void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char
     buffer_init(&extra->str, 1024);
 
     Py_XDECREF(yyget_in(scanner));
-    yyset_in((void*)file, scanner);
     Py_INCREF(file);
-}
-
-void yylex_finalize(yyscan_t scanner)
-{
-    yyextra_t* extra = yyget_extra(scanner);
-
-    Py_XDECREF(extra->filename);
-    buffer_free(&extra->str);
-    free(extra);
-
-    Py_XDECREF(yyget_in(scanner));
+    yyrestart((void *)file, scanner);
+    yybegin(scanner);
 }
 
 static void buffer_init(struct buffer* b, size_t size)

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -9,6 +9,21 @@
 typedef struct _yyextra_t yyextra_t;
 
 /**
+ * Allocate a new scanner object including private data.
+ *
+ * This encapsulates the native yylex_init_extra() API.
+ */
+yyscan_t yylex_new(void);
+
+/**
+ * Free scanner object including private data.
+ *
+ * This encapsulated the native yylex_destroy() API. Python objects
+ * references stored in the @scanner are decremented.
+ */
+yyscan_t yylex_free(yyscan_t scanner);
+
+/**
  * Allocate and initialize scanner private data.
  *
  * Setup @scanner to read from the Python file-like object @file. Set
@@ -17,18 +32,11 @@ typedef struct _yyextra_t yyextra_t;
  * the @file object. If this fails, use the empty string. @encoding is
  * used to decode strings read from the input file, if not NULL,
  * otherwise the default UTF-8 encoding is used. Python objects
- * references are incremented.
+ * references are incremented. It is safe to call this multiple times.
  */
 void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char* encoding, yyscan_t scanner);
 
-/**
- * Free scanner private data.
- *
- * Python objects references stored in the @scanner are decremented.
- */
-void yylex_finalize(yyscan_t scanner);
-
-#line 31 "beancount/parser/lexer.h"
+#line 39 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -542,9 +550,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 477 "beancount/parser/lexer.l"
+#line 485 "beancount/parser/lexer.l"
 
 
-#line 548 "beancount/parser/lexer.h"
+#line 556 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -8,13 +8,27 @@
 
 typedef struct _yyextra_t yyextra_t;
 
-/* Initialize scanner private data. */
-void yylex_initialize(PyObject* filename, int firstline, const char* encoding, yyscan_t yyscanner);
+/**
+ * Allocate and initialize scanner private data.
+ *
+ * Setup @scanner to read from the Python file-like object @file. Set
+ * the reported file name to @filename, if not NULL and not None.
+ * Otherwise try to obtain the file name from the @name attribute of
+ * the @file object. If this fails, use the empty string. @encoding is
+ * used to decode strings read from the input file, if not NULL,
+ * otherwise the default UTF-8 encoding is used. Python objects
+ * references are incremented.
+ */
+void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char* encoding, yyscan_t scanner);
 
-/* Free scanner private data */
-void yylex_finalize(yyscan_t yyscanner);
+/**
+ * Free scanner private data.
+ *
+ * Python objects references stored in the @scanner are decremented.
+ */
+void yylex_finalize(yyscan_t scanner);
 
-#line 17 "beancount/parser/lexer.h"
+#line 31 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -528,9 +542,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 463 "beancount/parser/lexer.l"
+#line 477 "beancount/parser/lexer.l"
 
 
-#line 534 "beancount/parser/lexer.h"
+#line 548 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -2,19 +2,19 @@
 #define yyHEADER_H 1
 #define yyIN_HEADER 1
 
-#line 6 "beancount/parser/lexer.h"
+#line 5 "beancount/parser/lexer.h"
 
 #include "parser.h"
 
 typedef struct _yyextra_t yyextra_t;
 
 /* Initialize scanner private data. */
-void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner);
+void yylex_initialize(PyObject* filename, int firstline, const char* encoding, yyscan_t yyscanner);
 
 /* Free scanner private data */
 void yylex_finalize(yyscan_t yyscanner);
 
-#line 18 "beancount/parser/lexer.h"
+#line 17 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -531,6 +531,6 @@ extern int yylex \
 #line 463 "beancount/parser/lexer.l"
 
 
-#line 535 "beancount/parser/lexer.h"
+#line 534 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -23,7 +23,7 @@
 typedef struct _yyextra_t yyextra_t;
 
 /* Initialize scanner private data. */
-void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner);
+void yylex_initialize(PyObject* filename, int firstline, const char* encoding, yyscan_t yyscanner);
 
 /* Free scanner private data */
 void yylex_finalize(yyscan_t yyscanner);
@@ -53,7 +53,7 @@ struct _yyextra_t {
     int n_line_tokens;
 
     /* The filename being tokenized. */
-    const char* filename;
+    PyObject* filename;
 
     /* Reporting line offset. This is used like the #line cpp macro */
     int line;
@@ -461,13 +461,15 @@ NULL		{
 
 %% /* User Code */
 
-void yylex_initialize(const char* filename, int firstline, const char* encoding, yyscan_t yyscanner)
+void yylex_initialize(PyObject* filename, int firstline, const char* encoding, yyscan_t yyscanner)
 {
     yyset_extra(malloc(sizeof(yyextra_t)), yyscanner);
 
+    Py_XDECREF(yy_filename);
+    yy_filename = filename;
+
     yy_eof_times = 0;
     yy_line_tokens = 0;
-    yy_filename = filename ? filename : "";
     yy_firstline = firstline;
     yy_encoding = encoding ? encoding : "utf-8";
     buffer_init(strbuf, 1024);
@@ -528,7 +530,7 @@ void build_lexer_error(YYLTYPE* loc, PyObject* builder, const char* string, size
     TRACE_ERROR("Invalid Token");
 
     /* Build and accumulate a new error object. {27d1d459c5cd} */
-    PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "sis#",
+    PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "Ois#",
 				       loc->file_name, loc->first_line,
 				       string, (Py_ssize_t)length);
     /* Note: If there was an exception in the callback, let it bubble up. */
@@ -551,7 +553,7 @@ void build_lexer_error_from_exception(YYLTYPE* loc, PyObject* builder)
 
     if (pvalue != NULL) {
         /* Build and accumulate a new error object. {27d1d459c5cd} */
-        PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "siOO",
+        PyObject* rv = PyObject_CallMethod(builder, "build_lexer_error", "OiOO",
 					   loc->file_name, loc->first_line,
 					   pvalue, ptype);
         Py_XDECREF(ptype);

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -23,6 +23,21 @@
 typedef struct _yyextra_t yyextra_t;
 
 /**
+ * Allocate a new scanner object including private data.
+ *
+ * This encapsulates the native yylex_init_extra() API.
+ */
+yyscan_t yylex_new(void);
+
+/**
+ * Free scanner object including private data.
+ *
+ * This encapsulated the native yylex_destroy() API. Python objects
+ * references stored in the @scanner are decremented.
+ */
+yyscan_t yylex_free(yyscan_t scanner);
+
+/**
  * Allocate and initialize scanner private data.
  *
  * Setup @scanner to read from the Python file-like object @file. Set
@@ -31,16 +46,9 @@ typedef struct _yyextra_t yyextra_t;
  * the @file object. If this fails, use the empty string. @encoding is
  * used to decode strings read from the input file, if not NULL,
  * otherwise the default UTF-8 encoding is used. Python objects
- * references are incremented.
+ * references are incremented. It is safe to call this multiple times.
  */
 void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char* encoding, yyscan_t scanner);
-
-/**
- * Free scanner private data.
- *
- * Python objects references stored in the @scanner are decremented.
- */
-void yylex_finalize(yyscan_t scanner);
 
 }
 
@@ -475,10 +483,53 @@ NULL		{
 
 %% /* User Code */
 
+yyscan_t yylex_new(void)
+{
+    yyscan_t scanner;
+    yyextra_t* extra;
+
+    extra = malloc(sizeof(*extra));
+    if (!extra)
+        return NULL;
+
+    extra->filename = NULL;
+    buffer_init(&extra->str, 1024);
+
+    yylex_init_extra(extra, &scanner);
+    if (!scanner) {
+        free(extra);
+        return NULL;
+    }
+
+    return scanner;
+}
+
+yyscan_t yylex_free(yyscan_t scanner)
+{
+    yyextra_t* extra = yyget_extra(scanner);
+
+    Py_XDECREF(extra->filename);
+    buffer_free(&extra->str);
+    free(extra);
+
+    Py_XDECREF(yyget_in(scanner));
+    yylex_destroy(scanner);
+
+    return NULL;
+}
+
+/* yyrestart() does not reset the scanner back to INITIAL state and
+ * Flex does not provide a way of doing so outside a scanner
+ * rule. This function does just that accessing Flex internals. */
+static void yybegin(yyscan_t scanner)
+{
+    struct yyguts_t* yyg = (struct yyguts_t*)scanner;
+    BEGIN(INITIAL);
+}
+
 void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char* encoding, yyscan_t scanner)
 {
-    yyextra_t* extra = malloc(sizeof(yyextra_t));
-    yyset_extra(extra, scanner);
+    yyextra_t* extra = yyget_extra(scanner);
 
     if (!filename || filename == Py_None) {
         /* If a filename has not been specified, get it from the 'name'
@@ -494,7 +545,9 @@ void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char
         Py_INCREF(filename);
     }
 
+    Py_XDECREF(extra->filename);
     extra->filename = filename;
+
     extra->n_eof = 0;
     extra->n_line_tokens = 0;
     extra->line = lineno;
@@ -502,19 +555,9 @@ void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char
     buffer_init(&extra->str, 1024);
 
     Py_XDECREF(yyget_in(scanner));
-    yyset_in((void*)file, scanner);
     Py_INCREF(file);
-}
-
-void yylex_finalize(yyscan_t scanner)
-{
-    yyextra_t* extra = yyget_extra(scanner);
-
-    Py_XDECREF(extra->filename);
-    buffer_free(&extra->str);
-    free(extra);
-
-    Py_XDECREF(yyget_in(scanner));
+    yyrestart((void *)file, scanner);
+    yybegin(scanner);
 }
 
 static void buffer_init(struct buffer* b, size_t size)

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -22,11 +22,25 @@
 
 typedef struct _yyextra_t yyextra_t;
 
-/* Initialize scanner private data. */
-void yylex_initialize(PyObject* filename, int firstline, const char* encoding, yyscan_t yyscanner);
+/**
+ * Allocate and initialize scanner private data.
+ *
+ * Setup @scanner to read from the Python file-like object @file. Set
+ * the reported file name to @filename, if not NULL and not None.
+ * Otherwise try to obtain the file name from the @name attribute of
+ * the @file object. If this fails, use the empty string. @encoding is
+ * used to decode strings read from the input file, if not NULL,
+ * otherwise the default UTF-8 encoding is used. Python objects
+ * references are incremented.
+ */
+void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char* encoding, yyscan_t scanner);
 
-/* Free scanner private data */
-void yylex_finalize(yyscan_t yyscanner);
+/**
+ * Free scanner private data.
+ *
+ * Python objects references stored in the @scanner are decremented.
+ */
+void yylex_finalize(yyscan_t scanner);
 
 }
 
@@ -55,7 +69,7 @@ struct _yyextra_t {
     /* The filename being tokenized. */
     PyObject* filename;
 
-    /* Reporting line offset. This is used like the #line cpp macro */
+    /* Reporting line offset. This is used like the #line cpp macro. */
     int line;
 
     /* The encoding to use for converting strings. */
@@ -461,24 +475,46 @@ NULL		{
 
 %% /* User Code */
 
-void yylex_initialize(PyObject* filename, int firstline, const char* encoding, yyscan_t yyscanner)
+void yylex_initialize(PyObject* file, PyObject* filename, int lineno, const char* encoding, yyscan_t scanner)
 {
-    yyset_extra(malloc(sizeof(yyextra_t)), yyscanner);
+    yyextra_t* extra = malloc(sizeof(yyextra_t));
+    yyset_extra(extra, scanner);
 
-    Py_XDECREF(yy_filename);
-    yy_filename = filename;
+    if (!filename || filename == Py_None) {
+        /* If a filename has not been specified, get it from the 'name'
+	 * attribute of the input file object. */
+        filename = PyObject_GetAttrString(file, "name");
+        if (!filename) {
+	    /* No 'name' attribute. */
+	    PyErr_Clear();
+            /* Use the empty string. */
+            filename = PyUnicode_FromString("");
+        }
+    } else {
+        Py_INCREF(filename);
+    }
 
-    yy_eof_times = 0;
-    yy_line_tokens = 0;
-    yy_firstline = firstline;
-    yy_encoding = encoding ? encoding : "utf-8";
-    buffer_init(strbuf, 1024);
+    extra->filename = filename;
+    extra->n_eof = 0;
+    extra->n_line_tokens = 0;
+    extra->line = lineno;
+    extra->encoding = encoding ? encoding : "utf-8";
+    buffer_init(&extra->str, 1024);
+
+    Py_XDECREF(yyget_in(scanner));
+    yyset_in((void*)file, scanner);
+    Py_INCREF(file);
 }
 
-void yylex_finalize(yyscan_t yyscanner)
+void yylex_finalize(yyscan_t scanner)
 {
-    buffer_free(strbuf);
-    free(yyget_extra(yyscanner));
+    yyextra_t* extra = yyget_extra(scanner);
+
+    Py_XDECREF(extra->filename);
+    buffer_free(&extra->str);
+    free(extra);
+
+    Py_XDECREF(yyget_in(scanner));
 }
 
 static void buffer_init(struct buffer* b, size_t size)

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -112,18 +112,8 @@ static PyObject* parser_parse(Parser* self, PyObject* args, PyObject* kwds)
         return NULL;
     }
 
-    if (!filename || filename == Py_None) {
-        /* Try to get the filename from the 'name' attribute. */
-        filename = PyObject_GetAttrString(file, "name");
-        if (!filename) {
-            filename = PyUnicode_FromString("");
-            PyErr_Clear();
-        }
-    }
-
     /* Initialize the scanner state. */
-    yylex_initialize(filename, lineno, encoding, self->scanner);
-    yyset_in((void*)file, self->scanner);
+    yylex_initialize(file, filename, lineno, encoding, self->scanner);
 
     /* Run the parser. */
     ret = yyparse(self->scanner, self->builder);
@@ -169,18 +159,8 @@ static PyObject* parser_lex(Parser* self, PyObject* args, PyObject* kwds)
         return NULL;
     }
 
-    if (!filename || filename == Py_None) {
-        /* Try to get the filename from the 'name' attribute. */
-        filename = PyObject_GetAttrString(file, "name");
-        if (!filename) {
-            filename = PyUnicode_FromString("");
-            PyErr_Clear();
-        }
-    }
-
     /* Initialize the scanner state. */
-    yylex_initialize(filename, lineno, encoding, self->scanner);
-    yyset_in((void*)file, self->scanner);
+    yylex_initialize(file, filename, lineno, encoding, self->scanner);
 
     Py_INCREF(self);
     return (PyObject*)self;

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -43,7 +43,7 @@ static PyObject* parser_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
         return NULL;
     }
 
-    yylex_init(&self->scanner);
+    self->scanner = yylex_new();
     if (!self->scanner) {
         Py_XDECREF(self);
         return NULL;
@@ -81,8 +81,7 @@ static void parser_dealloc(Parser* self)
     Py_XDECREF(self->builder);
 
     /* Finalize the scanner state. */
-    yylex_finalize(self->scanner);
-    yylex_destroy(self->scanner);
+    yylex_free(self->scanner);
 
     Py_TYPE(self)->tp_free((PyObject*)self);
 }

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -102,28 +102,23 @@ static PyObject* parser_parse(Parser* self, PyObject* args, PyObject* kwds)
 {
     static char* kwlist[] = {"file", "filename", "lineno", "encoding", NULL};
     const char* encoding = NULL;
-    const char* filename = NULL;
+    PyObject* filename = NULL;
     PyObject* file;
     int lineno = 0;
     int ret;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ziz", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|Oiz", kwlist,
                                      &file, &filename, &lineno, &encoding)) {
         return NULL;
     }
 
-    /* If we are provided a buffer object, try to get the filename from the
-     * '.name' attribute. */
-    if (!filename) {
-        PyObject* p = PyObject_GetAttrString(file, "name");
-        if (p) {
-            PyObject* name = PyUnicode_EncodeFSDefault(p);
-            if (name) {
-                filename = PyBytes_AsString(name);
-            }
-            Py_DECREF(p);
+    if (!filename || filename == Py_None) {
+        /* Try to get the filename from the 'name' attribute. */
+        filename = PyObject_GetAttrString(file, "name");
+        if (!filename) {
+            filename = PyUnicode_FromString("");
+            PyErr_Clear();
         }
-        PyErr_Clear();
     }
 
     /* Initialize the scanner state. */
@@ -165,28 +160,22 @@ static PyObject* parser_lex(Parser* self, PyObject* args, PyObject* kwds)
 {
     static char* kwlist[] = {"file", "filename", "lineno", "encoding", NULL};
     const char* encoding = NULL;
-    const char* filename = NULL;
+    PyObject* filename = NULL;
     PyObject* file;
     int lineno = 0;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ziz", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|Oiz", kwlist,
                                      &file, &filename, &lineno, &encoding)) {
         return NULL;
     }
 
-    /* If we are provided a buffer object, try to get the filename from the
-     * '.name' attribute. */
-    /* TODO(blais): Refactor this block. */
-    if (!filename) {
-        PyObject* p = PyObject_GetAttrString(file, "name");
-        if (p) {
-            PyObject* name = PyUnicode_EncodeFSDefault(p);
-            if (name) {
-                filename = PyBytes_AsString(name);
-            }
-            Py_DECREF(p);
+    if (!filename || filename == Py_None) {
+        /* Try to get the filename from the 'name' attribute. */
+        filename = PyObject_GetAttrString(file, "name");
+        if (!filename) {
+            filename = PyUnicode_FromString("");
+            PyErr_Clear();
         }
-        PyErr_Clear();
     }
 
     /* Initialize the scanner state. */

--- a/beancount/parser/parser.py
+++ b/beancount/parser/parser.py
@@ -199,7 +199,7 @@ def parse_file(file, report_filename=None, report_firstline=0, **kw):
     # readinto() method.
     elif not isinstance(file, io.IOBase):
         file = open(file, 'rb')
-    builder = grammar.Builder(report_filename or file.name)
+    builder = grammar.Builder()
     parser = _parser.Parser(builder)
     parser.parse(file, filename=report_filename, lineno=report_firstline, **kw)
     return builder.finalize()

--- a/beancount/parser/parser_test.py
+++ b/beancount/parser/parser_test.py
@@ -278,6 +278,28 @@ class TestReferenceCounting(unittest.TestCase):
         self.assertEqual(sys.getrefcount(name), 2)
         self.assertEqual(sys.getrefcount(f), 2)
 
+    def test_parser_lex_multi(self):
+        file1 = io.BytesIO(b"")
+        file1.name = object()
+        self.assertEqual(sys.getrefcount(file1.name), 2)
+
+        file2 = io.BytesIO(b"")
+        file2.name = object()
+        self.assertEqual(sys.getrefcount(file2.name), 2)
+
+        builder = lexer.LexBuilder()
+        parser = _parser.Parser(builder)
+        tokens = list(parser.lex(file1))
+        tokens = list(parser.lex(file2))
+
+        del parser
+        # Once the Parser object is gone we should have just the local
+        # references to the file objects and one references to the names.
+        self.assertEqual(sys.getrefcount(file1), 2)
+        self.assertEqual(sys.getrefcount(file1.name), 2)
+        self.assertEqual(sys.getrefcount(file2), 2)
+        self.assertEqual(sys.getrefcount(file2.name), 2)
+
     def test_parser_parse(self):
         # Do not use a string to avoid issues due to string interning.
         name = object()


### PR DESCRIPTION
The first two patches are simplifications of the parser code. The third fixes reference counting of Python object passed to the parser. The last one fixes a potential memory leak. The memory leak is not triggered by how Beancount uses the Parser object now, but the potential is there and it does not take much to fix it.