### PR TITLE
Use Click library for command line parsing

### DIFF
--- a/beancount/parser/version.py
+++ b/beancount/parser/version.py
@@ -23,11 +23,7 @@ def ArgumentParser(*args, **kwargs):
     """
     parser = argparse.ArgumentParser(*args, **kwargs)
 
-    parser.add_argument('--version', '-V', action='version',
-                        version=compute_version_string(
-                            beancount.__version__,
-                            getattr(_parser, "__vc_changeset__", None),
-                            getattr(_parser, "__vc_timestamp__", 0)))
+    parser.add_argument('--version', '-V', action='version', version=VERSION)
 
     return parser
 
@@ -60,3 +56,9 @@ def compute_version_string(version, changeset, timestamp):
             version, '; '.join(map(str, filter(None, [changeset, date]))))
 
     return version
+
+
+VERSION = compute_version_string(
+    beancount.__version__,
+    getattr(_parser, "__vc_changeset__", None),
+    getattr(_parser, "__vc_timestamp__", 0))

--- a/beancount/query/shell_test.py
+++ b/beancount/query/shell_test.py
@@ -200,7 +200,7 @@ class TestRun(unittest.TestCase):
         self.assertRegex(output, 'Expenses:Home:Rent')
 
 
-class TestShell(test_utils.TestCase):
+class TestShell(test_utils.ClickTestCase):
 
     @test_utils.docfile
     def test_success(self, filename):
@@ -222,9 +222,8 @@ class TestShell(test_utils.TestCase):
           Assets:Account1     -1000 USD
           Assets:Account3       800 EUR @ 1.25 USD
         """
-        with test_utils.capture('stdout', 'stderr') as (stdout, _):
-            test_utils.run_with_args(shell.main, [filename, "SELECT 1;"])
-        self.assertTrue(stdout.getvalue())
+        result = self.run_with_args(shell.main, filename, "SELECT 1;")
+        self.assertTrue(result.stdout)
 
 
 __incomplete__ = True

--- a/beancount/scripts/check.py
+++ b/beancount/scripts/check.py
@@ -1,62 +1,50 @@
-"""Parse, check and realize a beancount input file.
-
-This also measures the time it takes to run all these steps.
-"""
 __copyright__ = "Copyright (C) 2014, 2016-2017  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import logging
 import sys
 
+import click
+
 from beancount import loader
 from beancount.ops import validation
 from beancount.utils import misc_utils
-from beancount.parser import version
+from beancount.parser.version import VERSION
 
+@click.command()
+@click.argument('filename', type=click.Path())
+@click.option('--verbose', '-v', is_flag=True, help='Print timings.')
+@click.option('--no-cache', '-C', is_flag=True, help='Disable the cache.')
+@click.option('--cache-filename', type=click.Path(), help='Override the cache filename.')
+@click.version_option(message=VERSION)
+def main(filename, verbose, no_cache, cache_filename):
+    """Parse, check and realize a beancount ledger.
 
-def main():
-    parser = version.ArgumentParser(description=__doc__)
+    This also measures the time it takes to run all these steps.
 
-    parser.add_argument('filename',
-                        help='Beancount input filename.')
+    """
+    use_cache = not no_cache
 
-    parser.add_argument('-v', '--verbose', action='store_true',
-                        help='Print timings.')
+    if verbose:
+        logging.basicConfig(level=logging.INFO, format='%(levelname)-8s: %(message)s')
 
-    # Note: These are useful during development. We need to devise a global
-    # mechanism that will work from all the invocation programs, embedded in the
-    # loader.
-    parser.add_argument('-C', '--no-cache', action='store_false',
-                        dest='use_cache', default=True,
-                        help='Disable the cache from the command-line.')
-    parser.add_argument('--cache-filename', action='store',
-                        help='Override the name of the cache')
-
-    opts = parser.parse_args()
-
-    if opts.verbose:
-        logging.basicConfig(level=logging.INFO,
-                            format='%(levelname)-8s: %(message)s')
-
-    # Override loader caching setup if disabled or if the filename is
-    # overridden.
-    if not opts.use_cache or opts.cache_filename:
-        loader.initialize(opts.use_cache, opts.cache_filename)
+    # Override loader caching setup.
+    if use_cache or cache_filename:
+        loader.initialize(use_cache, cache_filename)
 
     with misc_utils.log_time('beancount.loader (total)', logging.info):
         # Load up the file, print errors, checking and validation are invoked
         # automatically.
         entries, errors, _ = loader.load_file(
-            opts.filename,
+            filename,
             log_timings=logging.info,
             log_errors=sys.stderr,
             # Force slow and hardcore validations, just for check.
             extra_validations=validation.HARDCORE_VALIDATIONS)
 
