### PR TITLE
Meson

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+subprojects/

--- a/.github/workflows/meson-ci.yaml
+++ b/.github/workflows/meson-ci.yaml
@@ -1,0 +1,32 @@
+name: meson-ci
+
+on:
+  [push, pull_request]
+
+jobs:
+  compile:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install build tools
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install ninja
+          python3 -m pip install meson
+      - name: Install Bison
+        run: |
+          wget https://ftp.gnu.org/gnu/bison/bison-3.7.4.tar.xz
+          tar xJf bison-3.7.4.tar.xz
+          cd bison-3.7.4 && ./configure && make && sudo make install
+      - name: Meson configure
+        run: |
+          meson build/
+      - name: Meson build
+        run: |
+          meson compile -C build/
+      - name: Meson test
+        run: |
+          meson test -C build/

--- a/.github/workflows/meson-ci.yaml
+++ b/.github/workflows/meson-ci.yaml
@@ -11,11 +11,18 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
+      - uses: dnicolodi/github-actions-cache@always
+        # fork of actions/cache that stores the cache also on job failure
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-meson-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-meson
       - name: Install build tools
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install ninja
           python3 -m pip install meson
+          sudo apt install ccache
       - name: Install Bison
         run: |
           wget https://ftp.gnu.org/gnu/bison/bison-3.7.4.tar.xz

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ examples/generated/*
 experiments/v3/arrow/*.feather
 experiments/v3/arrow/*.parquet
 experiments/v3/arrow/*.arrow
+subprojects/*/
+!subprojects/packagefiles/

