### PR TITLE
CI fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ python:
 
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
       - gnupg
       - zip
@@ -22,9 +20,13 @@ before_install:
   - wget https://github.com/bazelbuild/bazel/releases/download/3.2.0/bazel_3.2.0-linux-x86_64.deb
   - sha256sum -c tools/bazel_3.2.0-linux-x86_64.deb.sha256
   - sudo dpkg -i bazel_3.2.0-linux-x86_64.deb
+  - wget https://ftpmirror.gnu.org/gnu/bison/bison-3.6.4.tar.xz
+  - tar -xjvf bison-3.6.4.tar.xz
+  - pushd bison-3.6.4 && ./configure && make install && popd
 
 script:
   - /usr/bin/bazel --bazelrc=.bazelrc.travis test //...
-  - make build
+  - bison --version
+  - python3 setup.py build_ext -i
   - make test
   - make lint


### PR DESCRIPTION
The most recent Ununtu release supported by Travis-CI is Focal which
ships with Bison 3.5. We now require Bison 3.6. This worked because
the Makefile decided not to rebuild the checked in generted files when
the commit requiring Bison 3.6 was introduced. When the Makefile
attempts to regenerate the grammar it fails.

Install a more recent Bison as part of the CI setup.