### PR TITLE
parser: Test indentation handling

### DIFF
--- a/beancount/parser/grammar_test.py
+++ b/beancount/parser/grammar_test.py
@@ -227,6 +227,28 @@ class TestParserEntryTypes(unittest.TestCase):
                           (D('23'), Decimal)],
                          txns[0].values)
 
+class TestWhitespace(unittest.TestCase):
+    """Tests for handling of whitespace and indent."""
+
+    @parser.parse_doc(expect_errors=True)
+    def test_indent_error_0(self, entries, errors, _):
+        """
+          2020-07-28 open Assets:Foo
+            2020-07-28 open Assets:Bar
+        """
+        self.assertEqual(len(errors), 1)
+        self.assertRegex(errors[0].message, "unexpected DATE")
+
+    @parser.parse_doc(expect_errors=True)
+    def test_indent_error_1(self, entries, errors, _):
+        """
+          2020-07-28 open Assets:Foo
+
+            2020-07-28 open Assets:Bar
+        """
+        self.assertEqual(len(errors), 1)
+        self.assertRegex(errors[0].message, "unexpected INDENT")
+
 
 class TestParserComplete(unittest.TestCase):
     """Tests of completion of balance."""


### PR DESCRIPTION
This test is currently failing. Namely, this syntax
```
2020-07-28 open Assets:Foo

    2020-07-28 open Assets:Bar
```
and variations where an entry is indented, is allowed.

This is PR is only to demonstrate the issue. I have a fix for it ready to be pushed, if it is decided that it needs to be fixed.