### PR TITLE
Initialize decimal_type to NULL.

### DIFF
--- a/beancount/parser/decimal.c
+++ b/beancount/parser/decimal.c
@@ -6,4 +6,4 @@
  * objects. This avoid having to import the Python module and look up
  * the type object at each object instantiation.
  */
-const PyObject* decimal_type;
+const PyObject* decimal_type = NULL;


### PR DESCRIPTION
Partially fixes #573.

On Mac OS, without this initialization, using decimal_type produces the error "Symbol not found: _decimal_type". Full error:

Traceback (most recent call last):
  File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/bin/bean_check.py", line 5, in <module>
    from beancount.scripts.check import main
  File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/scripts/check.py", line 11, in <module>
    from beancount import loader
  File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/loader.py", line 25, in <module>
    from beancount.parser import parser
  File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/parser.py", line 118, in <module>
    from beancount.parser import _parser
ImportError: dlopen(/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/_parser.so, 2): Symbol not found: _decimal_type
  Referenced from: /private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/_parser.so
  Expected in: flat namespace
 in /private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/_parser.so