-    # Exit with an error code if there were any errors, so this can be used in a
-    # shell conditional.
-    return 1 if errors else 0
+    # Exit with an error code if there were any errors.
+    sys.exit(1 if errors else 0)
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    main()

--- a/beancount/scripts/check_examples_test.py
+++ b/beancount/scripts/check_examples_test.py
@@ -24,14 +24,13 @@ def find_example_files():
                 yield path.join(root, filename)
 
 
-class TestCheckExamples(test_utils.TestCase):
+class TestCheckExamples(test_utils.ClickTestCase):
 
     def test_example_files(self):
         for filename in find_example_files():
-            with test_utils.capture('stdout', 'stderr') as (stdout, _):
-                result = test_utils.run_with_args(check.main, [filename])
-            self.assertEqual(0, result)
-            self.assertLines("", stdout.getvalue())
+            result = self.run_with_args(check.main, filename)
+            self.assertEqual(0, result.exit_code)
+            self.assertLines("", result.stdout)
 
 
 if __name__ == '__main__':

--- a/beancount/scripts/check_test.py
+++ b/beancount/scripts/check_test.py
@@ -2,12 +2,13 @@ __copyright__ = "Copyright (C) 2014, 2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import unittest
+import click.testing
 
 from beancount.utils import test_utils
 from beancount.scripts import check
 
 
-class TestScriptCheck(test_utils.TestCase):
+class TestScriptCheck(test_utils.ClickTestCase):
 
     @test_utils.docfile
     def test_success(self, filename):
@@ -19,10 +20,8 @@ class TestScriptCheck(test_utils.TestCase):
           Expenses:Restaurant   50.02 USD
           Assets:Cash
         """
-        with test_utils.capture('stdout', 'stderr') as (stdout, _):
-            result = test_utils.run_with_args(check.main, [filename])
-        self.assertEqual(0, result)
-        self.assertLines("", stdout.getvalue())
+        result = self.run_with_args(check.main, filename)
+        self.assertLines("", result.stdout)
 
     @test_utils.docfile
     def test_fail(self, filename):
@@ -36,11 +35,14 @@ class TestScriptCheck(test_utils.TestCase):
 
         2014-03-07 balance Assets:Cash  100 USD
         """
-        with test_utils.capture('stderr') as stderr:
-            result = test_utils.run_with_args(check.main, [filename])
-        self.assertEqual(1, result)
-        self.assertRegex(stderr.getvalue(), "Balance failed")
-        self.assertRegex(stderr.getvalue(), "Assets:Cash")
+        # We should use mix_stderr=False and we check for the error
+        # message on result.stderr, but it does not work. See
+        # https://github.com/pallets/click/issues/1761
+        runner = click.testing.CliRunner()
+        result = runner.invoke(check.main, [filename])
+        self.assertEqual(result.exit_code, 1)
+        self.assertRegex(result.output, "Balance failed")
+        self.assertRegex(result.output, "Assets:Cash")
 
 
 if __name__ == '__main__':

--- a/beancount/scripts/doctor_test.py
+++ b/beancount/scripts/doctor_test.py
@@ -5,16 +5,17 @@ import os
 import re
 import textwrap
 import tempfile
-from os import path
 import unittest
+
+from os import path
 
 from beancount.parser import cmptest
 from beancount.utils import test_utils
-from beancount.scripts import doctor
+from beancount.scripts.doctor import doctor
 from beancount.scripts import directories_test
 
 
-class TestScriptDoctor(test_utils.TestCase):
+class TestScriptDoctor(test_utils.ClickTestCase):
 
     @test_utils.docfile
     def test_dump_lexer(self, filename):
