### PR TITLE
parser: Stop pretending we support encodings other than UTF-8

### DIFF
--- a/beancount/loader_test.py
+++ b/beancount/loader_test.py
@@ -388,8 +388,8 @@ class TestLoadIncludesEncrypted(encryption_test.TestEncryptedBase):
 
         self.assertFalse(errors)
         self.assertEqual(2, len(entries))
-        self.assertRegex(entries[0].meta['filename'], 'apples.beancount')
-        self.assertRegex(entries[1].meta['filename'], 'oranges.+count.asc')
+        self.assertTrue(entries[0].meta['filename'].endswith('/apples.beancount'))
+        self.assertTrue(entries[1].meta['filename'].endswith('/oranges.beancount.asc'))
 
 
 class TestLoadCache(unittest.TestCase):
@@ -547,25 +547,6 @@ class TestLoadCache(unittest.TestCase):
                 filename = path.join(tmp, 'apples.beancount')
                 entries, errors, options_map = loader.load_file(filename)
                 self.assertEqual({'apples.beancount'}, set(os.listdir(tmp)))
-
-
-class TestEncoding(unittest.TestCase):
-
-    def test_string_unicode(self):
-        utf8_bytes = textwrap.dedent("""
-          2015-01-01 open Assets:Something
-          2015-05-23 note Assets:Something "¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼ "
-        """).encode('utf-8')
-        entries, errors, options_map = loader.load_string(utf8_bytes, encoding='utf8')
-        self.assertFalse(errors)
-
-    def test_string_latin1(self):
-        utf8_bytes = textwrap.dedent("""
-          2015-01-01 open Assets:Something
-          2015-05-23 note Assets:Something "¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼ "
-        """).encode('latin1')
-        entries, errors, options_map = loader.load_string(utf8_bytes, encoding='latin1')
-        self.assertFalse(errors)
 
 
 class TestOptionsAggregation(unittest.TestCase):

--- a/beancount/parser/grammar.c
+++ b/beancount/parser/grammar.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.7.5.  */
+/* A Bison parser, made by GNU Bison 3.7.6.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -16,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -46,10 +46,10 @@
    USER NAME SPACE" below.  */
 
 /* Identify Bison output, and Bison version.  */
-#define YYBISON 30705
+#define YYBISON 30706
 
 /* Bison version string.  */
-#define YYBISON_VERSION "3.7.5"
+#define YYBISON_VERSION "3.7.6"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"

--- a/beancount/parser/grammar.h
+++ b/beancount/parser/grammar.h
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.7.5.  */
+/* A Bison parser, made by GNU Bison 3.7.6.  */
 
 /* Bison interface for Yacc-like parsers in C
 
@@ -16,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work

--- a/beancount/parser/lexer.c
+++ b/beancount/parser/lexer.c
@@ -1,4 +1,4 @@
-#line 2 "beancount/parser/lexer.c"
+#line 1 "beancount/parser/lexer.c"
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
@@ -6,14 +6,11 @@
 typedef struct _yyextra_t yyextra_t;
 
 struct _yyextra_t {
-  /* The filename being tokenized. */
-  PyObject* filename;
+    /* The filename being tokenized. */
+    PyObject* filename;
 
-  /* The encoding to use for converting strings. */
-  const char* encoding;
-
-  /* A reference to the beancount.core.number.MISSING object */
-  PyObject* missing_obj;
+    /* A reference to the beancount.core.number.MISSING object */
+    PyObject* missing_obj;
 };
 
 #ifndef YY_TYPEDEF_YY_SCANNER_T
@@ -43,18 +40,16 @@ yyscan_t yylex_free(yyscan_t scanner);
 /**
  * Initialize scanner private data.
  *
- * Setup @scanner to read from the Python file-like object @file. Set
- * the reported file name to @filename, if not NULL and not None.
- * Otherwise try to obtain the file name from the @name attribute of
- * the @file object. If this fails, use the empty string. @encoding is
- * used to decode strings read from the input file, if not NULL,
- * otherwise the default UTF-8 encoding is used. Python objects
- * references are incremented. It is safe to call this multiple times.
+ * Setup @scanner to read from the Python file-like object @file. Set the
+ * reported file name to @filename, if not NULL and not None. Otherwise try to
+ * obtain the file name from the @name attribute of the @file object. If this
+ * fails, use the empty string. Python objects references are incremented. It
+ * is safe to call this multiple times.
  */
 void yylex_initialize(PyObject* file, PyObject* filename, int lineno,
-                      const char* encoding, PyObject* missing_obj, yyscan_t scanner);
+                      PyObject* missing_obj, yyscan_t scanner);
 
