### PR TITLE
setup: fix gcc error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def get_cflags():
         # See https://bitbucket.org/blais/beancount/issues/173/
         return ["-DYY_NO_UNISTD_H"]
     else:
-        return None
+        return ["-std=c99"]
 
 # Read the version.
 with open("beancount/VERSION") as version_file:


### PR DESCRIPTION
beancount/parser/tokens.c:174:5:error: 'for' loop initial declaration used outside C99 mode