### PR TITLE
Reduce dependencies

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
-      - run: pip install -r requirements_dev.txt
+      - run: pip install -r requirements/dev.txt
       - run: make lint

--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - run: pip install -r requirements_dev.txt
+      - run: pip install -r requirements/dev.txt
       - run: python setup.py build_ext -i
       - run: make ctest
         env:

--- a/beancount/parser/cmptest.py
+++ b/beancount/parser/cmptest.py
@@ -7,8 +7,6 @@ import unittest
 import io
 import textwrap
 
-import pytest
-
 from beancount.core import amount
 from beancount.core import compare
 from beancount.core import data
@@ -138,117 +136,109 @@ def _transform_incomplete_amount(amt):
     return amt
 
 
-
-
 class TestCase(unittest.TestCase):
 
-    def assertEqualEntries(self, expected_entries, actual_entries):
-        return assertEqualEntries(expected_entries, actual_entries, self.fail)
-    def assertIncludesEntries(self, subset_entries, entries):
-        return assertIncludesEntries(subset_entries, entries, self.fail)
-    def assertExcludesEntries(self, subset_entries, entries):
-        return assertExcludesEntries(subset_entries, entries, self.fail)
+    def assertEqualEntries(self, expected_entries, actual_entries, allow_incomplete=False):
+        """Check that two lists of entries are equal.
 
+        Entries can be provided either as a list of directives or as a
+        string.  In the latter case, the string is parsed with
+        beancount.parser.parse_string() and the resulting directives
+        list is used. If allow_incomplete is True, light-weight
+        booking is performed before comparing the directive lists,
+        allowing to compare transactions with incomplete postings.
 
-DEFAULT_FAILFUNC = pytest.fail
+        Args:
+          expected_entries: Expected entries.
+          actual_entries: Actual entries.
+          allow_incomplete: Perform booking before comparison.
 
+        Raises:
+          AssertionError: If the exception fails.
 
-def assertEqualEntries(expected_entries, actual_entries,
-                       failfunc=DEFAULT_FAILFUNC, allow_incomplete=False):
-    """Compare two lists of entries exactly and print missing entries verbosely if
-    they occur.
+        """
+        expected_entries = read_string_or_entries(expected_entries, allow_incomplete)
+        actual_entries = read_string_or_entries(actual_entries, allow_incomplete)
 
-    Args:
-      expected_entries: Either a list of directives or a string, in which case the
-        string is run through beancount.parser.parse_string() and the resulting
-        list is used.
-      actual_entries: Same treatment as expected_entries, the other list of
-        directives to compare to.
-      failfunc: A function to call on failure.
-      allow_incomplete: A boolean, true if we allow incomplete inputs and perform
-        light-weight booking.
-    Raises:
-      AssertionError: If the exception fails.
-    """
-    expected_entries = read_string_or_entries(expected_entries, allow_incomplete)
-    actual_entries = read_string_or_entries(actual_entries, allow_incomplete)
+        same, expected_missing, actual_missing = compare.compare_entries(expected_entries, actual_entries)
+        if not same:
+            assert expected_missing or actual_missing, \
+                "Missing is missing: {}, {}".format(expected_missing, actual_missing)
+            oss = io.StringIO()
+            if expected_missing:
+                oss.write("Present in expected set and not in actual set:\n\n")
+                for entry in expected_missing:
+                    oss.write(printer.format_entry(entry))
+                    oss.write('\n')
+            if actual_missing:
+                oss.write("Present in actual set and not in expected set:\n\n")
+                for entry in actual_missing:
+                    oss.write(printer.format_entry(entry))
+                    oss.write('\n')
+            self.fail(oss.getvalue())
 
