### PR TITLE
Add alwayslink = 1 to the decimal library.

### DIFF
--- a/beancount/parser/BUILD
+++ b/beancount/parser/BUILD
@@ -246,6 +246,7 @@ cc_library(
         "decimal.h",
     ],
     srcs = ["decimal.c"],
+    alwayslink = 1,
     deps = [
         "@local_config_python//:python_headers",
     ],


### PR DESCRIPTION
This ensures that the symbol defined in the .c file (decimal_type) is always present.

Without it, on Mac OS, it produces the error:

Traceback (most recent call last):
File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/bin/bean_check.py", line 5, in
from beancount.scripts.check import main
File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/scripts/check.py", line 11, in
from beancount import loader
File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/loader.py", line 25, in
from beancount.parser import parser
File "/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/parser.py", line 118, in
from beancount.parser import _parser
ImportError: dlopen(/private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/_parser.so, 2): Symbol not found: _decimal_type
Referenced from: /private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/_parser.so
Expected in: flat namespace
in /private/var/tmp/_bazel_beder/cb97eb509905f10b4b346a1d0556de4a/execroot/beancount/bazel-out/darwin-opt/bin/bin/bean_check.runfiles/beancount/beancount/parser/_parser.so

#573