### PR TITLE
catch OSError on import of python-magic

### DIFF
--- a/beancount/scripts/deps.py
+++ b/beancount/scripts/deps.py
@@ -125,7 +125,7 @@ def check_python_magic():
             # 'filemagic' is installed; install python-magic.
             raise ImportError
         return ('python-magic', 'OK', True)
-    except ImportError:
+    except (ImportError, OSError):
         return ('python-magic', None, False)
 
 

--- a/beancount/utils/file_type.py
+++ b/beancount/utils/file_type.py
@@ -26,7 +26,7 @@ try:
         warnings.warn("You have installed 'filemagic' instead of 'python-magic'; "
                       "disabling.")
         magic = None # pylint: disable=invalid-name
-except ImportError:
+except (ImportError, OSError):
     magic = None
 
 


### PR DESCRIPTION
Close #523 

Some time ago, python-magic started throwing `OSError`s when trying to import the libmagic or something dynamic library in the Fava CI builds on Windows (there's also an open issue on python-magic tracker: https://github.com/ahupp/python-magic/issues/216). I worked around this by fixing the version of python-magic, but catching this error seems a cleaner work-around.