@@ -26,8 +27,7 @@ class TestScriptDoctor(test_utils.TestCase):
           Expenses:Restaurant   50.02 USD
           Assets:Cash
         """
-        with test_utils.capture() as stdout:
-            test_utils.run_with_args(doctor.main, ['dump-lexer', filename])
+        result = self.run_with_args(doctor, 'dump-lexer', filename)
 
         expected_output = """
             EOL               2 b'\\n'
@@ -53,14 +53,14 @@ class TestScriptDoctor(test_utils.TestCase):
             ACCOUNT           7 b'Assets:Cash'
             EOL               8 b'\\n'
         """
-        self.assertLines(expected_output, stdout.getvalue())
+        self.assertLines(expected_output, result.stdout)
 
     # pylint: disable=empty-docstring
     @test_utils.docfile
     def test_dump_lexer_empty(self, filename):
         ""
-        with test_utils.capture():
-            test_utils.run_with_args(doctor.main, ['dump-lexer', filename])
+        rv = self.run_with_args(doctor, 'dump-lexer', filename)
+        self.assertEqual(rv.stdout, "")
 
     @test_utils.docfile
     def test_dump_roundtrip(self, filename):
@@ -72,16 +72,14 @@ class TestScriptDoctor(test_utils.TestCase):
           Expenses:Restaurant   50.02 USD
           Assets:Cash
         """
-        with test_utils.capture('stdout', 'stderr'):
-            test_utils.run_with_args(doctor.main, ['roundtrip', filename])
+        self.run_with_args(doctor, 'roundtrip', filename)
 
     def test_list_options(self):
-        with test_utils.capture():
-            test_utils.run_with_args(doctor.main, ['list_options'])
-            test_utils.run_with_args(doctor.main, ['list-options'])
+        self.run_with_args(doctor, 'list_options')
 
 
-class TestScriptCheckDirectories(directories_test.TestScriptCheckDirectories):
+class TestScriptCheckDirectories(directories_test.TestScriptCheckDirectories,
+                                 test_utils.ClickTestCase):
 
     @test_utils.docfile
     def test_invocation(self, filename):
@@ -100,10 +98,9 @@ class TestScriptCheckDirectories(directories_test.TestScriptCheckDirectories):
         for directory in self.TEST_DIRECTORIES:
             os.makedirs(path.join(self.tmpdir, directory))
 
-        with test_utils.capture() as stdout:
-            test_utils.run_with_args(doctor.main, ['directories', filename, self.tmpdir])
-        self.assertEqual(2, len(stdout.getvalue().splitlines()))
-        matches = set(match.group(1) for match in re.finditer("'(.*?)'", stdout.getvalue()))
+        rv = self.run_with_args(doctor, 'directories', filename, self.tmpdir)
+        self.assertEqual(2, len(rv.stdout.splitlines()))
+        matches = set(match.group(1) for match in re.finditer("'(.*?)'", rv.stdout))
         clean_matches = set(match[len(self.tmpdir)+1:]
                             if match.startswith(self.tmpdir)
                             else match
@@ -114,7 +111,7 @@ class TestScriptCheckDirectories(directories_test.TestScriptCheckDirectories):
                           'Assets/Extra'}, clean_matches)
 
 
-class TestScriptMissingOpen(cmptest.TestCase):
+class TestScriptMissingOpen(cmptest.TestCase, test_utils.ClickTestCase):
 
     @test_utils.docfile
     def test_missing_open(self, filename):
@@ -132,18 +129,17 @@ class TestScriptMissingOpen(cmptest.TestCase):
               Expenses:Movie        25.00 USD
               Assets:Cash
         """
-        with test_utils.capture() as stdout:
-            test_utils.run_with_args(doctor.main, ['missing-open', filename])
+        rv = self.run_with_args(doctor, 'missing-open', filename)
 
         self.assertEqualEntries("""
 
             2014-03-03 open Expenses:Restaurant
             2014-04-04 open Expenses:Alcohol
 
-        """, stdout.getvalue())
+        """, rv.stdout)
 
 
-class TestScriptDisplayContext(cmptest.TestCase):
+class TestScriptDisplayContext(cmptest.TestCase, test_utils.ClickTestCase):
 
     @test_utils.docfile
     def test_display_context(self, filename):
