### PR TITLE
Amount constructor to support string for number arg

### DIFF
--- a/beancount/core/amount.py
+++ b/beancount/core/amount.py
@@ -43,7 +43,7 @@ class Amount(_Amount):
         """Constructor from a number and currency.
 
         Args:
-          number: A string or Decimal instance. Will get converted automatically.
+          number: A Decimal instance.
           currency: A string, the currency symbol to use.
         """
         assert isinstance(number, Amount.valid_types_number), repr(number)


### PR DESCRIPTION
As specified in docstring located here: beancount.core.amount.Amount.__new__

```
def __new__(cls, number, currency):
    """Constructor from a number and currency.

    Args:
      number: A string or Decimal instance. Will get converted automatically.
      currency: A string, the currency symbol to use.
    """
```
closes #532 