### PR TITLE
Combine parser C sources and headers into a single Bazel rule.

### DIFF
--- a/beancount/parser/BUILD
+++ b/beancount/parser/BUILD
@@ -139,27 +139,6 @@ py_test(
     ],
 )
 
-cc_library(
-    name = "grammar_c",
-    srcs = ["grammar.c"],
-    deps = [
-        ":parser_hdr",
-        ":lexer_hdr",
-        "@local_config_python//:python_headers",
-    ],
-)
-
-cc_library(
-    name = "grammar_hdr",
-    hdrs = [
-        "grammar.h",
-        "macros.h",
-    ],
-    deps = [
-        "@local_config_python//:python_headers",
-    ],
-)
-
 py_library(
     name = "grammar",
     srcs = ["grammar.py"],
@@ -240,56 +219,6 @@ py_test(
     ],
 )
 
-cc_library(
-    name = "decimal_c",
-    hdrs = [
-        "decimal.h",
-    ],
-    srcs = ["decimal.c"],
-    deps = [
-        "@local_config_python//:python_headers",
-    ],
-)
-
-cc_library(
-    name = "decimal_hdr",
-    hdrs = [
-        "decimal.h",
-    ],
-    deps = [
-        "@local_config_python//:python_headers",
-    ],
-)
-
-cc_library(
-    name = "lexer_c",
-    hdrs = [
-        "lexer.h",
-    ],
-    srcs = ["lexer.c"],
-    deps = [
-        ":lexer_hdr",
-        ":parser_hdr",
-        ":grammar_hdr",
-        ":decimal_hdr",
-        "@local_config_python//:python_headers",
-    ],
-)
-
-cc_library(
-    name = "lexer_hdr",
-    hdrs = [
-        "lexer.h",
-        "tokens.h",
-        "decimal.h",
-    ],
-    deps = [
-        ":parser_hdr",
-        ":grammar_hdr",
-        "@local_config_python//:python_headers",
-    ],
-)
-
 py_library(
     name = "lexer",
     srcs = ["lexer.py"],
@@ -310,26 +239,11 @@ py_test(
     ],
 )
 
-cc_library(
-    name = "tokens_c",
-    hdrs = [
-        "tokens.h",
-    ],
-    srcs = ["tokens.c"],
-    deps = [
-        ":parser_hdr",
-        ":decimal_c",
-        ":grammar_hdr",
-        "@local_config_python//:python_headers",
-    ],
-)
-
 # cc_test(
 #     name = "tokens_test",
 #     srcs = ["tokens_test.c"],
 #     deps = [
-#         ":lexer_hdr",
-#         ":tokens_c",
+#         ":_parser",
 #         "@local_config_python//:python_headers",
 #     ],
 # )
@@ -359,22 +273,22 @@ py_test(
 py_extension(
     name = "_parser",
     srcs = [
+        "decimal.c",
+        "grammar.c",
+        "lexer.c",
         "parser.c",
+        "tokens.c",
         ":parser_source_hash",
         "//beancount:version_header",
     ],
-    deps = [
-        ":grammar_c",
-        ":lexer_c",
-        ":decimal_c",
-        ":tokens_c",
-        "@local_config_python//:python_headers",
+    hdrs = [
+        "decimal.h",
+        "grammar.h",
+        "lexer.h",
+        "macros.h",
+        "parser.h",
+        "tokens.h",
     ],
-)
-
-cc_library(
-    name = "parser_hdr",
-    hdrs = ["parser.h"],
     deps = [
         "@local_config_python//:python_headers",
     ],


### PR DESCRIPTION
There are circular dependencies which prevent each pair of .h/.c files from being its own c_library. The existing BUILD rules split each pair into two libraries, one for the C files and one for the headers; but this causes Bazel to get confused with file-scope symbols. On Mac OS, it produces the error:

```
Traceback (most recent call last):
File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/bin/bean_check.py", line 5, in
from beancount.scripts.check import main
File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/scripts/check.py", line 11, in
from beancount import loader
File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/loader.py", line 25, in
from beancount.parser import parser
File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/parser.py", line 118, in
from beancount.parser import _parser
ImportError: dlopen(/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/_parser.so, 2): Symbol not found: _decimal_type
Referenced from: /private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/_parser.so
Expected in: flat namespace
in /private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/_parser.so
```

#573