### PR TITLE
query: Fix meta() BQL function when used in the FROM clause

### DIFF
--- a/beancount/query/query_env.py
+++ b/beancount/query/query_env.py
@@ -355,7 +355,7 @@ class Meta(query_compile.EvalFunction):
 
     def __call__(self, context):
         args = self.eval_args(context)
-        meta = context.posting.meta
+        meta = context.posting.meta if context.posting else None
         if meta is None:
             return None
         return meta.get(args[0], None)


### PR DESCRIPTION
Using the BQL meta() function is the query FROM clause does not make
much sense as there are no posting to operate on in this context, only
entries, but raising an exception does not seem useful. Make meta()
simply return None in this context.

The issue in in master and in beanquery too, but these start to be too many places where to apply the same fix.