### PR TITLE
ci: Add Bazel build to the Github Actions CI jobs

### DIFF
--- a/.github/workflows/bazel-ci.yaml
+++ b/.github/workflows/bazel-ci.yaml
@@ -1,0 +1,21 @@
+name: bazel-ci
+
+on:
+  [push, pull_request]
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: bazel install
+        run: |
+          wget https://github.com/bazelbuild/bazel/releases/download/3.2.0/bazel_3.2.0-linux-x86_64.deb
+          sha256sum -c tools/bazel_3.2.0-linux-x86_64.deb.sha256
+          sudo dpkg -i bazel_3.2.0-linux-x86_64.deb
+      - run: pip install numpy
+      - name: bazel build
+        run: /usr/bin/bazel --bazelrc=.bazelrc.travis test //...


### PR DESCRIPTION
The build fails. Someone more familiar with Bazel should look into this.