-    same, expected_missing, actual_missing = compare.compare_entries(expected_entries,
-                                                                     actual_entries)
-    if not same:
-        assert expected_missing or actual_missing, "Missing is missing: {}, {}".format(
-            expected_missing, actual_missing)
-        oss = io.StringIO()
-        if expected_missing:
-            oss.write("Present in expected set and not in actual set:\n\n")
-            for entry in expected_missing:
-                oss.write(printer.format_entry(entry))
-                oss.write('\n')
-        if actual_missing:
-            oss.write("Present in actual set and not in expected set:\n\n")
-            for entry in actual_missing:
-                oss.write(printer.format_entry(entry))
-                oss.write('\n')
-        failfunc(oss.getvalue())
+    def assertIncludesEntries(self, subset_entries, entries, allow_incomplete=False):
+        """Check that subset_entries is included in entries.
 
+        Entries can be provided either as a list of directives or as a
+        string.  In the latter case, the string is parsed with
+        beancount.parser.parse_string() and the resulting directives
+        list is used. If allow_incomplete is True, light-weight
+        booking is performed before comparing the directive lists,
+        allowing to compare transactions with incomplete postings.
 
-def assertIncludesEntries(subset_entries, entries,
-                          failfunc=DEFAULT_FAILFUNC, allow_incomplete=False):
-    """Check that subset_entries is included in entries and print missing entries.
+        Args:
+          subset_entries: Subset entries.
+          entries: Entries.
+          allow_incomplete: Perform booking before comparison.
 
-    Args:
-      subset_entries: Either a list of directives or a string, in which case the
-        string is run through beancount.parser.parse_string() and the resulting
-        list is used.
-      entries: Same treatment as subset_entries, the other list of
-        directives to compare to.
-      failfunc: A function to call on failure.
-      allow_incomplete: A boolean, true if we allow incomplete inputs and perform
-        light-weight booking.
-    Raises:
-      AssertionError: If the exception fails.
-    """
-    subset_entries = read_string_or_entries(subset_entries, allow_incomplete)
-    entries = read_string_or_entries(entries)
+        Raises:
+          AssertionError: If the exception fails.
 
-    includes, missing = compare.includes_entries(subset_entries, entries)
-    if not includes:
-        assert missing, "Missing is empty: {}".format(missing)
-        oss = io.StringIO()
-        if missing:
-            oss.write("Missing from from expected set:\n\n")
-            for entry in missing:
-                oss.write(printer.format_entry(entry))
-                oss.write('\n')
-        failfunc(oss.getvalue())
+        """
+        subset_entries = read_string_or_entries(subset_entries, allow_incomplete)
+        entries = read_string_or_entries(entries)
 
+        includes, missing = compare.includes_entries(subset_entries, entries)
+        if not includes:
+            assert missing, "Missing is empty: {}".format(missing)
+            oss = io.StringIO()
+            if missing:
+                oss.write("Missing from from expected set:\n\n")
+                for entry in missing:
+                    oss.write(printer.format_entry(entry))
+                    oss.write('\n')
+            self.fail(oss.getvalue())
 
-def assertExcludesEntries(subset_entries, entries,
-                          failfunc=DEFAULT_FAILFUNC, allow_incomplete=False):
-    """Check that subset_entries is not included in entries and print extra entries.
+    def assertExcludesEntries(self, subset_entries, entries, allow_incomplete=False):
+        """Check that subset_entries is not included in entries.
 