--- a/beancount/cparser/meson.build
+++ b/beancount/cparser/meson.build
@@ -1,0 +1,18 @@
+scanner_cc = custom_target('scanner.cc',
+  input : 'scanner.lxx',
+  output : ['@BASENAME@.cc', '@BASENAME@.h'],
+  command : [reflex,
+             '--unicode', '--full',
+             '--header-file=@OUTPUT1@',
+             '-o', '@OUTPUT0@',
+             '@INPUT@'])
+
+parser_cc = custom_target('parser.cc',
+  input : 'parser.yxx',
+  output : ['@BASENAME@.cc', '@BASENAME@.h', 'location.h'],
+  command : [bison,
+             '-Wall', '-Werror',
+             '--defines=@OUTPUT1@',
+             '--define=api.location.file="location.h"',
+             '-o', '@OUTPUT0@',
+             '@INPUT@'])

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,172 @@
+project('beancount', 'cpp',
+        version : '2.90.0',
+        license : 'GPL-v2-only',
+        default_options: [
+          'cpp_std=c++17',
+          'optimization=2',
+          'default_library=static',
+        ])
+
+absl_container_dep = dependency('absl_container')
+absl_hash_dep = dependency('absl_hash')
+absl_status_dep = dependency('absl_status')
+absl_strings_dep = dependency('absl_strings')
+absl_time_dep = dependency('absl_time')
+
+mpdecimal_dep = dependency('mpdecpp')
+
+re2_dep = dependency('re2')
+
+pybind11_dep = dependency('pybind11')
+
+gtest = subproject('gtest')
+gtest_main_dep = gtest.get_variable('gtest_main_dep')
+gmock_dep = gtest.get_variable('gmock_dep')
+
+# FIXME: Fix protobuf wrap to do not require this. Also update to latest protobuf release.
+protobuf_dep = dependency('protobuf', required : false)
+if protobuf_dep.found()
+  protoc = find_program('protoc')
+else
+  protobuf = subproject('protobuf')
+  protobuf_dep = protobuf.get_variable('protobuf_dep')
+  protoc = protobuf.get_variable('protoc')
+endif
+
+python = import('python').find_installation()
+py3_dep = python.dependency()
+
+bison = find_program('bison', version : '>3.7')
+
+reflex_dep = dependency('reflex')
+reflex = find_program('reflex')
+
+cc = meson.get_compiler('cpp')
+
+# Silence warnings from reflex headers
+add_project_arguments(cc.get_supported_arguments('-Wno-non-virtual-dtor'), language : 'cpp')
+
+deps = [
+  absl_container_dep,
+  absl_hash_dep,
+  absl_status_dep,
+  absl_strings_dep,
+  absl_time_dep,
+  mpdecimal_dep,
+  protobuf_dep,
+  re2_dep,
+  reflex_dep,
+]
+
+includes = include_directories('.')
+
+proto = files(
+  'beancount/ccore/data.proto',
+  'beancount/ccore/date.proto',
+  'beancount/ccore/number.proto',
+  'beancount/cparser/ledger.proto',
+  'beancount/cparser/options.proto',
+  'beancount/cparser/parser.proto',
+)
+
+protoc_gen = generator(protoc,
+  output : ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
+  arguments : ['--proto_path=@CURRENT_SOURCE_DIR@', '--cpp_out=@BUILD_DIR@', '@INPUT@'])
+
+proto_cc = protoc_gen.process(proto,
+  preserve_path_from : meson.current_source_dir())
+
+subdir('beancount/cparser')
+
+# reflex_gen = generator(reflex,
+#   output : ['@BASENAME@.cc', '@BASENAME@.h'],
+#   arguments : ['--unicode', '--full', '--header-file=@OUTPUT1@', '-o', '@OUTPUT0@', '@INPUT@'])
+
+# scanner_cc = reflex_gen.process('beancount/cparser/scanner.lxx',
+#   preserve_path_from : meson.current_source_dir())
+
+# bison_gen = generator(bison,
+#   output : ['@BASENAME@.cc', '@BASENAME@.h'],
+#   arguments : ['--report=itemset', '--verbose', '-Wall', '-Werror',
+#                '--defines=@OUTPUT1@',
+#                '--define=api.location.file="location.h"',
+#                '-o', '@OUTPUT0@', '@INPUT@'])
+
+# parser_cc = bison_gen.process('beancount/cparser/parser.yxx',
+#   preserve_path_from : meson.current_source_dir())
+
+sources = files(
+  'beancount/ccore/account.cc',
+  'beancount/ccore/account_types.cc',
+  'beancount/ccore/data.cc',
+  'beancount/ccore/date.cc',
+  'beancount/ccore/inventory.cc',
+  'beancount/ccore/number.cc',
+  'beancount/ccore/std_utils.cc',
+  'beancount/cparser/builder.cc',
+  'beancount/cparser/ledger.cc',
+  'beancount/cparser/test_utils.cc',
+)
+
+cbeancount = static_library('cbeancount',
+  sources, proto_cc, scanner_cc, parser_cc,
+  include_directories : includes,
+  dependencies : deps)
+
+tests = [
+  'beancount/ccore/account_test.cc',
+  'beancount/ccore/date_test.cc',
+  'beancount/ccore/number_test.cc',
+  'beancount/ccore/std_utils_test.cc',
+  'beancount/cparser/parser_test.cc',
+  'beancount/cparser/scanner_test.cc',
+  'beancount/cparser/test_utils_test.cc',
+]
+
+foreach test : tests
+  t = executable(
+    test.underscorify(),
+    test,
+    include_directories : [
+      includes,
+      cbeancount.private_dir_include()
+    ],
+    link_with : cbeancount,
+    dependencies : [
+      deps,
+      gmock_dep,
+      gtest_main_dep,
+    ])
+
+  test(test.split('.')[0], t, protocol : 'gtest')
+endforeach
+
+python.extension_module(
+  'beancount.ccore._core',
+  'beancount/ccore/_core.cc',
+  include_directories : [
+    includes,
+    cbeancount.private_dir_include()
+  ],  
+  link_with : cbeancount,
+  dependencies : [
+    deps,
+    py3_dep,
+    pybind11_dep,
+  ],
+  override_options : ['b_lto=true'])
+
+python.extension_module(
+  'beancount.cparser.extmodule',
+  'beancount/cparser/extmodule.cc',
+  include_directories : [
+    includes,
+    cbeancount.private_dir_include()
+  ],  
+  link_with : cbeancount,
+  dependencies : [
+    deps,
+    py3_dep,
+    pybind11_dep,
+  ],
+  override_options : ['b_lto=true'])

--- a/subprojects/abseil-cpp.wrap
+++ b/subprojects/abseil-cpp.wrap
@@ -1,0 +1,23 @@
+[wrap-file]
+directory = abseil-cpp-20200923.2
+source_url = https://github.com/abseil/abseil-cpp/archive/20200923.2.tar.gz
+source_filename = abseil-cpp-20200923.2.tar.gz
+source_hash = bf3f13b13a0095d926b25640e060f7e13881bd8a792705dd9e161f3c2b9aa976
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/abseil-cpp/20200923.2/1/get_zip
+patch_filename = abseil-cpp-20200923.2-1-wrap.zip
+patch_hash = 501e9656ecbeb0fbec176e1bbd94e83fab372af9e212390d7ab072ad3b6c75a8
+
+[provide]
+absl_base = absl_base_dep
+absl_container = absl_container_dep
+absl_debugging = absl_debugging_dep
+absl_flags = absl_flags_dep
+absl_hash = absl_hash_dep
+absl_numeric = absl_numeric_dep
+absl_random = absl_random_dep
+absl_status = absl_status_dep
+absl_strings = absl_strings_dep
+absl_synchronization = absl_synchronization_dep
+absl_time = absl_time_dep
+absl_types = absl_types_dep
+

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = googletest-release-1.10.0
+
+source_url = https://github.com/google/googletest/archive/release-1.10.0.zip
+source_filename = gtest-1.10.0.zip
+source_hash = 94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/gtest/1.10.0/1/get_zip
+patch_filename = gtest-1.10.0-1-wrap.zip
+patch_hash = 04ff14e8880e4e465f6260221e9dfd56fea6bc7cce4c4aff0dc528e4a2c8f514

