### PR TITLE
parser: Print balance tolerances

### DIFF
--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -267,9 +267,16 @@ class EntryPrinter:
 
     def Balance(self, entry, oss):
         comment = '   ; Diff: {}'.format(entry.diff_amount) if entry.diff_amount else ''
-        oss.write(('{e.date} balance {e.account:47} {amount}'
+        amount = entry.amount.to_string(self.dformat)[:-(len(entry.amount.currency) + 1)]
+        tolerance = ''
+        if entry.tolerance:
+            tolerance_fmt = self.dformat.format(entry.tolerance, entry.amount.currency)
+            tolerance = '~{tolerance} '.format(tolerance=tolerance_fmt)
+        oss.write(('{e.date} balance {e.account:47} {amount} {tolerance}{currency}'
                    '{comment}\n').format(e=entry,
-                                         amount=entry.amount.to_string(self.dformat),
+                                         amount=amount,
+                                         tolerance=tolerance,
+                                         currency=entry.amount.currency,
                                          comment=comment))
         self.write_metadata(entry.meta, oss)
 

--- a/beancount/parser/printer_test.py
+++ b/beancount/parser/printer_test.py
@@ -134,6 +134,20 @@ class TestEntryPrinter(cmptest.TestCase):
         self.assertRoundTrip(entries, errors)
 
     @loader.load_doc()
+    def test_BalanceTolerance(self, entries, errors, __):
+        """
+        2014-06-01 open Assets:Account1
+        2014-06-01 open Assets:Cash
+
+        2014-06-02 * "Deposit"
+          Assets:Account1       199.95 USD
+          Assets:Cash          -199.95 USD
+
+        2014-06-04 balance Assets:Account1     200.00 ~0.05 USD
+        """
+        self.assertRoundTrip(entries, errors)
+
+    @loader.load_doc()
     def test_Note(self, entries, errors, __):
         """
         2014-06-01 open Assets:Account1


### PR DESCRIPTION
I noticed that balance tolerances were not printed with `bean-query example.beancount print`

I'm not sure my fix is the cleanest, but it wasn't immediately obvious to me how to better break up the traditional way the amounts are printed (which have the number and currency paired) in order to stick the tolerance between them. Suggestions welcome!