### PR TITLE
add a windows deps to enable python-magic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,62 +76,6 @@ for get_changeset in get_git_changeset, get_hg_changeset:
 else:
     vc_changeset, vc_timestamp = '', 0
 
-
-install_requires = [
-    # Testing support now uses the pytest module.
-    'pytest',
-
-    # This is required to parse dates from command-line options in a
-    # loose, accepting format. Note that we use dateutil for timezone
-    # database definitions as well, although it is inferior to pytz, but
-    # because it can use the OS timezone database in the Windows
-    # registry. See this article for context:
-    # https://www.assert.cc/2014/05/25/which-python-time-zone-library.html
-    # However, for creating offset timezones, we use the datetime.timezone
-    # helper class because it is built-in.
-    # Where this matters is for price source fetchers.
-    # (Note: If pytz supported the Windows registry timezone information,
-    # I would switch to that.)
-    'python-dateutil',
-
-    # The SQL parser uses PLY in order to parse the input syntax.
-    'ply',
-
-    # The bean-web web application is built on top of this web
-    # framework.
-    'bottle',
-
-    # This XML parsing library is mainly required to web scrape the
-    # bean-web pages for testing.
-    'lxml',
-
-    # This library is needed to parse XML files (for the OFX examples).
-    'beautifulsoup4',
-
-    # This library is needed to make requests for price sources.
-    'requests',
-
-    # This library is needed to identify the character set of a file for
-    # import, in order to read its contents and match expressions
-    # against it.
-    'chardet',
-
-    # This library is used to download and convert the documentation
-    # programmatically and to upload lists of holdings to a Google
-    # Spreadsheet for live intra-day monitoring.
-    'google-api-python-client',
-]
-
-if sys.platform != 'win32':
-    install_requires += [
-        # This library is needed to identify the type of a file for
-        # import. It uses ctypes to wrap the libmagic library which is
-        # not generally available on Windows nor is easily installed,
-        # thus the conditional dependency.
-        'python-magic',
-    ]
-
-
 # Create a setup.
 # Please read: http://furius.ca/beancount/doc/install about version numbers.
 setup(name="beancount",
@@ -189,7 +133,50 @@ setup(name="beancount",
           ('elisp', ['editors/emacs/beancount.el']),
       ],
 
-      install_requires = install_requires,
+      install_requires = [
+          # Testing support now uses the pytest module.
+          'pytest',
+
+          # This is required to parse dates from command-line options in a
+          # loose, accepting format. Note that we use dateutil for timezone
+          # database definitions as well, although it is inferior to pytz, but
+          # because it can use the OS timezone database in the Windows
+          # registry. See this article for context:
+          # https://www.assert.cc/2014/05/25/which-python-time-zone-library.html
+          # However, for creating offset timezones, we use the datetime.timezone
+          # helper class because it is built-in.
+          # Where this matters is for price source fetchers.
+          # (Note: If pytz supported the Windows registry timezone information,
+          # I would switch to that.)
+          'python-dateutil',
+
+          # The SQL parser uses PLY in order to parse the input syntax.
+          'ply',
+
+          # This library is needed to parse XML files (for the OFX examples).
+          'beautifulsoup4',
+
+          # This library is needed to identify the character set of a file for
+          # import, in order to read its contents and match expressions
+          # against it.
+          'chardet',
+
+          # This library is used to download and convert the documentation
+          # programmatically and to upload lists of holdings to a Google
+          # Spreadsheet for live intra-day monitoring.
+          'google-api-python-client',
+
+          # This library is needed to identify the type of a file for
+          # import. It uses ctypes to wrap the libmagic library which is
+          # not generally available on Windows nor is easily installed,
+          # thus the conditional dependency.
+          'python-magic',
+
+          # python-magic need DLLs for libmagic
+          # This pypi package contains the DLLs.
+          # Otherwise it will cause Segmentation fault on windows
+          "python-magic-bin; sys_platform == 'win32'"
+      ],
 
       entry_points = {
           'console_scripts': [


### PR DESCRIPTION
This pr enable `python-magic` as wheel is released on pypi, and user don't need to compile it from source.
And add `python-magic-bin` package as `python-magic` suggested 

> Windows
>You'll need DLLs for libmagic. @julian-r maintains a pypi package with the DLLs, you can fetch it with:
>
>$ pip install python-magic-bin