### PR TITLE
Improve the CSV exporter's chances of surviving an emoji-filled input file

### DIFF
--- a/beancount/ingest/cache.py
+++ b/beancount/ingest/cache.py
@@ -58,9 +58,9 @@ class _FileMemo:
         """Computes the MIME type of the file."""
         return self.convert(mimetype)
 
-    def head(self, num_bytes=8192):
+    def head(self, num_bytes=8192, encoding=None):
         """An alias for reading just the first bytes of a file."""
-        return self.convert(head(num_bytes))
+        return self.convert(head(num_bytes, encoding=encoding))
 
     def contents(self):
         """An alias for reading the entire contents of the file."""
@@ -76,7 +76,7 @@ def mimetype(filename):
     return file_type.guess_file_type(filename)
 
 
-def head(num_bytes=8192):
+def head(num_bytes=8192, encoding=None):
     """A converter that just reads the first bytes of a file.
 
     Args:
@@ -87,9 +87,8 @@ def head(num_bytes=8192):
     def head_reader(filename):
         with open(filename, 'rb') as file:
             rawdata = file.read(num_bytes)
-            detected = chardet.detect(rawdata)
-            encoding = detected['encoding']
-            return rawdata.decode(encoding)
+            file_encoding = encoding or chardet.detect(rawdata)['encoding']
+            return rawdata.decode(file_encoding)
     return head_reader
 
 

--- a/beancount/ingest/cache_test.py
+++ b/beancount/ingest/cache_test.py
@@ -47,6 +47,14 @@ class TestFileMemo(unittest.TestCase):
             mimetype = wrap.convert(cache.mimetype)
             self.assertRegex(mimetype, r'text/(x-(python|c\+\+)|plain)')
 
+    def test_cache_head_obeys_explict_utf8_encoding_avoids_chardet_exception(self):
+        emoji_header = 'asciiHeader1,🍏Header1,asciiHeader2'.encode('utf-8')
+        with mock.patch('builtins.open',
+                mock.mock_open(read_data=emoji_header)):
+            try:
+                function_return = cache._FileMemo('anyFile').head(encoding='utf-8')
+            except UnicodeDecodeError:
+                self.fail("Failed to decode emoji")
 
 if __name__ == '__main__':
     unittest.main()

--- a/beancount/ingest/importers/csv.py
+++ b/beancount/ingest/importers/csv.py
@@ -184,7 +184,11 @@ class Importer(identifier.IdentifyMixin, filing.FilingMixin):
     def file_date(self, file):
         "Get the maximum date from the file."
         iconfig, has_header = normalize_config(
-            self.config, file.head(), self.csv_dialect, self.skip_lines)
+            self.config,
+            file.head(encoding=self.encoding),
+            self.csv_dialect,
+            self.skip_lines,
+        )
         if Col.DATE in iconfig:
             reader = iter(csv.reader(open(file.name, encoding=self.encoding),
                                      dialect=self.csv_dialect))
@@ -210,7 +214,11 @@ class Importer(identifier.IdentifyMixin, filing.FilingMixin):
 
         # Normalize the configuration to fetch by index.
         iconfig, has_header = normalize_config(
-            self.config, file.head(), self.csv_dialect, self.skip_lines)
+            self.config,
+            file.head(encoding=self.encoding),
+            self.csv_dialect,
+            self.skip_lines,
+        )
 
         reader = iter(csv.reader(open(file.name, encoding=self.encoding),
                                  dialect=self.csv_dialect))

--- a/beancount/ingest/importers/csv_test.py
+++ b/beancount/ingest/importers/csv_test.py
@@ -325,6 +325,26 @@ class TestCSVImporter(cmptest.TestCase):
             Assets:Bank  -25.00 EUR
         """, entries)
 
+    @test_utils.docfile
+    def test_explict_encoding_utf8(self, filename):
+        """\
+          Posting,Description,Amount
+          2020/08/08,🍏,2
+        """
+        file = cache.get_file(filename)
+        importer = csv.Importer({Col.DATE: 'Posting',
+                                 Col.NARRATION: 'Description',
+                                 Col.AMOUNT: 'Amount'},
+                                'Assets:Bank', 'EUR', [],
+                                encoding='utf-8')
+        entries = importer.extract(file)
+        self.assertEqualEntries(r"""
+
+          2020-08-08 * "🍏"
+            Assets:Bank  2 EUR
+
+        """, entries)
+
 # TODO: Test things out with/without payee and with/without narration.
 # TODO: Test balance support.
 # TODO: Add balances every month or week.


### PR DESCRIPTION
The British bank "Monzo" embeds emoji in its CSV exports.

Files containing these emoji (or at the very least, some of them) cause the underlying `chardet` library to explode.

The only user-level control that exists is the Importer's `encoding` param, but this setting wasn't being respected during attempts to sniff the CSV to see if it contains a header row.

This PR adds a harmless-if-absent parameter to the cache's head() methods, by which the CSV importer can communicate the encoding the user has set explicitly.

[Apologies for the lack of additional tests. I'd naively assumed that, as a python project, this would be trivially testable with a `pip install -r req.txt` and a `make test`. The fact that it's not (see below) was a big enough bump in the road that I thought it best to just PR this change without tests. The cache tests pass, but they're the only ones I can run without getting into why I can't build the parser ...

Tests produced oodles of these:

```
ImportError while importing test module '/home/user/code/beancount/beancount/ingest/scripts_utils_test.py'.
Hint: make sure your test modules/packages have valid Python names.                                                                                                                                                         
Traceback:                                                                                                                                                                                                                  
beancount/ingest/scripts_utils_test.py:11: in <module>                                                                                                
    from beancount.ingest import scripts_utils                            
beancount/ingest/scripts_utils.py:19: in <module>                                                                                                                                                                           
    from beancount.parser import version                                                                                                            
beancount/parser/version.py:11: in <module>                                                                                                              
    from beancount.parser import _parser                                                                                                                                                                                   
E   ImportError: cannot import name '_parser' from 'beancount.parser' (/home/user/code/beancount/beancount/parser/__init__.py)
```

I understand they're because the parser isn't written in python, but I lack the immediate expertise to get it building successfully.]