### PR TITLE
Provide SSL context on request.urlopen()

### DIFF
--- a/beancount/utils/net_utils.py
+++ b/beancount/utils/net_utils.py
@@ -6,7 +6,7 @@ __license__ = "GNU GPLv2"
 import logging
 from urllib import request
 from urllib import error
-
+import ssl
 
 def retrying_urlopen(url, timeout=5, max_retry=5):
     """Open and download the given URL, retrying if it times out.
@@ -22,10 +22,13 @@ def retrying_urlopen(url, timeout=5, max_retry=5):
     for _ in range(max_retry):
         logging.debug("Reading %s", url)
         try:
-            response = request.urlopen(url, timeout=timeout)
+            ctx = ssl.create_default_context()
+            ctx.set_ciphers('DEFAULT@SECLEVEL=1')
+            response = request.urlopen(url, timeout=timeout, context=ctx)
             if response:
                 break
-        except error.URLError:
+        except error.URLError as err:
+            logging.error("Error when opening URL: {0}".format(err))
             return None
     if response and response.getcode() != 200:
         return None


### PR DESCRIPTION
This fixes an error returned with newer OpenSSL default settings
with some beanprice sources where a URLError is now raised with message
<urlopen error [SSL: DH_KEY_TOO_SMALL] dh key too small (_ssl.c:1123)>