### PR TITLE
parser: Move functions defined in tokens.h to own compilation unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ SOURCES =					\
 build: $(SOURCES)
 	$(PYTHON) setup.py build_ext -i
 
-$(CROOT)/tokens_test: $(CROOT)/tokens_test.c
+$(CROOT)/tokens_test: $(CROOT)/tokens_test.c $(CROOT)/tokens.c $(CROOT)/datetime.c $(CROOT)/decimal.c
 
 .PHONY: ctest
 ctest: $(CROOT)/tokens_test

--- a/beancount/parser/BUILD
+++ b/beancount/parser/BUILD
@@ -241,6 +241,27 @@ py_test(
 )
 
 cc_library(
+    name = "datetime_c",
+    hdrs = [
+        "datetime.h",
+    ],
+    srcs = ["datetime.c"],
+    deps = [
+        "@local_config_python//:python_headers",
+    ],
+)
+
+cc_library(
+    name = "datetime_hdr",
+    hdrs = [
+        "datetime.h",
+    ],
+    deps = [
+        "@local_config_python//:python_headers",
+    ],
+)
+
+cc_library(
     name = "decimal_c",
     hdrs = [
         "decimal.h",
@@ -271,6 +292,7 @@ cc_library(
         ":lexer_hdr",
         ":parser_hdr",
         ":grammar_hdr",
+        ":datetime_hdr",        
         ":decimal_hdr",
         "@local_config_python//:python_headers",
     ],
@@ -310,11 +332,26 @@ py_test(
     ],
 )
 
+cc_library(
+    name = "tokens_c",
+    hdrs = [
+        "tokens.h",
+    ],
+    srcs = ["tokens.c"],
+    deps = [
+        ":datetime_c",    
+        ":decimal_c",
+        ":grammar_hdr",
+        "@local_config_python//:python_headers",
+    ],
+)
+
 cc_test(
     name = "tokens_test",
     srcs = ["tokens_test.c"],
     deps = [
         ":lexer_hdr",
+        ":tokens_c",
         "@local_config_python//:python_headers",
     ],
 )

--- a/beancount/parser/datetime.c
+++ b/beancount/parser/datetime.c
@@ -1,0 +1,4 @@
+#include <Python.h>
+#include <datetime.h>
+
+PyDateTime_CAPI* datetime_api;

--- a/beancount/parser/datetime.h
+++ b/beancount/parser/datetime.h
@@ -1,0 +1,18 @@
+#ifndef BEANCOUNT_DATETIME_H
+#define BEANCOUNT_DATETIME_H
+
+#include <Python.h>
+#include <datetime.h>
+
+/** 
+ * PyDateTimeAPI is a static variable used in the Python C-API to the
+ * datetime module. This forces PyDateTime_IMPORT() to be called in
+ * every compilation module using the C datetime API.  Redefine
+ * PyDateTimeAPI to point to a global variable, which needs to be
+ * initialized only once.
+ */
+#define PyDateTimeAPI datetime_api
+
+extern PyDateTime_CAPI* datetime_api;
+
+#endif /* BEANCOUNT_DECIMAL_H */

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -3031,9 +3031,6 @@ yyscan_t yylex_new(void)
         return NULL;
     }
 
-    PyDateTime_IMPORT;
-    PyDecimal_IMPORT;
-
     return scanner;
 }
 

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -353,9 +353,6 @@ yyscan_t yylex_new(void)
         return NULL;
     }
 
-    PyDateTime_IMPORT;
-    PyDecimal_IMPORT;
-
     return scanner;
 }
 

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -4,6 +4,8 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#include "datetime.h"
+#include "decimal.h"
 #include "macros.h"
 #include "parser.h"
 #include "grammar.h"
@@ -313,6 +315,9 @@ PyMODINIT_FUNC PyInit__parser(void)
     if (!module) {
         goto error;
     }