@@ -161,13 +157,12 @@ class TestScriptDisplayContext(cmptest.TestCase):
               Expenses:Movie        25.00 USD
               Assets:Cash
         """
-        with test_utils.capture() as stdout:
-            test_utils.run_with_args(doctor.main, ['display-context', filename])
+        rv = self.run_with_args(doctor, 'display-context', filename)
         # Note: This probably deserves a little more love.
-        self.assertTrue(stdout.getvalue())
+        self.assertTrue(rv.stdout)
 
 
-class TestContext(cmptest.TestCase):
+class TestContext(cmptest.TestCase, test_utils.ClickTestCase):
 
     @test_utils.docfile
     def test_context(self, filename):
@@ -185,10 +180,9 @@ class TestContext(cmptest.TestCase):
               Expenses:Movie        25.00 USD
               Assets:Cash
         """
-        with test_utils.capture() as stdout:
-            test_utils.run_with_args(doctor.main, ['context', filename, '6'])
-        self.assertRegex(stdout.getvalue(), 'Location:')
-        self.assertRegex(stdout.getvalue(), '50.02')
+        rv = self.run_with_args(doctor, 'context', filename, '6')
+        self.assertRegex(rv.stdout, 'Location:')
+        self.assertRegex(rv.stdout, '50.02')
 
     @test_utils.docfile
     def test_context_multiple_files(self, filename):
@@ -212,13 +206,13 @@ class TestContext(cmptest.TestCase):
                 include "{}"
             """.format(filename)))
             topfile.flush()
-            with test_utils.capture() as stdout:
-                test_utils.run_with_args(doctor.main, ['context', topfile.name,
-                                                       '{}:6'.format(filename)])
-            self.assertRegex(stdout.getvalue(), 'Location:')
-            self.assertRegex(stdout.getvalue(), '50.02')
+            rv = self.run_with_args(doctor, 'context',
+                                   topfile.name, '{}:6'.format(filename))
+            self.assertRegex(rv.stdout, 'Location:')
+            self.assertRegex(rv.stdout, '50.02')
 
-class TestLinked(cmptest.TestCase):
+
+class TestLinked(cmptest.TestCase, test_utils.ClickTestCase):
 
     test_string = """
         2013-01-01 open Expenses:Movie
@@ -242,12 +236,11 @@ class TestLinked(cmptest.TestCase):
 
     @test_utils.docfile_extra(contents=test_string)
     def test_linked_lineno_only(self, filename):
-        with test_utils.capture() as stdout:
-            test_utils.run_with_args(doctor.main, ['linked', filename, '6'])
-        self.assertRegex(stdout.getvalue(), 'Apples')
-        self.assertRegex(stdout.getvalue(), 'Oranges')
+        rv = self.run_with_args(doctor, 'linked', filename, '6')
+        self.assertRegex(rv.stdout, 'Apples')
+        self.assertRegex(rv.stdout, 'Oranges')
         self.assertEqual(2, len(list(re.finditer(r'/(tmp|var/folders)/.*:\d+:',
-                                                 stdout.getvalue()))))
+                                                 rv.stdout))))
 
     @test_utils.docfile_extra(contents=test_string)
     def test_linked_multiple_files(self, filename):
