### PR TITLE
setup, ci: Explicitly drop support for Python 3.5

### DIFF
--- a/.github/workflows/pypi-wheel.yaml
+++ b/.github/workflows/pypi-wheel.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
+        python: ['3.6', '3.7', '3.8']
         os: [windows, macos]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
+        python: ['3.6', '3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,7 @@ setup(name="beancount",
           ]
       },
 
-      python_requires='>=3.5',
+      python_requires='>=3.6',
 )
 
 


### PR DESCRIPTION
The codebase uses APIs and features introduced only with Python 3.6.
Python 3.5 is reaching its end of life at the end of September 2020,
thus it is unlikely to be in whidespread use.

Closes #556.