### PR TITLE
typing: booking key is optional

### DIFF
--- a/beancount/core/data.py
+++ b/beancount/core/data.py
@@ -87,7 +87,7 @@ class Open(NamedTuple):
     date: datetime.date
     account: Account
     currencies: List[Currency]
-    booking: Booking
+    booking: Optional[Booking]
 
 
 class Close(NamedTuple):


### PR DESCRIPTION
According to the documentation, the "booking" key of the directive "Open" is optional.