### PR TITLE
Removed rounding in Coinbase price fetcher

### DIFF
--- a/beancount/prices/sources/coinbase.py
+++ b/beancount/prices/sources/coinbase.py
@@ -38,7 +38,7 @@ def fetch_quote(ticker, time=None):
                                                                response.text))
     result = response.json()
 
-    price = D(result['data']['amount']).quantize(D('0.01'))
+    price = D(result['data']['amount'])
     if time is None:
         time = datetime.datetime.now(tz.tzutc())
     currency = result['data']['currency']

--- a/beancount/prices/sources/coinbase_test.py
+++ b/beancount/prices/sources/coinbase_test.py
@@ -31,22 +31,22 @@ class CoinbasePriceFetcher(unittest.TestCase):
     def test_valid_response(self):
         contents = {"data": {"base": "BTC",
                              "currency": "USD",
-                             "amount": 101.23}}
+                             "amount": "101.23456"}}
         with response(contents):
             srcprice = coinbase.Source().get_latest_price('BTC-GBP')
             self.assertIsInstance(srcprice, source.SourcePrice)
-            self.assertEqual(D('101.23'), srcprice.price)
+            self.assertEqual(D('101.23456'), srcprice.price)
             self.assertEqual('USD', srcprice.quote_currency)
 
     def test_historical_price(self):
         contents = {"data": {"base": "BTC",
                              "currency": "USD",
-                             "amount": 101.23}}
+                             "amount": "101.23456"}}
         with response(contents):
             time = datetime.datetime(2018, 3, 27, 0, 0, 0, tzinfo=tz.tzutc())
             srcprice = coinbase.Source().get_historical_price('BTC-GBP', time)
             self.assertIsInstance(srcprice, source.SourcePrice)
-            self.assertEqual(D('101.23'), srcprice.price)
+            self.assertEqual(D('101.23456'), srcprice.price)
             self.assertEqual('USD', srcprice.quote_currency)
             self.assertEqual(datetime.datetime(2018, 3, 27, 0, 0, 0, tzinfo=tz.tzutc()),
                              srcprice.time)


### PR DESCRIPTION
I noticed the coinbase prices were always rounded to two decimals, something that doesn't make any sense for crypto currencies that for example are worth less than a cent right now.

Coinbase returns the amounts as strings, not as numerics. my guess is that's what previously made the test fail without the rounding.