### PR TITLE
makefile: Do not clobber the Bazel build definition on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ all: build
 # Clean everything up.
 clean:
 	rm -f core
-	rm -rf build
 	rm -f $(CROOT)/grammar.h $(CROOT)/grammar.c
 	rm -f $(CROOT)/lexer.h $(CROOT)/lexer.c
 	rm -f $(CROOT)/*.so


### PR DESCRIPTION
As far as I can tell there is no reason to remove a 'build' directory
on 'make clean' and this removes the Bazel BUIL definition on my
system: macOS uses case insensitive filesystem by defaul. Yes, it
sucks.