### PR TITLE
parser: More MSVC compiler fixes

### DIFF
--- a/beancount/parser/macros.h
+++ b/beancount/parser/macros.h
@@ -7,16 +7,30 @@
 #define XSTRINGIFY(x) "" #x
 
 
+/**
+ * Force the preprocessor to expand the argument one more time.
+ *
+ * MSVC expands __VA_ARGS__ in a variadic macro to a single token
+ * instead of a list of arguments resulting in the wrong number of
+ * arguments passed to the function the macro expands to. Adding a
+ * second macro expansion forces the preprocessor to scan again the
+ * input and correctly tokenize the arguments. This is required to
+ * make the code below and the code in token.h work as intended when
+ * compiled with MSVC.
+ */
+#define EXPAND(x) x
+
+
 #define _CC_FUNC_01(FN, X, ...) FN(X)
-#define _CC_FUNC_02(FN, X, ...) FN(X); _CC_FUNC_01(FN, __VA_ARGS__)
-#define _CC_FUNC_03(FN, X, ...) FN(X); _CC_FUNC_02(FN, __VA_ARGS__)
-#define _CC_FUNC_04(FN, X, ...) FN(X); _CC_FUNC_03(FN, __VA_ARGS__)
-#define _CC_FUNC_05(FN, X, ...) FN(X); _CC_FUNC_04(FN, __VA_ARGS__)
-#define _CC_FUNC_06(FN, X, ...) FN(X); _CC_FUNC_05(FN, __VA_ARGS__)
-#define _CC_FUNC_07(FN, X, ...) FN(X); _CC_FUNC_06(FN, __VA_ARGS__)
-#define _CC_FUNC_08(FN, X, ...) FN(X); _CC_FUNC_07(FN, __VA_ARGS__)
-#define _CC_FUNC_09(FN, X, ...) FN(X); _CC_FUNC_08(FN, __VA_ARGS__)
-#define _CC_FUNC_10(FN, X, ...) FN(X); _CC_FUNC_09(FN, __VA_ARGS__)
+#define _CC_FUNC_02(FN, X, ...) FN(X); EXPAND(_CC_FUNC_01(FN, __VA_ARGS__))
+#define _CC_FUNC_03(FN, X, ...) FN(X); EXPAND(_CC_FUNC_02(FN, __VA_ARGS__))
+#define _CC_FUNC_04(FN, X, ...) FN(X); EXPAND(_CC_FUNC_03(FN, __VA_ARGS__))
+#define _CC_FUNC_05(FN, X, ...) FN(X); EXPAND(_CC_FUNC_04(FN, __VA_ARGS__))
+#define _CC_FUNC_06(FN, X, ...) FN(X); EXPAND(_CC_FUNC_05(FN, __VA_ARGS__))
+#define _CC_FUNC_07(FN, X, ...) FN(X); EXPAND(_CC_FUNC_06(FN, __VA_ARGS__))
+#define _CC_FUNC_08(FN, X, ...) FN(X); EXPAND(_CC_FUNC_07(FN, __VA_ARGS__))
+#define _CC_FUNC_09(FN, X, ...) FN(X); EXPAND(_CC_FUNC_08(FN, __VA_ARGS__))
+#define _CC_FUNC_10(FN, X, ...) FN(X); EXPAND(_CC_FUNC_09(FN, __VA_ARGS__))
 
 #define _CC_FUNC_SEQ(_01, _02, _03, _04, _05, _06, _07, _08, _09, _10, NAME, ...) NAME
 
@@ -24,17 +38,17 @@
  * A macro that applies the function @FN to all successive arguments.
  */
 #define _CC_FUNC(FN, ...)                               \
-        _CC_FUNC_SEQ(__VA_ARGS__,                       \
-                     _CC_FUNC_10,                       \
-                     _CC_FUNC_09,                       \
-                     _CC_FUNC_08,                       \
-                     _CC_FUNC_07,                       \
-                     _CC_FUNC_06,                       \
-                     _CC_FUNC_05,                       \
-                     _CC_FUNC_04,                       \
-                     _CC_FUNC_03,                       \
-                     _CC_FUNC_02,                       \
-                     _CC_FUNC_01) (FN, __VA_ARGS__)
+    EXPAND(_CC_FUNC_SEQ(__VA_ARGS__,                    \
+                        _CC_FUNC_10,                    \
+                        _CC_FUNC_09,                    \
+                        _CC_FUNC_08,                    \
+                        _CC_FUNC_07,                    \
+                        _CC_FUNC_06,                    \
+                        _CC_FUNC_05,                    \
+                        _CC_FUNC_04,                    \
+                        _CC_FUNC_03,                    \
+                        _CC_FUNC_02,                    \
+                        _CC_FUNC_01) (FN, __VA_ARGS__))
 
 /* An example is the best way to exaplain how the above preprocessor
  * magic works. Assuume a macro call like the following:

--- a/beancount/parser/tokens.h
+++ b/beancount/parser/tokens.h
@@ -4,19 +4,7 @@
 #include <stdbool.h>
 #include <datetime.h>
 
-
-/**
- * Force the preprocessor to expand the argument one more time.
- *
- * MSVC expands __VA_ARGS__ in a variadic macro to a single token
- * instead of a list of arguments resulting in the wrong number of
- * arguments passed to the function the macro expands to. Adding a
- * second macro expansion forces the preprocessor to scan again the
- * input and correctly tokenize the arguments. This is required to
- * make the defition of token() below work as intended when compiled
- * with MSVC.
- */
-#define EXPAND(x) x
+#include "macros.h"
 
 
 /**


### PR DESCRIPTION
More work-arounds to the broken MSVC handling of __VA_ARGS__. The
source was compiling but the generated code was most probably not
doing the right thing.