--- a/subprojects/mpdecimal.wrap
+++ b/subprojects/mpdecimal.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = mpdecimal-2.5.0
+source_url = http://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.0.tar.gz
+source_filename = mpdecimal-2.5.0.tar.gz
+source_hash = 15417edc8e12a57d1d9d75fa7e3f22b158a3b98f44db9d694cfd2acde8dfa0ca
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/mpdecimal/2.5.0/2/get_zip
+patch_filename = mpdecimal-2.5.0-2-wrap.zip
+patch_hash = 631f6bd67ff6be1ed77eed7acd12efea18d8df07c03d277096395022e760b1fb
+
+[provide]
+mpdec = mpdec_dep
+mpdecpp = mpdecpp_dep
+

--- a/subprojects/protobuf.wrap
+++ b/subprojects/protobuf.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = protobuf-3.12.2
+source_url = https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/protobuf-all-3.12.2.zip
+source_filename = protobuf-all-3.12.2.zip
+source_hash = af6a9cf80a99090a38a027e4b1a0545220f368368d8b03b3309ff760cb60d92d
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/protobuf/3.12.2/2/get_zip
+patch_filename = protobuf-3.12.2-2-wrap.zip
+patch_hash = 7e0e5e7eb39f30fa6399a64a1748e916b5241e2705609da0e7ae0dbccfd1ab49
+

--- a/subprojects/pybind11.wrap
+++ b/subprojects/pybind11.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = pybind11-2.6.1
+source_url = https://github.com/pybind/pybind11/archive/v2.6.1.tar.gz
+source_filename = pybind11-2.6.1.tar.gz
+source_hash = cdbe326d357f18b83d10322ba202d69f11b2f49e2d87ade0dc2be0c5c34f8e2a
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/pybind11/2.6.1/1/get_zip
+patch_filename = pybind11-2.6.1-1-wrap.zip
+patch_hash = 6de5477598b56c8a2e609196420c783ac35b79a31d6622121602e6ade6b3cee8
+
+[provide]
+pybind11 = pybind11_dep
+

--- a/subprojects/re2.wrap
+++ b/subprojects/re2.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = re2-2020-11-01
+source_url = https://github.com/google/re2/archive/2020-11-01.tar.gz
+source_filename = re2-2020-11-01.tar.gz
+source_hash = 8903cc66c9d34c72e2bc91722288ebc7e3ec37787ecfef44d204b2d6281954d7
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/re2/20201101/1/get_zip
+patch_filename = re2-20201101-1-wrap.zip
+patch_hash = 9ead358791dd104c3f355b2626c52670cbb5c0ac29dd2771f3b08291c0444dc1
+
+[provide]
+re2 = re2_dep
+

--- a/subprojects/reflex.wrap
+++ b/subprojects/reflex.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = RE-flex-3.0.1
+source_url = https://github.com/Genivia/RE-flex/archive/v3.0.1.tar.gz
+source_filename = v3.0.1.tar.gz
+source_hash = 7ceab8075677e618b39451ff5487a7f463f8e1bfa7668010ae992d84eefd6dca
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/reflex/3.0.1/1/get_zip
+patch_filename = reflex-3.0.1-1-wrap.zip
+patch_hash = adb3cda531c427e28715a8472512404520bfd7ece45ca5892c268e20f282b7f4
+
+[provide]
+reflex = reflex_dep
+


### PR DESCRIPTION
Technology preview of how the Meson build looks like.

I gave up on integrating the Bison build, it is a build time only dependence and I compile it on the build machine. It takes about 1 minute to build and install, notably with a sizeable fraction of it spent in the configure script. This time can be reduced with some clever use of the cache or producing a deb package for Bison 3.7.4 for Ubuntu 20.04.

It also uses an oldish version of protobuf, 3.12.2. Updating to a newer release should be easy. However, tests pass with the old version too.

This does not build the Python protobuf modules or a Python package, mostly because I haven't yet understood how to test it.

It would be nice to see if this does something sensible on Windows, but I don't know if there is an easy way to get Bison on Windows.

Oh, this includes the commit form #610 to make things a tiny bit easier.