-#line 58 "beancount/parser/lexer.c"
+#line 52 "beancount/parser/lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -825,7 +820,7 @@ static const flex_int32_t yy_rule_can_match_eol[61] =
 /* Top code. This is included in the generated header file. */
 
 /* Definitions. */
-#line 80 "beancount/parser/lexer.l"
+#line 75 "beancount/parser/lexer.l"
 
 #include <math.h>
 #include <stdlib.h>
@@ -862,12 +857,12 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size);
         yycolumn += yyleng;                                   \
     }
 
-#line 866 "beancount/parser/lexer.c"
+#line 860 "beancount/parser/lexer.c"
 
-#line 133 "beancount/parser/lexer.l"
+#line 128 "beancount/parser/lexer.l"
  /* Characters that may be used as flags. Single-character letters may also be
   * used as flags, but must be prefixed by a quote, as in "'P' for "P". */
-#line 871 "beancount/parser/lexer.c"
+#line 865 "beancount/parser/lexer.c"
 
 #define INITIAL 0
 #define INVALID 1
@@ -1154,11 +1149,11 @@ YY_DECL
 		}
 
 	{
-#line 137 "beancount/parser/lexer.l"
+#line 132 "beancount/parser/lexer.l"
 
 
  /* Newlines matter. */
-#line 1162 "beancount/parser/lexer.c"
+#line 1156 "beancount/parser/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1227,7 +1222,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 140 "beancount/parser/lexer.l"
+#line 135 "beancount/parser/lexer.l"
 {
     yycolumn = 1;
     return EOL;
@@ -1241,38 +1236,38 @@ case 2:
 yyg->yy_c_buf_p = yy_cp -= 1;
 YY_DO_BEFORE_ACTION; /* set up yytext again */
 YY_RULE_SETUP
-#line 148 "beancount/parser/lexer.l"
+#line 143 "beancount/parser/lexer.l"
 { return INDENT; }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 149 "beancount/parser/lexer.l"
+#line 144 "beancount/parser/lexer.l"
 { }
 	YY_BREAK
 /* Comments. */
 case 4:
 YY_RULE_SETUP
-#line 152 "beancount/parser/lexer.l"
+#line 147 "beancount/parser/lexer.l"
 { }
 	YY_BREAK
 /* Boolean values. Must be before currencies. */
 case 5:
 YY_RULE_SETUP
-#line 155 "beancount/parser/lexer.l"
+#line 150 "beancount/parser/lexer.l"
 {
     return TOKEN(BOOL, true);
 }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 159 "beancount/parser/lexer.l"
+#line 154 "beancount/parser/lexer.l"
 {
     return TOKEN(BOOL, false);
 }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 163 "beancount/parser/lexer.l"
+#line 158 "beancount/parser/lexer.l"
 {
     return TOKEN(NONE);
 }
@@ -1316,14 +1311,14 @@ YY_RULE_SETUP
   */
 case 8:
 YY_RULE_SETUP
-#line 204 "beancount/parser/lexer.l"
+#line 199 "beancount/parser/lexer.l"
 {
     return TOKEN(CURRENCY, yytext, yyleng);
 }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 207 "beancount/parser/lexer.l"
+#line 202 "beancount/parser/lexer.l"
 {
     return TOKEN(CURRENCY, yytext, yyleng);
 }
@@ -1331,92 +1326,92 @@ YY_RULE_SETUP
 /* Characters with special meanings. */
 case 10:
 YY_RULE_SETUP
-#line 212 "beancount/parser/lexer.l"
+#line 207 "beancount/parser/lexer.l"
 { return PIPE; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 213 "beancount/parser/lexer.l"
+#line 208 "beancount/parser/lexer.l"
 { return ATAT; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 214 "beancount/parser/lexer.l"
+#line 209 "beancount/parser/lexer.l"
 { return AT; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 215 "beancount/parser/lexer.l"
+#line 210 "beancount/parser/lexer.l"
 { return LCURLCURL; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 216 "beancount/parser/lexer.l"
+#line 211 "beancount/parser/lexer.l"
 { return RCURLCURL; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 217 "beancount/parser/lexer.l"
+#line 212 "beancount/parser/lexer.l"
 { return LCURL; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 218 "beancount/parser/lexer.l"
+#line 213 "beancount/parser/lexer.l"
 { return RCURL; }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 219 "beancount/parser/lexer.l"
+#line 214 "beancount/parser/lexer.l"
 { return COMMA; }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 220 "beancount/parser/lexer.l"
+#line 215 "beancount/parser/lexer.l"
 { return TILDE; }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 221 "beancount/parser/lexer.l"
+#line 216 "beancount/parser/lexer.l"
 { return PLUS; }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 222 "beancount/parser/lexer.l"
+#line 217 "beancount/parser/lexer.l"
 { return MINUS; }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 223 "beancount/parser/lexer.l"
+#line 218 "beancount/parser/lexer.l"
 { return SLASH; }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 224 "beancount/parser/lexer.l"
+#line 219 "beancount/parser/lexer.l"
 { return LPAREN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 225 "beancount/parser/lexer.l"
+#line 220 "beancount/parser/lexer.l"
 { return RPAREN; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 226 "beancount/parser/lexer.l"
+#line 221 "beancount/parser/lexer.l"
 { return HASH; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 227 "beancount/parser/lexer.l"
+#line 222 "beancount/parser/lexer.l"
 { return ASTERISK; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 228 "beancount/parser/lexer.l"
+#line 223 "beancount/parser/lexer.l"
 { return COLON; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 230 "beancount/parser/lexer.l"
+#line 225 "beancount/parser/lexer.l"
 {
     yylval->character = yytext[0];
     return FLAG;
@@ -1424,7 +1419,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 234 "beancount/parser/lexer.l"
+#line 229 "beancount/parser/lexer.l"
 {
     yylval->character = yytext[1];
     return FLAG;
@@ -1433,103 +1428,103 @@ YY_RULE_SETUP
 /* Keywords. */
 case 29:
 YY_RULE_SETUP
-#line 240 "beancount/parser/lexer.l"
+#line 235 "beancount/parser/lexer.l"
 { return TXN; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 241 "beancount/parser/lexer.l"
+#line 236 "beancount/parser/lexer.l"
 { return BALANCE; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 242 "beancount/parser/lexer.l"
+#line 237 "beancount/parser/lexer.l"
 { return OPEN; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 243 "beancount/parser/lexer.l"
+#line 238 "beancount/parser/lexer.l"
 { return CLOSE; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 244 "beancount/parser/lexer.l"
+#line 239 "beancount/parser/lexer.l"
 { return COMMODITY; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 245 "beancount/parser/lexer.l"
+#line 240 "beancount/parser/lexer.l"
 { return PAD; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 246 "beancount/parser/lexer.l"
+#line 241 "beancount/parser/lexer.l"
 { return EVENT; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 247 "beancount/parser/lexer.l"
+#line 242 "beancount/parser/lexer.l"
 { return QUERY; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 248 "beancount/parser/lexer.l"
+#line 243 "beancount/parser/lexer.l"
 { return CUSTOM; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 249 "beancount/parser/lexer.l"
+#line 244 "beancount/parser/lexer.l"
 { return PRICE; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 250 "beancount/parser/lexer.l"
+#line 245 "beancount/parser/lexer.l"
 { return NOTE; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 251 "beancount/parser/lexer.l"
+#line 246 "beancount/parser/lexer.l"
 { return DOCUMENT; }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 252 "beancount/parser/lexer.l"
+#line 247 "beancount/parser/lexer.l"
 { return PUSHTAG; }
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 253 "beancount/parser/lexer.l"
+#line 248 "beancount/parser/lexer.l"
 { return POPTAG; }
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 254 "beancount/parser/lexer.l"
+#line 249 "beancount/parser/lexer.l"
 { return PUSHMETA; }
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 255 "beancount/parser/lexer.l"
+#line 250 "beancount/parser/lexer.l"
 { return POPMETA; }
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 256 "beancount/parser/lexer.l"
+#line 251 "beancount/parser/lexer.l"
 { return OPTION; }
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 257 "beancount/parser/lexer.l"
+#line 252 "beancount/parser/lexer.l"
 { return PLUGIN; }
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 258 "beancount/parser/lexer.l"
+#line 253 "beancount/parser/lexer.l"
 { return INCLUDE; }
 	YY_BREAK
 /* Dates. */
 case 48:
 YY_RULE_SETUP
-#line 261 "beancount/parser/lexer.l"
+#line 256 "beancount/parser/lexer.l"
 {
     return TOKEN(DATE, yytext);
 }
@@ -1537,7 +1532,7 @@ YY_RULE_SETUP
 /* Account names. */
 case 49:
 YY_RULE_SETUP
-#line 266 "beancount/parser/lexer.l"
+#line 261 "beancount/parser/lexer.l"
 {
     return TOKEN(ACCOUNT, yytext);
 }
@@ -1546,15 +1541,15 @@ YY_RULE_SETUP
 case 50:
 /* rule 50 can match eol */
 YY_RULE_SETUP
-#line 271 "beancount/parser/lexer.l"
+#line 266 "beancount/parser/lexer.l"
 {
-    return TOKEN(STRING, yytext + 1, yyleng - 2, yyget_extra(yyscanner)->encoding);
+    return TOKEN(STRING, yytext + 1, yyleng - 2);
 }
 	YY_BREAK
 /* Numbers. */
 case 51:
 YY_RULE_SETUP
-#line 276 "beancount/parser/lexer.l"
+#line 271 "beancount/parser/lexer.l"
 {
     return TOKEN(NUMBER, yytext);
 }
@@ -1562,7 +1557,7 @@ YY_RULE_SETUP
 /* Tags. */
 case 52:
 YY_RULE_SETUP
-#line 281 "beancount/parser/lexer.l"
+#line 276 "beancount/parser/lexer.l"
 {
     return TOKEN(TAG, yytext + 1, yyleng - 1);
 }
@@ -1570,7 +1565,7 @@ YY_RULE_SETUP
 /* Links. */
 case 53:
 YY_RULE_SETUP
-#line 286 "beancount/parser/lexer.l"
+#line 281 "beancount/parser/lexer.l"
 {
     return TOKEN(LINK, yytext + 1, yyleng - 1);
 }
@@ -1581,7 +1576,7 @@ case 54:
 yyg->yy_c_buf_p = yy_cp -= 1;
 YY_DO_BEFORE_ACTION; /* set up yytext again */
 YY_RULE_SETUP
-#line 291 "beancount/parser/lexer.l"
+#line 286 "beancount/parser/lexer.l"
 {
     return TOKEN(KEY, yytext, yyleng);
 }
@@ -1594,7 +1589,7 @@ case 55:
 yyg->yy_c_buf_p = yy_cp = yy_bp + 1;
 YY_DO_BEFORE_ACTION; /* set up yytext again */
 YY_RULE_SETUP
-#line 298 "beancount/parser/lexer.l"
+#line 293 "beancount/parser/lexer.l"
 { BEGIN(IGNORE); }
 	YY_BREAK
 case 56:
@@ -1602,13 +1597,13 @@ case 56:
 yyg->yy_c_buf_p = yy_cp = yy_bp + 1;
 YY_DO_BEFORE_ACTION; /* set up yytext again */
 YY_RULE_SETUP
-#line 299 "beancount/parser/lexer.l"
+#line 294 "beancount/parser/lexer.l"
 { BEGIN(IGNORE); }
 	YY_BREAK
 /* Default rule. {bf253a29a820} */
 case 57:
 YY_RULE_SETUP
-#line 302 "beancount/parser/lexer.l"
+#line 297 "beancount/parser/lexer.l"
 {
     unput(*yytext);
     BEGIN(INVALID);
@@ -1617,7 +1612,7 @@ YY_RULE_SETUP
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(INVALID):
 case YY_STATE_EOF(IGNORE):
-#line 307 "beancount/parser/lexer.l"
+#line 302 "beancount/parser/lexer.l"
 {
     /* Ensure location data is populated. */
     YY_USER_ACTION;
@@ -1627,7 +1622,7 @@ case YY_STATE_EOF(IGNORE):
 /* Ivalid input: skip over to to the next whitespace character. */
 case 58:
 YY_RULE_SETUP
-#line 314 "beancount/parser/lexer.l"
+#line 309 "beancount/parser/lexer.l"
 {
     PyObject* input = PyUnicode_Decode(yytext, yyleng, "utf-8", "backslashreplace");
     build_lexer_error(yylloc, builder, "Invalid token: '%U'", input);
@@ -1638,17 +1633,17 @@ YY_RULE_SETUP
 /* Ignore input till the newline. */
 case 59:
 YY_RULE_SETUP
-#line 321 "beancount/parser/lexer.l"
+#line 316 "beancount/parser/lexer.l"
 {
     BEGIN(INITIAL);
 }
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 325 "beancount/parser/lexer.l"
+#line 320 "beancount/parser/lexer.l"
 ECHO;
 	YY_BREAK
-#line 1652 "beancount/parser/lexer.c"
+#line 1646 "beancount/parser/lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -2853,7 +2848,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 325 "beancount/parser/lexer.l"
+#line 320 "beancount/parser/lexer.l"
 
 
 yyscan_t yylex_new(void)
@@ -2899,7 +2894,7 @@ static void yybegin(yyscan_t scanner)
 }
 
 void yylex_initialize(PyObject* file, PyObject* filename, int lineno,
-                      const char* encoding, PyObject* missing_obj, yyscan_t scanner)
+                      PyObject* missing_obj, yyscan_t scanner)
 {
     yyextra_t* extra = yyget_extra(scanner);
 
@@ -2919,8 +2914,6 @@ void yylex_initialize(PyObject* file, PyObject* filename, int lineno,
 
     Py_XDECREF(extra->filename);
     extra->filename = filename;
-
-    extra->encoding = encoding ? encoding : "utf-8";
 
     extra->missing_obj = missing_obj;
 

--- a/beancount/parser/lexer.h
+++ b/beancount/parser/lexer.h
@@ -2,7 +2,7 @@
 #define yyHEADER_H 1
 #define yyIN_HEADER 1
 
-#line 6 "beancount/parser/lexer.h"
+#line 5 "beancount/parser/lexer.h"
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
@@ -10,14 +10,11 @@
 typedef struct _yyextra_t yyextra_t;
 
 struct _yyextra_t {
-  /* The filename being tokenized. */
-  PyObject* filename;
+    /* The filename being tokenized. */
+    PyObject* filename;
 
-  /* The encoding to use for converting strings. */
-  const char* encoding;
-
-  /* A reference to the beancount.core.number.MISSING object */
-  PyObject* missing_obj;
+    /* A reference to the beancount.core.number.MISSING object */
+    PyObject* missing_obj;
 };
 
 #ifndef YY_TYPEDEF_YY_SCANNER_T
@@ -47,18 +44,16 @@ yyscan_t yylex_free(yyscan_t scanner);
 /**
  * Initialize scanner private data.
  *
- * Setup @scanner to read from the Python file-like object @file. Set
- * the reported file name to @filename, if not NULL and not None.
- * Otherwise try to obtain the file name from the @name attribute of
- * the @file object. If this fails, use the empty string. @encoding is
- * used to decode strings read from the input file, if not NULL,
- * otherwise the default UTF-8 encoding is used. Python objects
- * references are incremented. It is safe to call this multiple times.
+ * Setup @scanner to read from the Python file-like object @file. Set the
+ * reported file name to @filename, if not NULL and not None. Otherwise try to
+ * obtain the file name from the @name attribute of the @file object. If this
+ * fails, use the empty string. Python objects references are incremented. It
+ * is safe to call this multiple times.
  */
 void yylex_initialize(PyObject* file, PyObject* filename, int lineno,
-                      const char* encoding, PyObject* missing_obj, yyscan_t scanner);
+                      PyObject* missing_obj, yyscan_t scanner);
 
-#line 62 "beancount/parser/lexer.h"
+#line 56 "beancount/parser/lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -572,9 +567,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 325 "beancount/parser/lexer.l"
+#line 320 "beancount/parser/lexer.l"
 
 
-#line 579 "beancount/parser/lexer.h"
+#line 573 "beancount/parser/lexer.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -25,14 +25,11 @@
 typedef struct _yyextra_t yyextra_t;
 
 struct _yyextra_t {
-  /* The filename being tokenized. */
-  PyObject* filename;
+    /* The filename being tokenized. */
+    PyObject* filename;
 
-  /* The encoding to use for converting strings. */
-  const char* encoding;
-
-  /* A reference to the beancount.core.number.MISSING object */
-  PyObject* missing_obj;
+    /* A reference to the beancount.core.number.MISSING object */
+    PyObject* missing_obj;
 };
 
 #ifndef YY_TYPEDEF_YY_SCANNER_T
@@ -62,16 +59,14 @@ yyscan_t yylex_free(yyscan_t scanner);
 /**
  * Initialize scanner private data.
  *
- * Setup @scanner to read from the Python file-like object @file. Set
- * the reported file name to @filename, if not NULL and not None.
- * Otherwise try to obtain the file name from the @name attribute of
- * the @file object. If this fails, use the empty string. @encoding is
- * used to decode strings read from the input file, if not NULL,
- * otherwise the default UTF-8 encoding is used. Python objects
- * references are incremented. It is safe to call this multiple times.
+ * Setup @scanner to read from the Python file-like object @file. Set the
+ * reported file name to @filename, if not NULL and not None. Otherwise try to
+ * obtain the file name from the @name attribute of the @file object. If this
+ * fails, use the empty string. Python objects references are incremented. It
+ * is safe to call this multiple times.
  */
 void yylex_initialize(PyObject* file, PyObject* filename, int lineno,
-                      const char* encoding, PyObject* missing_obj, yyscan_t scanner);
+                      PyObject* missing_obj, yyscan_t scanner);
 
 }
 
@@ -268,7 +263,7 @@ include		{ return INCLUDE; }
 
  /* String literals. */
 \"([^\\\"]|\\.)*\" {
-    return TOKEN(STRING, yytext + 1, yyleng - 2, yyget_extra(yyscanner)->encoding);
+    return TOKEN(STRING, yytext + 1, yyleng - 2);
 }
 
  /* Numbers. */
@@ -366,7 +361,7 @@ static void yybegin(yyscan_t scanner)
 }
 
 void yylex_initialize(PyObject* file, PyObject* filename, int lineno,
-                      const char* encoding, PyObject* missing_obj, yyscan_t scanner)
+                      PyObject* missing_obj, yyscan_t scanner)
 {
     yyextra_t* extra = yyget_extra(scanner);
 
@@ -386,8 +381,6 @@ void yylex_initialize(PyObject* file, PyObject* filename, int lineno,
 
     Py_XDECREF(extra->filename);
     extra->filename = filename;
-
-    extra->encoding = encoding ? encoding : "utf-8";
 
     extra->missing_obj = missing_obj;
 

--- a/beancount/parser/lexer.py
+++ b/beancount/parser/lexer.py
@@ -33,14 +33,13 @@ class LexBuilder:
             LexerError(new_metadata(filename, lineno), str(message), None))
 
 
-def lex_iter(file, builder=None, encoding=None):
+def lex_iter(file, builder=None):
     """An iterator that yields all the tokens in the given file.
 
     Args:
       file: A string, the filename to run the lexer on, or a file object.
       builder: A builder of your choice. If not specified, a LexBuilder is
         used and discarded (along with its errors).
-      encoding: A string (or None), the default encoding to use for strings.
     Yields:
       All the tokens in the input file as ``(token, lineno, text,
       value)`` tuples where ``token`` is a string representing the
@@ -58,7 +57,7 @@ def lex_iter(file, builder=None, encoding=None):
         if builder is None:
             builder = LexBuilder()
         parser = _parser.Parser(builder)
-        yield from parser.lex(file, encoding=encoding)
+        yield from parser.lex(file)
 
 
 def lex_iter_string(string, builder=None, **kwargs):

--- a/beancount/parser/lexer_test.py
+++ b/beancount/parser/lexer_test.py
@@ -587,11 +587,7 @@ class TestLexerUnicode(unittest.TestCase):
         utf8_bytes = self.test_utf8_string.encode('utf8')
         builder = lexer.LexBuilder()
         tokens = list(lexer.lex_iter_string(utf8_bytes, builder))
-
-        # The lexer outputs no errors.
         self.assertFalse(builder.errors)
-
-        # Check that the lexer correctly parsed the UTF8 string.
         str_tokens = [token for token in tokens if token[0] == 'STRING']
         self.assertEqual(self.expected_utf8_string, str_tokens[0][3])
 
@@ -600,27 +596,9 @@ class TestLexerUnicode(unittest.TestCase):
         latin1_bytes = self.test_utf8_string.encode('latin1')
         builder = lexer.LexBuilder()
         tokens = list(lexer.lex_iter_string(latin1_bytes, builder))
-
-        # The lexer outputs no errors.
-        self.assertFalse(builder.errors)
-
-        # Check that the lexer failed to convert the string but did not cause
-        # other errors.
-        str_tokens = [token for token in tokens if token[0] == 'STRING']
-        self.assertNotEqual(self.expected_utf8_string, str_tokens[0][3])
-
-    # Test providing latin1 bytes to the lexer with an encoding.
-    def test_bytes_encoded_latin1(self):
-        latin1_bytes = self.test_latin1_string.encode('latin1')
-        builder = lexer.LexBuilder()
-        tokens = list(lexer.lex_iter_string(latin1_bytes, builder, encoding='latin1'))
-
-        # The lexer outputs no errors.
-        self.assertFalse(builder.errors)
-
-        # Check that the lexer correctly parsed the latin1 string.
-        str_tokens = [token for token in tokens if token[0] == 'STRING']
-        self.assertEqual(self.expected_latin1_string, str_tokens[0][3])
+        errors = builder.errors
+        self.assertTrue(errors)
+        self.assertRegex(errors[0].message, "^UnicodeDecodeError: 'utf-8' codec ")
 
     # Test providing utf16 bytes to the lexer when it is expecting utf8.
     def test_bytes_encoded_utf16_invalid(self):

--- a/beancount/parser/parser.c
+++ b/beancount/parser/parser.c
@@ -112,32 +112,30 @@ static void parser_dealloc(Parser* self)
 }
 
 PyDoc_STRVAR(parser_parse_doc,
-             "parse(file, filename=None, lineno=1, encoding='utf8')\n"
+             "parse(file, filename=None, lineno=1)\n"
              "\n"
              "Parse input from file object. The filename and lineno keyword\n"
              "arguments allow to specify the file name and start line number to be\n"
              "used in error reporting and in the returned metadata objects. If\n"
              "filename is not specified or None, the name attribute of the file\n"
-             "object is used, if present. The encoding parameter allows to specify\n"
-             "the file encoding. Parsing results are retrieved from the Builder\n"
-             "object specified when the Parser object was instantiated.");
+             "object is used, if present. Parsing results are retrieved from the \n"
+             "Builder object specified when the Parser object was instantiated.");
 
 static PyObject* parser_parse(Parser* self, PyObject* args, PyObject* kwds)
 {
-    static char* kwlist[] = {"file", "filename", "lineno", "encoding", NULL};
-    const char* encoding = NULL;
+    static char* kwlist[] = {"file", "filename", "lineno", NULL};
     PyObject* filename = NULL;
     PyObject* file;
     int lineno = 1;
     int ret;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|Oiz", kwlist,
-                                     &file, &filename, &lineno, &encoding)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|Oi", kwlist,
+                                     &file, &filename, &lineno)) {
         return NULL;
     }
 
     /* Initialize the scanner state. */
-    yylex_initialize(file, filename, lineno, encoding, missing_obj, self->scanner);
+    yylex_initialize(file, filename, lineno, missing_obj, self->scanner);
 
     /* Run the parser. */
     ret = yyparse(self->scanner, self->builder);
@@ -161,30 +159,28 @@ static PyObject* parser_parse(Parser* self, PyObject* args, PyObject* kwds)
 }
 
 PyDoc_STRVAR(parser_lex_doc,
-             "lex(file, filename=None, lineno=1, encoding='utf8')\n"
+             "lex(file, filename=None, lineno=1)\n"
              "\n"
              "Run the input file object trough the Beancount tokenizer. filename and\n"
              "lineno keyword arguments allow to specify the file name and start line\n"
              "number to be used in error reporting. If filename is not specified or\n"
-             "None, the name attribute of the file object is used, if present.\n"
-             "The encoding parameter allows to specify the file encoding. Return an\n"
-             "iterable yielding (token name, string value, sematical value) tuples.");
+             "None, the name attribute of the file object is used, if present. Return \n"
+             "an iterable yielding (token name, string value, sematical value) tuples.");
 
 static PyObject* parser_lex(Parser* self, PyObject* args, PyObject* kwds)
 {
-    static char* kwlist[] = {"file", "filename", "lineno", "encoding", NULL};
-    const char* encoding = NULL;
+    static char* kwlist[] = {"file", "filename", "lineno", NULL};
     PyObject* filename = NULL;
     PyObject* file;
     int lineno = 1;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|Oiz", kwlist,
-                                     &file, &filename, &lineno, &encoding)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|Oi", kwlist,
+                                     &file, &filename, &lineno)) {
         return NULL;
     }
 
     /* Initialize the scanner state. */
-    yylex_initialize(file, filename, lineno, encoding, missing_obj, self->scanner);
+    yylex_initialize(file, filename, lineno, missing_obj, self->scanner);
 
     Py_INCREF(self);
     return (PyObject*)self;

--- a/beancount/parser/parser_test.py
+++ b/beancount/parser/parser_test.py
@@ -148,29 +148,10 @@ class TestUnicodeErrors(unittest.TestCase):
     def test_bytes_encoded_incorrect(self):
         latin1_bytes = self.test_utf8_string.encode('latin1')
         entries, errors, _ = parser.parse_string(latin1_bytes)
-        self.assertEqual(1, len(entries))
-        self.assertFalse(errors)
-        # Check that the lexer failed to convert the string but did not cause
-        # other errors.
-        self.assertNotEqual(self.expected_utf8_string, entries[0].comment)
-
-    # Test providing latin1 bytes to the lexer with an encoding.
-    def test_bytes_encoded_latin1(self):
-        latin1_bytes = self.test_latin1_string.encode('latin1')
-        entries, errors, _ = parser.parse_string(latin1_bytes, encoding='latin1')
-        self.assertEqual(1, len(entries))
-        self.assertFalse(errors)
-        # Check that the lexer correctly parsed the latin1 string.
-        self.assertEqual(self.expected_latin1_string, entries[0].comment)
-
-    # Test using a garbage invalid encoding.
-    def test_bytes_encoded_invalid(self):
-        latin1_bytes = self.test_latin1_string.encode('latin1')
-        entries, errors, _ = parser.parse_string(latin1_bytes, encoding='garbage')
+        # Check that the lexer failed to convert the string and reported an error.
         self.assertEqual(1, len(errors))
-        self.assertRegex(errors[0].message, "unknown encoding")
+        self.assertRegex(errors[0].message, "^UnicodeDecodeError: 'utf-8' codec ")
         self.assertFalse(entries)
-
 
 class TestTestUtils(unittest.TestCase):
 

--- a/beancount/parser/tokens.c
+++ b/beancount/parser/tokens.c
@@ -136,7 +136,7 @@ ssize_t cunescape(const char* string, size_t len, int strict, char** ret, int* l
     return dst - buffer;
 }
 
-PyObject* pyunicode_from_cquotedstring(const char* string, size_t len, const char* encoding) {
+PyObject* pyunicode_from_cquotedstring(const char* string, size_t len) {
     char* unescaped = NULL;
     ssize_t r;
     int lines;
@@ -154,7 +154,7 @@ PyObject* pyunicode_from_cquotedstring(const char* string, size_t len, const cha
         return NULL;
     }
 
-    PyObject* rv = PyUnicode_Decode(unescaped, r, encoding, "ignore");
+    PyObject* rv = PyUnicode_FromStringAndSize(unescaped, r);
     free(unescaped);
 
     return rv;

--- a/beancount/parser/tokens.h
+++ b/beancount/parser/tokens.h
@@ -37,7 +37,7 @@ extern "C" {
 #define build_NONE() ( Py_INCREF(Py_None), Py_None )
 #define build_NUMBER(_str) pydecimal_from_cstring(_str)
 #define build_DATE(_str) pydate_from_cstring(_str)
-#define build_STRING(_str, _len, _enc) pyunicode_from_cquotedstring(_str, _len, _enc)
+#define build_STRING(_str, _len) pyunicode_from_cquotedstring(_str, _len)
 #define build_ACCOUNT(_str) PyUnicode_InternFromString(_str)
 #define build_EXCEPTION(_loc, _builder) ( build_lexer_error_from_exception(_loc, _builder), YYerror )
 
@@ -80,13 +80,13 @@ ssize_t cunescape(const char* string, size_t len, int strict, char** ret, int* l
 
 
 /**
- * Convert a string to a PyUnicode object using the specified @encoding.
+ * Convert an UTF-8 encoded string to a PyUnicode object.
  *
  * C-style escape codes contained in the string are unescaped. An
  * exception is raised if the string contains invalid escape sequences
  * or if the string contains more than 64 lines.
  */
-PyObject* pyunicode_from_cquotedstring(const char* string, size_t len, const char* encoding);
+PyObject* pyunicode_from_cquotedstring(const char* string, size_t len);
 
 
 /**


### PR DESCRIPTION
During the work on the include directive I had to think about which encoding to use for the included files. And I realized that our encoding support is mostly a joke. Ripping it out completely is easier and more honest.

The parser does not really understand any encoding other than UTF-8. Support for other encodings is limited to string literals, which makes sense only for a very limited subset of encodings.

The limited support for other encodings is not exposed to the command line tools and no one ever complained, so I assume that all Beancount users use systems with UTF-8 default encoding or arrange for their ledgers to be encoded in UTF-8 or in an encoding which is subset equivalent to UTF-8 like ascii or latin1.

I stopped at the innermost interface layer in removing the `encoding` argument to parser functions. It can be removed all the way and we can be happy supporting UTF-8 only (which is not a bad choice in 2021, IMHO) or we can support ether encodings via transparent recoding using, for example, `codecs.EncodedFile`.