### PR TITLE
Remove User-Agent sent to yahoo finance api.

### DIFF
--- a/beancount/prices/sources/yahoo.py
+++ b/beancount/prices/sources/yahoo.py
@@ -83,7 +83,7 @@ class Source(source.Source):
             'exchange': 'NYSE',
         }
         payload.update(_DEFAULT_PARAMS)
-        response = requests.get(url, params=payload)
+        response = requests.get(url, params=payload, headers={'User-Agent': None})
         result = parse_response(response)
         try:
             price = D(result['regularMarketPrice'])


### PR DESCRIPTION
The default "python-requests/$VERSION" is causing 403.

https://github.com/beancount/beancount/issues/667