### PR TITLE
fix beancount/scripts/setup_test.py::TestSetup::test_sdist_includes_c_files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(name="beancount",
       packages=find_packages(exclude=['experiments*']),
 
       package_data = {
-          'beancount': ['VERSION'],
+          'beancount': ['VERSION', '*.h'],
           'beancount.utils.file_type_testdata': ['*'],
       },
 


### PR DESCRIPTION
```
=================================== FAILURES ===================================
____________________ TestSetup.test_sdist_includes_c_files _____________________
self = <beancount.scripts.setup_test.TestSetup testMethod=test_sdist_includes_c_files>
    @unittest.skipIf(is_bazel_build(), "Cannot setup within Bazel.")
    def test_sdist_includes_c_files(self):
        # Clean previously built "build" output.
        rootdir = test_utils.find_repository_root(__file__)
        subprocess.check_call(
            [sys.executable, 'setup.py', 'sdist', '--dist-dir', self.installdir],
            cwd=rootdir, shell=False,
            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
        files = os.listdir(self.installdir)
        self.assertEqual(1, len(files))
        targz = path.join(self.installdir, files[0])
    
        # Find the set of expected header & C files.
        exp_filenames = set()
        for root, dirs, files in os.walk(path.join(rootdir, 'beancount')):
            for filename in files:
                if re.match(r'.*\.[hc]$', filename):
                    exp_filenames.add(path.join(root[len(rootdir)+1:], filename))
    
        # Find the set of packaged files in the source distribution.
        tar = tarfile.open(targz)
        tar_filenames = set(re.sub('^.*?{}'.format(os.sep), '', info.name)
                            for info in tar
                            if re.match(r'.*\.[hc]$', info.name))
    
        # Check that all the expected files are present.
>       self.assertLessEqual(exp_filenames, tar_filenames)
E       AssertionError: {'beancount/parser/lexer.c', 'beancount/parser/grammar.h', 'beancount/parser/parser.h', 'beancount/parser/macros.h', 'beancount/defs.h', 'beancount/parser/tokens_test.c', 'beancount/parser/parser.c', 'beancount/parser/grammar.c', 'beancount/parser/lexer.h', 'beancount/parser/tokens.h', 'beancount/ccore/account.h'} not less than or equal to {'beancount/parser/lexer.c', 'beancount/parser/grammar.h', 'beancount/parser/parser.h', 'beancount/parser/tokens_test.c', 'beancount/parser/parser.c', 'beancount/parser/grammar.c', 'beancount/parser/lexer.h', 'beancount/parser/tokens.h', 'beancount/parser/macros.h'}
beancount/scripts/setup_test.py:161: AssertionError
=========================== short test summary info ============================
FAILED beancount/scripts/setup_test.py::TestSetup::test_sdist_includes_c_files
```

```console
(.venv) ~/proj/beancount (fix-test_sdist_includes_c_files) # python setup.py sdist|grep defs.h
C:\Users\Trim21\proj\beancount\.venv\lib\site-packages\setuptools\dist.py:454: UserWarning: Normalizing '2.3.2-dev' to '2.3.2.dev0'
  warnings.warn(tmpl.format(**locals()))
copying beancount\defs.h -> beancount-2.3.2.dev0\beancount
```