@@ -256,33 +249,30 @@ class TestLinked(cmptest.TestCase):
                 include "{}"
             """.format(filename)))
             topfile.flush()
-            with test_utils.capture() as stdout:
-                test_utils.run_with_args(doctor.main, ['linked', topfile.name,
-                                                       '{}:6'.format(filename)])
-            self.assertRegex(stdout.getvalue(), 'Apples')
-            self.assertRegex(stdout.getvalue(), 'Oranges')
+            rv = self.run_with_args(doctor, 'linked',
+                                   topfile.name, '{}:6'.format(filename))
+            self.assertRegex(rv.stdout, 'Apples')
+            self.assertRegex(rv.stdout, 'Oranges')
             self.assertEqual(2, len(list(re.finditer(r'/(tmp|var/folders)/.*:\d+:',
-                                                     stdout.getvalue()))))
+                                                     rv.stdout))))
 
     @test_utils.docfile_extra(contents=test_string)
     def test_linked_explicit_link(self, filename):
-        with test_utils.capture() as stdout:
-            test_utils.run_with_args(doctor.main, ['linked', filename, '^abc'])
-        self.assertRegex(stdout.getvalue(), 'Apples')
-        self.assertRegex(stdout.getvalue(), 'Oranges')
+        rv = self.run_with_args(doctor, 'linked', filename, '^abc')
+        self.assertRegex(rv.stdout, 'Apples')
+        self.assertRegex(rv.stdout, 'Oranges')
         self.assertEqual(2, len(list(re.finditer(r'/(tmp|var/folders)/.*:\d+:',
-                                                 stdout.getvalue()))))
+                                                 rv.stdout))))
 
 
-class TestRegion(cmptest.TestCase):
+class TestRegion(cmptest.TestCase, test_utils.ClickTestCase):
 
     test_string = TestLinked.test_string
 
     @test_utils.docfile_extra(contents=test_string)
     def test_region(self, filename):
-        with test_utils.capture() as stdout:
-            test_utils.run_with_args(doctor.main, ['region', filename, '4:12'])
-        self.assertRegex(stdout.getvalue(), r'Cash\s+-110.32 USD')
+        rv = self.run_with_args(doctor, 'region', filename, '4:12')
+        self.assertRegex(rv.stdout, r'Cash\s+-110.32 USD')
 
 
 if __name__ == '__main__':

--- a/beancount/scripts/example_test.py
+++ b/beancount/scripts/example_test.py
@@ -9,18 +9,13 @@ from beancount.ops import validation
 from beancount import loader
 
 
-class TestScriptExample(test_utils.TestCase):
+class TestScriptExample(test_utils.ClickTestCase):
 
     def test_generate(self):
-        # Basic test that calls out the generator.
-        with test_utils.capture('stdout', 'stderr') as (stdout, _):
-            result = test_utils.run_with_args(example.main, [])
-        self.assertEqual(0, result, str(result))
-        file_contents = stdout.getvalue()
-        self.assertTrue(file_contents)
+        rv = self.run_with_args(example.main)
+        self.assertTrue(rv.stdout)
 
-        loaded_entries, errors, _ = loader.load_string(
-            file_contents,
+        loaded_entries, errors, _ = loader.load_string(rv.stdout,
             extra_validations=validation.HARDCORE_VALIDATIONS)
         self.assertFalse(errors)
 

--- a/beancount/scripts/format_test.py
+++ b/beancount/scripts/format_test.py
@@ -8,7 +8,7 @@ from beancount.utils import test_utils
 from beancount.scripts import format
 
 
-class TestScriptFormat(test_utils.TestCase):
+class TestScriptFormat(test_utils.ClickTestCase):
 
     @test_utils.docfile
     def test_success(self, filename):
@@ -31,9 +31,7 @@ class TestScriptFormat(test_utils.TestCase):
             Assets:Cash
 
         """
-        with test_utils.capture() as stdout:
-            result = test_utils.run_with_args(format.main, [filename])
-        self.assertEqual(0, result)
+        result = self.run_with_args(format.main, filename)
         self.assertEqual(textwrap.dedent("""
 
           * Section header
@@ -52,7 +50,7 @@ class TestScriptFormat(test_utils.TestCase):
             Assets:Other                        10 HOOL {500.23} USD ; Bla
             Assets:Cash
 
-        """), stdout.getvalue())
+        """), result.stdout)
 
     @test_utils.docfile
     def test_align_posting_starts(self, filename):
@@ -69,9 +67,7 @@ class TestScriptFormat(test_utils.TestCase):
             Expenses:Restaurant   50.03 USD
             Assets:Cash
         """
-        with test_utils.capture() as stdout:
-            result = test_utils.run_with_args(format.main, [filename])
-        self.assertEqual(0, result)
+        result = self.run_with_args(format.main, filename)
         self.assertEqual(textwrap.dedent("""
           2014-03-01 * "Something"
             Expenses:Restaurant  50.01 USD
@@ -84,16 +80,14 @@ class TestScriptFormat(test_utils.TestCase):
           2014-03-03 * "Something"
             Expenses:Restaurant  50.03 USD
             Assets:Cash
-        """), stdout.getvalue())
+        """), result.stdout)
 
     @test_utils.docfile
     def test_open_only_issue80(self, filename):
         """
           2015-07-16 open Assets:BoA:checking USD
         """
-        with test_utils.capture():
-            result = test_utils.run_with_args(format.main, [filename])
-        self.assertEqual(0, result)
+        result = self.run_with_args(format.main, filename)
         with open(filename) as infile:
             actual = infile.read()
         self.assertEqual("""
