### PR TITLE
printer: Ignore all metadata fields whose key starts with "__"

### DIFF
--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -124,7 +124,7 @@ class EntryPrinter:
         method(obj, oss)
         return oss.getvalue()
 
-    META_IGNORE = set(['filename', 'lineno', '__automatic__'])
+    META_IGNORE = {'filename', 'lineno'}
 
     def write_metadata(self, meta, oss, prefix=None):
         """Write metadata to the file object, excluding filename and line number.
@@ -138,7 +138,7 @@ class EntryPrinter:
         if prefix is None:
             prefix = self.prefix
         for key, value in sorted(meta.items()):
-            if key not in self.META_IGNORE:
+            if key not in self.META_IGNORE and not key.startswith('__'):
                 value_str = None
                 if isinstance(value, str):
                     value_str = '"{}"'.format(misc_utils.escape_string(value))


### PR DESCRIPTION
Fields with key `__automatic__` are already ignored. Extend this to
all field with a key starting with `__`. This allows to to use such
entries for attaching extra information to the entries, without having
to explicitly remove it before serializing the entries to file. The
immediate use is for markign duplicate entries identified during the
import process with a `__duplicate__` metadata field.

The `filename` and `lineno` metadata fields could be renamed to obey
to this scheme too and the special handling removed, but this requires
modifying the parser.