### PR TITLE
Fix meta handling of check_closing plugin

### DIFF
--- a/beancount/plugins/check_closing.py
+++ b/beancount/plugins/check_closing.py
@@ -55,12 +55,13 @@ def check_closing(entries, options_map):
     new_entries = []
     for entry in entries:
         if isinstance(entry, data.Transaction):
-            for posting in entry.postings:
+            for i, posting in enumerate(entry.postings):
                 if posting.meta and posting.meta.get('closing', False):
                     # Remove the metadata.
                     meta = posting.meta.copy()
                     del meta['closing']
-                    entry = entry._replace(meta=meta)
+                    posting = posting._replace(meta=meta)
+                    entry.postings[i] = posting
 
                     # Insert a balance.
                     date = entry.date + datetime.timedelta(days=1)


### PR DESCRIPTION
I believe the intention of the replace is to remove the `closing` from the posting, rather than overriding the meta of `entry` with the meta from `posting`. The current overriding just doesn't make any sense to me. It also causes issues like beancount/fava#1301.