### PR TITLE
Improve matching of lots with computed cost basis.

### DIFF
--- a/beancount/parser/booking_full_test.py
+++ b/beancount/parser/booking_full_test.py
@@ -1732,16 +1732,18 @@ class TestBookReductions(_BookingTestBase):
         """
         option "inferred_tolerance_default" "USD:0.01"
         2016-01-01 * #ante
-          Assets:Account   3 HOOL {{ 10 USD }}
+          Assets:Account           3 HOOL {{ 10 USD }}
 
         2016-05-02 * #apply
-          Assets:Account              -1 HOOL { 3.33 USD } ; this is within 0.01 USD so it should match
+          ; This is within 0.01 USD so it should match
+          Assets:Account           -1 HOOL { 3.33 USD }
 
         2016-05-02 * #apply
-          Assets:Account              -1 HOOL { 3.34 USD } ; this is within 0.01 USD so it should match
+          ; This is within 0.01 USD so it should match
+          Assets:Account           -1 HOOL { 3.34 USD }
 
         2016-01-01 * #booked
-          Assets:Account              -1 HOOL { 3.333333333333333333333333333 USD, 2016-01-01 }
+          Assets:Account           -1 HOOL { 3.333333333333333333333333333 USD, 2016-01-01 }
         """
 
     @book_test(Booking.STRICT)
@@ -1749,16 +1751,18 @@ class TestBookReductions(_BookingTestBase):
         """
         option "inferred_tolerance_default" "*:0.01"
         2016-01-01 * #ante
-          Assets:Account   3 HOOL {{ 10 USD }}
+          Assets:Account           3 HOOL {{ 10 USD }}
 
         2016-05-02 * #apply
-          Assets:Account              -1 HOOL { 3.33 USD } ; this is within 0.01 USD so it should match
+          ; This is within 0.01 USD so it should match
+          Assets:Account           -1 HOOL { 3.33 USD }
 
         2016-05-02 * #apply
-          Assets:Account              -1 HOOL { 3.34 USD } ; this is within 0.01 USD so it should match
+          ; This is within 0.01 USD so it should match
+          Assets:Account           -1 HOOL { 3.34 USD }
 
         2016-01-01 * #booked
-          Assets:Account              -1 HOOL { 3.333333333333333333333333333 USD, 2016-01-01 }
+          Assets:Account           -1 HOOL { 3.333333333333333333333333333 USD, 2016-01-01 }
         """
 
     @book_test(Booking.STRICT)


### PR DESCRIPTION
When basis is computed, either via the {{ }} total cost syntax, an
expression, or when using average cook booking one can easily get 
large fractional unit basis. If a user attempts to match that lot, they
need to know the exact number of digits beancount uses
for quantizing digits to match the lot. By using tolerance, users can
use specify a fractional cost in a human-readable way:
3.33 USD for 0.01 tolerance will match 10 / 3.

For example:
```
        2016-01-01 * #ante
          Assets:Account              3 HOOL {{ 10 USD }}
; can today only be reduced via:
          Assets:Account              -1 HOOL { 3.333333333333333333333333333 USD }

; but with this PR, the user can now write
         option "inferred_tolerance_default" "USD:0.01" 
         Assets:Account              -1 HOOL { 3.33 USD }
```

A downside of this change: If a user specifies an absurdly large
tolerance, it will make lot matching by cost overly broad.

Note, reusing tolerances on balance seems OK to me but has some
downsides. Specifically, we're using the configured tolerance for a currency,
which is currently used to resolve ambiguous precision when that context
is unavailble locally, per http://furius.ca/beancount/doc/tolerances and
`infer_tolerances()`. I think in practice these values are similar
enough to reuse this config, but am open to feedback.