### PR TITLE
Use the same python binary to run testimport.py

### DIFF
--- a/beancount/ingest/identify_test.py
+++ b/beancount/ingest/identify_test.py
@@ -96,7 +96,7 @@ class TestScriptIdentify(scripts_utils.TestScriptsBase):
             env = os.environ.copy()
             env['PYTHONPATH'] = ':'.join(sys.path)
             output = subprocess.check_output(
-                [path.join(self.tempdir, 'testimport.py'),
+                [sys.executable, path.join(self.tempdir, 'testimport.py'),
                  '--downloads', path.join(self.tempdir, 'Downloads'),
                  'identify'], shell=False, env=env)
         self.assertTrue(re.match(regexp, output.decode().strip()))


### PR DESCRIPTION
Rather than relying on the shebang of `testimport.py` (which will load the first `python3` on `PATH`), use the same binary that the test suite is running under.

On Debian, multiple versions of cPython can be installed concurrently and this lets us test under a non-default version, e.g.:

```
$ python3.9 -m pytest beancount/
```

Debian Bug: https://bugs.debian.org/972328