### PR TITLE
Add a valid XHTML file type

### DIFF
--- a/beancount/utils/file_type_test.py
+++ b/beancount/utils/file_type_test.py
@@ -71,7 +71,8 @@ class TestFileType(unittest.TestCase):
         self.check_mime_type('example.html', 'text/html')
 
     def test_xhtml(self):
-        self.check_mime_type('example.xhtml', 'application/xhtml+xml')
+        self.check_mime_type('example.xhtml', ['application/xhtml+xml',
+                                               'text/html'])
 
     def test_zip(self):
         self.check_mime_type('example.zip', ['application/zip',


### PR DESCRIPTION
So that tests pass on Alpine Linux

On Ubuntu, guess_file_type returns 'application/xhtml+xml' for `example.xhtml`:

    $ docker run -ti --rm ubuntu:focal
    # apt update &&
      apt install --yes python3-pip wget &&
      python3 -m pip install beancount==2.2.3 &&
      wget https://raw.githubusercontent.com/beancount/beancount/master/beancount/utils/file_type_testdata/example.xhtml &&
      python3
    ✂
    >>> from beancount.utils.file_type import guess_file_type
    >>> guess_file_type('example.xhtml')
    'application/xhtml+xml'

Whereas on Alpine Linux guess_file_type returns text/html for example.xhtml:

    $ docker run -ti --rm alpine:latest
    # apk add beancount &&
      wget https://raw.githubusercontent.com/beancount/beancount/master/beancount/utils/file_type_testdata/example.xhtml &&
      python3
    ✂
    >>> from beancount.utils.file_type import guess_file_type
    >>> guess_file_type('example.xhtml')
    'text/html'

Both are valid. Before this change `test_xhtml` fails on Alpine Linux. After this change the `test_xhtml` passes on Alpine Linux as well.