### PR TITLE
ci: Move pylint to its own CI job

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,0 +1,17 @@
+name: linting
+
+on:
+  [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - run: pip install -r requirements_dev.txt
+      - run: make lint

--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -25,6 +25,3 @@ jobs:
         # little value in running them for different Python version.
         if: ${{ matrix.python == '3.9' }}
       - run: make test
-      - run: make lint
-        # There is no need to run pylint with all Python versions.
-        if: ${{ matrix.python == '3.9' }}


### PR DESCRIPTION
This should allow pyling to run in parrallel to the other CI jobs and
provide more immediate feedback whether the test failure is due to
pylint or something else.