### PR TITLE
lexer: Fix subtle bug

### DIFF
--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -175,7 +175,7 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
     do {                                        \
         for (;;) {                              \
             int c = input(yyscanner);           \
-            if (c == EOF || c == -1) {          \
+            if (c == 0 || c == -1) {		\
                 break;                          \
             }                                   \
             if (c == '\n') {                    \


### PR DESCRIPTION
This typo would cause yy_skip_line() to loop forever if it does not encounter newline before the end of the input.