### PR TITLE
Condition py_extension linker flag --export-dynamic-symbol on compiling for Linux.

### DIFF
--- a/third_party/python/py_extension.bzl
+++ b/third_party/python/py_extension.bzl
@@ -37,12 +37,22 @@ def py_extension(
         local_defines = local_defines,
     )
 
+    native.config_setting(
+        name = name+"_on_linux",
+        constraint_values = [
+            "@platforms//os:linux",
+        ],
+    )
+
     native.cc_binary(
         name = cc_binary_name,
         linkshared = True,
         linkstatic = True,
-        # Ensure that the init function is exported. Required for gold.
-        linkopts = ['-Wl,--export-dynamic-symbol=PyInit_{}'.format(name)],
+        linkopts = select({
+            # Ensure that the init function is exported. Required for gold.
+            name+"_on_linux": ['-Wl,--export-dynamic-symbol=PyInit_{}'.format(name)],
+            "//conditions:default": [],
+		}),
         visibility = ["//visibility:private"],
         deps = [cc_library_name],
     )


### PR DESCRIPTION
On Mac OS, for example, these flags are not defined in clang, and produce the error:

ERROR: beancount/parser/BUILD:359:13: Linking of rule '//beancount/parser:_parser.so' failed (Exit 1) cc_wrapper.sh failed: error executing command external/local_config_cc/cc_wrapper.sh -lc++ -fobjc-link-runtime -shared -o bazel-out/darwin-opt/bin/beancount/parser/_parser.so ... (remaining 11 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
ld: unknown option: --export-dynamic-symbol=PyInit__parser
clang: error: linker command failed with exit code 1 (use -v to see invocation)

Fixes #573.