### PR TITLE
query: fix dtype for date()

### DIFF
--- a/beancount/query/query_env.py
+++ b/beancount/query/query_env.py
@@ -801,7 +801,7 @@ class Date(query_compile.EvalFunction):
     __intypes__ = [int, int, int]
 
     def __init__(self, operands):
-        super().__init__(operands, inventory.Inventory)
+        super().__init__(operands, datetime.date)
 
     def __call__(self, context):
         args = self.eval_args(context)
@@ -813,7 +813,7 @@ class ParseDate(query_compile.EvalFunction):
     __intypes__ = [str]
 
     def __init__(self, operands):
-        super().__init__(operands, inventory.Inventory)
+        super().__init__(operands, datetime.date)
 
     def __call__(self, context):
         args = self.eval_args(context)


### PR DESCRIPTION
fixes dtype for the `date()` function in BQL, seems like it was a copy-paste error