@@ -121,9 +115,7 @@ class TestScriptFormat(test_utils.TestCase):
             Assets:Cash
 
         """
-        with test_utils.capture() as stdout:
-            result = test_utils.run_with_args(format.main, [filename])
-        self.assertEqual(0, result)
+        result = self.run_with_args(format.main, filename)
         self.assertEqual(textwrap.dedent("""
 
           * Section header
@@ -142,7 +134,7 @@ class TestScriptFormat(test_utils.TestCase):
             Assets:Other                           10 HOOL {5,000.23} USD ; Bla
             Assets:Cash
 
-        """), stdout.getvalue())
+        """), result.stdout)
 
     @test_utils.docfile
     def test_currency_issue146(self, filename):
@@ -154,9 +146,7 @@ class TestScriptFormat(test_utils.TestCase):
             Assets:Investments                 1.23 FOO_BAR
             Equity:Opening-balances
         """
-        with test_utils.capture() as stdout:
-            result = test_utils.run_with_args(format.main, [filename])
-        self.assertEqual(0, result)
+        result = self.run_with_args(format.main, filename)
         self.assertEqual(textwrap.dedent("""
           1970-01-01 open Equity:Opening-balances
           1970-01-01 open Assets:Investments
@@ -164,7 +154,7 @@ class TestScriptFormat(test_utils.TestCase):
           2014-03-31 * "opening"
             Assets:Investments  1.23 FOO_BAR
             Equity:Opening-balances
-        """), stdout.getvalue())
+        """), result.stdout)
 
     @test_utils.docfile
     def test_fixed_width(self, filename):
@@ -176,9 +166,7 @@ class TestScriptFormat(test_utils.TestCase):
           Expenses:Test     10.00 USD
           Assets:Test
         """
-        with test_utils.capture() as stdout:
-            result = test_utils.run_with_args(format.main, [filename, '--prefix-width=40'])
-        self.assertEqual(0, result)
+        result = self.run_with_args(format.main, filename, '--prefix-width=40')
         self.assertEqual(textwrap.dedent("""
         2016-08-01 open Expenses:Test
         2016-08-01 open Assets:Test
@@ -186,7 +174,7 @@ class TestScriptFormat(test_utils.TestCase):
         2016-08-02 * "" ""
           Expenses:Test                           10.00 USD
           Assets:Test
-        """), stdout.getvalue())
+        """), result.stdout)
 
     @test_utils.docfile
     def test_fixed_column(self, filename):
@@ -199,10 +187,7 @@ class TestScriptFormat(test_utils.TestCase):
           Expenses:Test     10.00 USD
           Assets:Test
         """
-        with test_utils.capture() as stdout:
-            result = test_utils.run_with_args(
-                format.main, [filename, '--currency-column=50'])
-        self.assertEqual(0, result)
+        result = self.run_with_args(format.main, filename, '--currency-column=50')
         self.assertEqual(textwrap.dedent("""
         2016-08-01 open Expenses:Test
         2016-08-01 open Assets:Test
@@ -211,7 +196,7 @@ class TestScriptFormat(test_utils.TestCase):
         2016-08-02 * "" ""
           Expenses:Test                            10.00 USD
           Assets:Test
-        """), stdout.getvalue())
+        """), result.stdout)
 
     @test_utils.docfile
     def test_metadata_issue400(self, filename):
@@ -223,10 +208,7 @@ class TestScriptFormat(test_utils.TestCase):
           Assets:Test   10.00 EUR
           Assets:Test  -10.00 EUR
         """
-        with test_utils.capture() as stdout:
-            result = test_utils.run_with_args(
-                format.main, [filename, '--currency-column=50'])
-        self.assertEqual(0, result)
+        result = self.run_with_args(format.main, filename, '--currency-column=50')
         self.assertEqual(textwrap.dedent("""
         2020-01-01 open Assets:Test
 
@@ -234,7 +216,7 @@ class TestScriptFormat(test_utils.TestCase):
           payment_amount: 20.00 EUR
           Assets:Test                              10.00 EUR
           Assets:Test                             -10.00 EUR
