### PR TITLE
Cast float to string before casting to Decimal

### DIFF
--- a/beancount/core/number.py
+++ b/beancount/core/number.py
@@ -55,8 +55,10 @@ def D(strord=None):
             return Decimal(_CLEAN_NUMBER_RE.sub('', strord))
         elif isinstance(strord, Decimal):
             return strord
-        elif isinstance(strord, (int, float)):
+        elif isinstance(strord, int):
             return Decimal(strord)
+        elif isinstance(strord, float):
+            return Decimal(str(strord))
         else:
             assert strord is None, "Invalid value to convert: {}".format(strord)
     except Exception as exc:


### PR DESCRIPTION
float to Decimal gives approximation errors as below example
 
But casting it to `str` and then to `D`/`Decimal` would solve this problem I suppose.

```python
In [1]: from beancount.core.number import D                                                                                                                                                    

In [2]: D(22.5)                                                                                                                                                                                
Out[2]: Decimal('22.5')

In [3]: D(22.50)                                                                                                                                                                               
Out[3]: Decimal('22.5')

In [4]: D(22.52)  # these shouldn't exist                                                                                                                                                                               
Out[4]: Decimal('22.519999999999999573674358543939888477325439453125')

In [5]: D(str(22.52)) # cast to str first                                                                                                                                   
Out[5]: Decimal('22.52')

In [6]: D(22.52)/D(11.26) # I see the operations have already been handled                             
Out[6]: Decimal('2')
```

I understand that the `D` documentation clearly mentions about passing strings. But since `D` is accepting float, I think it should be handled here.