### PR TITLE
use env marker in `install_require`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,17 +120,13 @@ install_requires = [
     # programmatically and to upload lists of holdings to a Google
     # Spreadsheet for live intra-day monitoring.
     'google-api-python-client',
+  
+    # This library is needed to identify the type of a file for
+    # import. It uses ctypes to wrap the libmagic library which is
+    # not generally available on Windows nor is easily installed,
+    # thus the conditional dependency.
+    'python-magic>=0.4.12; sys_platform != "win32"'
 ]
-
-if sys.platform != 'win32':
-    install_requires += [
-        # This library is needed to identify the type of a file for
-        # import. It uses ctypes to wrap the libmagic library which is
-        # not generally available on Windows nor is easily installed,
-        # thus the conditional dependency.
-        'python-magic',
-    ]
-
 
 # Create a setup.
 # Please read: http://furius.ca/beancount/doc/install about version numbers.


### PR DESCRIPTION
This avoids some installer dependence resolve bug that can't detect `python-magic` isn't required on windows.