### PR TITLE
validation: allow reopening closed accounts

### DIFF
--- a/beancount/ops/validation.py
+++ b/beancount/ops/validation.py
@@ -69,11 +69,17 @@ def validate_open_close(entries, unused_options_map):
 
         if isinstance(entry, Open):
             if entry.account in open_map:
-                errors.append(
-                    ValidationError(
-                        entry.meta,
-                        "Duplicate open directive for {}".format(entry.account),
-                        entry))
+                close_entry = close_map.get(entry.account, None)
+                if close_entry is not None and close_entry.date < entry.date:
+                    # reopening closed account
+                    del close_map[entry.account]
+                    open_map[entry.account] = entry
+                else:
+                    errors.append(
+                        ValidationError(
+                            entry.meta,
+                            "Duplicate open directive for {}".format(entry.account),
+                            entry))
             else:
                 open_map[entry.account] = entry
 

--- a/beancount/ops/validation_test.py
+++ b/beancount/ops/validation_test.py
@@ -75,6 +75,28 @@ class TestValidateOpenClose(cmptest.TestCase):
         self.assertEqual(['Assets:US:Bank:Checking1'],
                          [error.entry.account for error in errors])
 
+    @loader.load_doc(expect_errors=True)
+    def test_validate_open_close__reopen(self, entries, _, options_map):
+        """
+        ;; Open then close account
+        2014-02-10 open  Assets:US:Bank:Checking1
+        2014-02-11 close Assets:US:Bank:Checking1
+
+        ;; Try re-opening and closing it later, no error
+        2014-02-12 open  Assets:US:Bank:Checking1
+        2014-02-13 close Assets:US:Bank:Checking1
+
+        ;; Open then close account
+        2014-02-10 open  Assets:US:Bank:Checking2
+        2014-02-20 close Assets:US:Bank:Checking2
+
+        ;; Try re-opening while not closed yet
+        2014-02-15 open  Assets:US:Bank:Checking2
+        """
+        errors = validation.validate_open_close(entries, options_map)
+        self.assertEqual(['Assets:US:Bank:Checking2'],
+                         [error.entry.account for error in errors])
+
 
 class TestValidateDuplicateBalances(cmptest.TestCase):
 


### PR DESCRIPTION
Fixes #611

First draft to allow re-opening a previously closed account. This only prevents the error from appearing, but allowing this may have effects elsewhere, I'll play around with my ledger to see if anything breaks!

Feedback welcome, feel free to point me to places where additional tests should be written for this use case.