-    Args:
-      subset_entries: Either a list of directives or a string, in which case the
-        string is run through beancount.parser.parse_string() and the resulting
-        list is used.
-      entries: Same treatment as subset_entries, the other list of
-        directives to compare to.
-      failfunc: A function to call on failure.
-      allow_incomplete: A boolean, true if we allow incomplete inputs and perform
-        light-weight booking.
-    Raises:
-      AssertionError: If the exception fails.
-    """
-    subset_entries = read_string_or_entries(subset_entries, allow_incomplete)
-    entries = read_string_or_entries(entries)
+        Entries can be provided either as a list of directives or as a
+        string. In the latter case, the string is parsed with
+        beancount.parser.parse_string() and the resulting directives
+        list is used. If allow_incomplete is True, light-weight
+        booking is performed before comparing the directive lists,
+        allowing to compare transactions with incomplete postings.
 
-    excludes, extra = compare.excludes_entries(subset_entries, entries)
-    if not excludes:
-        assert extra, "Extra is empty: {}".format(extra)
-        oss = io.StringIO()
-        if extra:
-            oss.write("Extra from from first/excluded set:\n\n")
-            for entry in extra:
-                oss.write(printer.format_entry(entry))
-                oss.write('\n')
-        failfunc(oss.getvalue())
+        Args:
+          subset_entries: Subset entries.
+          entries: Entries.
+          allow_incomplete: Perform booking before comparison.
+
+        Raises:
+          AssertionError: If the exception fails.
+
+        """
+        subset_entries = read_string_or_entries(subset_entries, allow_incomplete)
+        entries = read_string_or_entries(entries)
+
+        excludes, extra = compare.excludes_entries(subset_entries, entries)
+        if not excludes:
+            assert extra, "Extra is empty: {}".format(extra)
+            oss = io.StringIO()
+            if extra:
+                oss.write("Extra from from first/excluded set:\n\n")
+                for entry in extra:
+                    oss.write(printer.format_entry(entry))
+                    oss.write('\n')
+            self.fail(oss.getvalue())

--- a/beancount/parser/parser_test.py
+++ b/beancount/parser/parser_test.py
@@ -11,8 +11,6 @@ import textwrap
 import sys
 import subprocess
 
-from pytest import mark
-
 from beancount.core.number import D
 from beancount.core import data
 from beancount.parser import parser, _parser, lexer, grammar
@@ -49,7 +47,7 @@ class TestParserDoc(unittest.TestCase):
         self.assertTrue(errors)
 
     @unittest.skipIf('/bazel/' in __file__, "Skipping test in Bazel")
-    @mark.xfail
+    @unittest.expectedFailure
     @parser.parse_doc(expect_errors=False)
     def test_parse_doc__errors(self, _, __, ___):
         """
@@ -59,7 +57,7 @@ class TestParserDoc(unittest.TestCase):
         """
 
     @unittest.skipIf('/bazel/' in __file__, "Skipping test in Bazel")
-    @mark.xfail
+    @unittest.expectedFailure
     @parser.parse_doc(expect_errors=True)
     def test_parse_doc__noerrors(self, _, __, ___):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
 python-dateutil>=2.6.0
 ply>=3.4
 lxml>=3.0
-google-api-python-client>=1.8.2
-google_auth_oauthlib>=0.4.2
-oauth2client>=4.0
-httplib2>=0.10
-requests>=2.0
 click>=7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-python-dateutil>=2.6.0
-ply>=3.4
-lxml>=3.0
-click>=7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
--r requirements.txt
+-r tools.txt
 pylint>=2.6.0
 pylint_protobuf>=0.13
 pytest>=6.0.2

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -1,0 +1,9 @@
+click>=7.0
+google-api-python-client>=1.8.2
+google_auth_oauthlib>=0.4.2
+httplib2>=0.10
+lxml>=3.0
+oauth2client>=4.0
+ply>=3.4
+python-dateutil>=2.6.0
+requests>=2.0

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,6 @@ else:
 
 
 install_requires = [
-    # Testing support now uses the pytest module.
-    'pytest',
-
     # This is required to parse dates from command-line options in a
     # loose, accepting format. Note that we use dateutil for timezone
     # database definitions as well, although it is inferior to pytz, but

--- a/setup.py
+++ b/setup.py
@@ -97,11 +97,6 @@ install_requires = [
     # The SQL parser uses PLY in order to parse the input syntax.
     'ply',
 
-    # This library is used to download and convert the documentation
-    # programmatically and to upload lists of holdings to a Google
-    # Spreadsheet for live intra-day monitoring.
-    'google-api-python-client',
-
     # Command line parsing.
     'click',
 ]


### PR DESCRIPTION
Now that `upload-to-sheets` has been moved we can reduce the list of dependencies significantly. There is still an optional but somehow large and somehow obscure dependency on `lxml` that may need some more thought.