+
+    PyDateTime_IMPORT;
+    PyDecimal_IMPORT;
 
 #define SETATTR(module, name, value)                       \
     if (!value) {                                          \

--- a/beancount/parser/tokens.c
+++ b/beancount/parser/tokens.c
@@ -1,0 +1,190 @@
+#include "tokens.h"
+
+#define DIGITS "0123456789"
+#define LONG_STRING_LINES_MAX 64
+
+ssize_t validate_decimal_number(const char* str, char* buffer, size_t len)
+{
+    size_t n, digits = 0;
+    bool comma = false;
+    bool dot = false;
+    char* dst;
+
+    if (len == 0) {
+        return -ENOMEM;
+    }
+
+    for (n = 0, dst = buffer; str[n] != '\0'; n++) {
+        if (str[n] == ',') {
+            if (n == 0 || (n > 2 && digits != 3) || dot)
+                return -EINVAL;
+            comma = true;
+            digits = 0;
+            continue;
+        }
+
+        if (isdigit(str[n])) {
+            *dst++ = str[n];
+            digits++;
+        }
+
+        if (str[n] == '.') {
+            if (n == 0 || (comma && digits != 3))
+                return -EINVAL;
+            *dst++ = str[n];
+            dot = true;
+            digits = 0;
+        }
+
+        if (dst == buffer + len) {
+            return -ENOMEM;
+        }
+    }
+
+    if (comma && !dot && digits != 3) {
+        return -EINVAL;
+    }
+
+    *dst = '\0';
+
+    return dst - buffer;
+}
+
+PyObject* pydecimal_from_cstring(const char* str)
+{
+    char buffer[256];
+    Py_ssize_t len;
+
+    len = validate_decimal_number(str, buffer, sizeof(buffer));
+    if (len < 0) {
+        PyErr_Format(PyExc_ValueError, "Invalid number format: '%s'", str);
+        return NULL;
+    }
+
+    return PyDec_FromCString(buffer, len);
+}
+
+ssize_t cunescape(const char* string, size_t len, int strict, char** ret, int* lines)
+{
+    const char* src;
+    char* buffer;
+    char* dst;
+    int lin = 1;
+
+    /* The unescaped string can be at most as long as the escaped
+     * string. Make sure we hace space for the string terminator: it
+     * is safer to handle NULL terminated strings. */
+    buffer = malloc(len + 1);
+    if (!buffer) {
+        return -ENOMEM;
+    }
+
+    for (src = string, dst = buffer; src < string + len; src++) {
+        if (*src == '\n')
+            lin++;
+
+        if (*src != '\\') {
+            *dst = *src;
+            dst++;
+            continue;
+        }
+
+        if (string + len - src < 2) {
+            free(buffer);
+            return -EINVAL;
+        }
+
+        src++;
+
+        switch (*src) {
+        case '"':
+            *dst++ = '"';
+            break;
+        case 'n':
+            *dst++ = '\n';
+            break;
+        case 't':
+            *dst++ = '\t';
+            break;
+        case 'r':
+            *dst++ = '\r';
+            break;
+        case 'f':
+            *dst++ = '\f';
+            break;
+        case 'b':
+            *dst++ = '\b';
+            break;
+        default:
+            if (strict) {
+                free(buffer);
+                return -EINVAL;
+            }
+            *dst++ = *src;
+        }
+    }
+
+    /* Add NULL terminator to the unescaped string. */
+    *dst = '\0';
+
+    *ret = buffer;
+    *lines = lin;
+
+    return dst - buffer;
+}
+
+PyObject* pyunicode_from_cquotedstring(char* string, size_t len, const char* encoding)
+{
+    char* unescaped = NULL;
+    ssize_t r;
+    int lines;
+
+    r = cunescape(string, len, false, &unescaped, &lines);
+    if (r < 0) {
+        PyErr_Format(PyExc_ValueError, "Invalid string");
+        free(unescaped);
+        return NULL;
+    }
+
+    if (lines > LONG_STRING_LINES_MAX) {
+        PyErr_Format(PyExc_ValueError, "String too long (%d lines)", lines);
+        free(unescaped);
+        return NULL;
+    }
+
+    PyObject* rv = PyUnicode_Decode(unescaped, r, encoding, "ignore");
+    free(unescaped);
+
+    return rv;
+}
+
+int strtonl(const char* string, size_t len)
+{
+    int result = 0;
+
+    for (size_t i = 0; i < len; ++i) {
+        result *= 10;
+        result += string[i] - '0';
+    }
+
+    return result;
+}
+
+PyObject* pydate_from_cstring(const char* string)
+{
+    int year, month, day;
+    size_t n;
+
+    n = strspn(string, DIGITS);
+    year = strtonl(string, n);
+    string += n + 1;
+
+    n = strspn(string, DIGITS);
+    month = strtonl(string, n);
+    string += n + 1;
+
+    n = strspn(string, DIGITS);
+    day = strtonl(string, n);
+
+    return PyDate_FromDate(year, month, day);
+}

--- a/beancount/parser/tokens.h
+++ b/beancount/parser/tokens.h
@@ -2,10 +2,10 @@
 #define BEANCOUNT_TOKENS_H
 
 #include <stdbool.h>
-#include <datetime.h>
 
-#include "macros.h"
+#include "datetime.h"
 #include "decimal.h"
+#include "macros.h"
 
 
 /**
@@ -35,9 +35,6 @@
 #define build_ACCOUNT(_str) PyUnicode_InternFromString(_str)
 #define build_EXCEPTION(_loc, _builder) ( build_lexer_error_from_exception(_loc, _builder), YYerror )
 
-#define DIGITS "0123456789"
-#define LONG_STRING_LINES_MAX 64
-
 
 /**
  * Validate number string representation and remove commas.
@@ -50,67 +47,15 @@
  * does not fit fit in the provided buffer, the length of the cleaned
  * up string otherwise.
  */
-static ssize_t validate_decimal_number(const char* str, char* buffer, size_t len)
-{
-    size_t n, digits = 0;
-    bool comma = false;
-    bool dot = false;
-    char* dst;
-
-    if (len == 0) {
-        return -ENOMEM;
-    }
-
-    for (n = 0, dst = buffer; str[n] != '\0'; n++) {
-        if (str[n] == ',') {
-            if (n == 0 || (n > 2 && digits != 3) || dot)
-                return -EINVAL;
-            comma = true;
-            digits = 0;
-            continue;
-        }
-
-        if (isdigit(str[n])) {
-            *dst++ = str[n];
-            digits++;
-        }
-
-        if (str[n] == '.') {
-            if (n == 0 || (comma && digits != 3))
-                return -EINVAL;
-            *dst++ = str[n];
-            dot = true;
-            digits = 0;
-        }
-
-        if (dst == buffer + len) {
-            return -ENOMEM;
-        }
-    }
-
-    if (comma && !dot && digits != 3) {
-        return -EINVAL;
-    }
-
-    *dst = '\0';
-
-    return dst - buffer;
-}
+ssize_t validate_decimal_number(const char* str, char* buffer, size_t len);
 
 
-static PyObject* pydecimal_from_cstring(const char* str)
-{
-    char buffer[256];
-    Py_ssize_t len;
-
-    len = validate_decimal_number(str, buffer, sizeof(buffer));
-    if (len < 0) {
-        PyErr_Format(PyExc_ValueError, "Invalid number format: '%s'", str);
-        return NULL;
-    }
-
-    return PyDec_FromCString(buffer, len);
-}
+/**
+ * Convert an ASCII string to a PyDecimal object.
+ *
+ * The string may contain commas as thouands separator.
+ */
+PyObject* pydecimal_from_cstring(const char* str);
 
 
 /**
@@ -125,100 +70,17 @@ static PyObject* pydecimal_from_cstring(const char* str)
  * string contains is not valid, -ENOMEM if the output string cannot
  * be allocated.
  */
-static ssize_t cunescape(const char* string, size_t len, int strict, char** ret, int* lines)
-{
-    const char* src;
-    char* buffer;
-    char* dst;
-    int lin = 1;
-
-    /* The unescaped string can be at most as long as the escaped
-     * string. Make sure we hace space for the string terminator: it
-     * is safer to handle NULL terminated strings. */
-    buffer = malloc(len + 1);
-    if (!buffer) {
-        return -ENOMEM;
-    }
-
-    for (src = string, dst = buffer; src < string + len; src++) {
-        if (*src == '\n')
-            lin++;
-
-        if (*src != '\\') {
-            *dst = *src;
-            dst++;
-            continue;
-        }
-
-        if (string + len - src < 2) {
-            free(buffer);
-            return -EINVAL;
-        }
-
-        src++;
-
-        switch (*src) {
-        case '"':
-            *dst++ = '"';
-            break;
-        case 'n':
-            *dst++ = '\n';
-            break;
-        case 't':
-            *dst++ = '\t';
-            break;
-        case 'r':
-            *dst++ = '\r';
-            break;
-        case 'f':
-            *dst++ = '\f';
-            break;
-        case 'b':
-            *dst++ = '\b';
-            break;
-        default:
-            if (strict) {
-                free(buffer);
-                return -EINVAL;
-            }
-            *dst++ = *src;
-        }
-    }
-
-    /* Add NULL terminator to the unescaped string. */
-    *dst = '\0';
-
-    *ret = buffer;
-    *lines = lin;
-
-    return dst - buffer;
-}
+ssize_t cunescape(const char* string, size_t len, int strict, char** ret, int* lines);
 
 
-static PyObject* pyunicode_from_cquotedstring(char* string, size_t len, const char* encoding)
-{
-    char* unescaped = NULL;
-    ssize_t r;
-    int lines;
-
-    r = cunescape(string, len, false, &unescaped, &lines);
-    if (r < 0) {
-        PyErr_Format(PyExc_ValueError, "Invalid string");
-        free(unescaped);
-        return NULL;
-    }
-
-    if (lines > LONG_STRING_LINES_MAX) {
-        PyErr_Format(PyExc_ValueError, "String too long (%d lines)", lines);
-        free(unescaped);
-        return NULL;
-    }
-
-    PyObject* rv = PyUnicode_Decode(unescaped, r, encoding, "ignore");
-    free(unescaped);
-
-    return rv;
-}
+/**
+ * Convert a string to a PyUnicode object using the specified @encoding.
+ *
+ * C-style escape codes contained in the string are unescaped. An
+ * exception is raised if the string contains invalid escape sequences
+ * or if the string contains more than 64 lines.
+ */
+PyObject* pyunicode_from_cquotedstring(char* string, size_t len, const char* encoding);
 
 
 /**
@@ -228,17 +90,7 @@ static PyObject* pyunicode_from_cquotedstring(char* string, size_t len, const ch
  * assumed to be a valid representation of an integer number. No input
  * validation or error checking is performed.
  */
-static int strtonl(const char* string, size_t len)
-{
-    int result = 0;
-
-    for (size_t i = 0; i < len; ++i) {
-        result *= 10;
-        result += string[i] - '0';
-    }
-
-    return result;
-}
+int strtonl(const char* string, size_t len);
 
 
 /**
@@ -248,24 +100,7 @@ static int strtonl(const char* string, size_t len)
  * format YYYY-MM-DD allowing for any character to divide the three
  * digits groups.
  */
-static PyObject* pydate_from_cstring(const char* string)
-{
-    int year, month, day;
-    size_t n;
-
-    n = strspn(string, DIGITS);
-    year = strtonl(string, n);
-    string += n + 1;
-
-    n = strspn(string, DIGITS);
-    month = strtonl(string, n);
-    string += n + 1;
-
-    n = strspn(string, DIGITS);
-    day = strtonl(string, n);
-
-    return PyDate_FromDate(year, month, day);
-}
+PyObject* pydate_from_cstring(const char* string);
 
 
 #endif /* BEANCOUNT_TOKENS_H */

--- a/beancount/parser/tokens_test.c
+++ b/beancount/parser/tokens_test.c
@@ -3,8 +3,6 @@
 #include <string.h>
 #include <assert.h>
 
-#include <Python.h>
-
 #include "tokens.h"
 
 

--- a/setup.py
+++ b/setup.py
@@ -171,10 +171,12 @@ setup(name="beancount",
       ext_modules = [
           Extension("beancount.parser._parser",
                     sources=[
+                        "beancount/parser/datetime.c",
                         "beancount/parser/decimal.c",
                         "beancount/parser/lexer.c",
                         "beancount/parser/grammar.c",
                         "beancount/parser/parser.c",
+                        "beancount/parser/tokens.c",
                     ],
                     define_macros=[
                         ('BEANCOUNT_VERSION', version),


### PR DESCRIPTION
This requires hacking around the limitations of the Python C-API to
the datetime module to avoid having to initialize it in every
compilation unit using it.