-        """), stdout.getvalue())
+        """), result.stdout)
 
     @unittest.skip("Eventually we will want to support arithmetic expressions. "
                    "It will require to invoke the expression parser because "
@@ -250,9 +232,7 @@ class TestScriptFormat(test_utils.TestCase):
           Expenses:Test     10.0/2 USD
           Assets:Test
         """
-        with test_utils.capture() as stdout:
-            result = test_utils.run_with_args(format.main, [filename])
-        self.assertEqual(0, result)
+        result = self.run_with_args(format.main, filename)
         self.assertEqual(textwrap.dedent("""
 
         2016-08-01 open Expenses:Test
@@ -262,7 +242,7 @@ class TestScriptFormat(test_utils.TestCase):
           Expenses:Test     10.0/2 USD
           Assets:Test
 
-        """), stdout.getvalue())
+        """), result.stdout)
 
 
 if __name__ == '__main__':

--- a/beancount/scripts/sql_test.py
+++ b/beancount/scripts/sql_test.py
@@ -44,14 +44,11 @@ ONE_OF_EACH_TYPE = """
 """
 
 
-class TestScriptSQL(test_utils.TestCase):
+class TestScriptSQL(test_utils.ClickTestCase):
 
     def convert_to_sql(self, filename):
         dbfile = tempfile.NamedTemporaryFile('w', suffix='.db')
-        with test_utils.capture('stdout', 'stderr'):
-            result = test_utils.run_with_args(sql.main,
-                                              [filename, dbfile.name])
-        self.assertEqual(0, result)
+        result = self.run_with_args(sql.main, filename, dbfile.name)
         self.assertNotEqual(0, path.getsize(dbfile.name))
         return dbfile
 

--- a/beancount/utils/test_utils.py
+++ b/beancount/utils/test_utils.py
@@ -5,21 +5,23 @@ __license__ = "GNU GPLv2"
 
 import builtins
 import collections
-import textwrap
-import unittest
-import io
-import re
-import tempfile
-import logging
-import sys
 import contextlib
 import functools
-import shutil
+import io
 import itertools
+import logging
 import os
+import re
+import shutil
 import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
 from os import path
 
+import click.testing
 
 # A port allocation global. All the tests should use this global in order to
 # avoid port collisions during testing.
@@ -365,6 +367,14 @@ class TestCase(unittest.TestCase):
         with capture() as oss:
             yield oss
         self.assertLines(textwrap.dedent(expected_text), oss.getvalue())
+
+
+class ClickTestCase(TestCase):
+    def run_with_args(self, function, *args):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(function, args)
+        self.assertEqual(result.exit_code, 0)
+        return result
 
 
 @contextlib.contextmanager

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ httplib2>=0.10
 requests>=2.0
 beautifulsoup4>=4
 python-magic>=0.4.12; sys_platform != 'win32'
+click>=7.0

--- a/setup.py
+++ b/setup.py
@@ -109,17 +109,16 @@ install_requires = [
     # programmatically and to upload lists of holdings to a Google
     # Spreadsheet for live intra-day monitoring.
     'google-api-python-client',
+
+    # This library is needed to identify the type of a file for
+    # import. It uses ctypes to wrap the libmagic library which is
+    # not generally available on Windows nor is easily installed,
+    # thus the conditional dependency.
+    'python-magic; sys_platform != "win32"',
+
+    # Command line parsing.
+    'click',
 ]
-
-if sys.platform != 'win32':
-    install_requires += [
-        # This library is needed to identify the type of a file for
-        # import. It uses ctypes to wrap the libmagic library which is
-        # not generally available on Windows nor is easily installed,
-        # thus the conditional dependency.
-        'python-magic',
-    ]
-
 
 # Create a setup.
 # Please read: http://furius.ca/beancount/doc/install about version numbers.


### PR DESCRIPTION
This converts the ingest mechanism and `bean-doctor` to use Click for command line parsing. Other scripts can be converted later. I did some copy editing of the help strings for the commands of `bean-doctor` but some more could be done.

I haven't decided yet if it is better to name the file argument `FILENAME` or `LEDGER`. The first may be a tiny bit clearer, but the second allows for nicer help text: `Read transaction from ledger FILENAME` vs `Read transactions from LEDGER`.

I hope I haven't introduced any bug rebasing the PR.