### PR TITLE
makefile: Tiny cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ LINT_SRCS =					\
 PYLINT = python3 -m pylint
 
 pylint lint:
-	ENABLE_AUTOIMPORTS= $(PYLINT) $(LINT_SRCS)
+	$(PYLINT) $(LINT_SRCS)
 
 LINT_TESTS=useless-suppression,empty-docstring
 pylint-only:


### PR DESCRIPTION
The ENABLE_AUTOIMPORTS environment variable does not seem to have any
effect on the execution of pylint. If it does it is not documented
anywhere.