### PR TITLE
cparser: std::filesystem is not experimental anymore in c++17

### DIFF
--- a/beancount/cparser/BUILD
+++ b/beancount/cparser/BUILD
@@ -71,7 +71,6 @@ cc_library(
         "scanner.cc",
         "parser.cc",
     ],
-    linkopts = ["-Wl,-lstdc++fs"],  # std::experimental::filesystem
     copts = [
         "-Wno-implicit-fallthrough",
         "-O2",

--- a/beancount/cparser/builder.cc
+++ b/beancount/cparser/builder.cc
@@ -1,7 +1,7 @@
 #include "beancount/cparser/builder.h"
 #include "beancount/ccore/std_utils.h"
 
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "google/protobuf/descriptor.pb.h"
 #include "google/protobuf/text_format.h"
@@ -11,7 +11,7 @@
 
 namespace beancount {
 namespace parser {
-namespace filesystem = std::experimental::filesystem;
+namespace filesystem = std::filesystem;
 using absl::StrFormat;
 using google::protobuf::FieldDescriptor;
 using google::protobuf::TextFormat;


### PR DESCRIPTION
Other c++17 features like std::string_view are already used in the codebase. There is no reason to do not use this one too.