### PR TITLE
Remove User-Agent sent to yahoo finance chart api.

### DIFF
--- a/beancount/prices/sources/yahoo.py
+++ b/beancount/prices/sources/yahoo.py
@@ -114,7 +114,7 @@ class Source(source.Source):
             'interval': '1d',
         }
         payload.update(_DEFAULT_PARAMS)
-        response = requests.get(url, params=payload)
+        response = requests.get(url, params=payload, headers={'User-Agent': None})
         result = parse_response(response)
 
         meta = result['meta']


### PR DESCRIPTION
This invocation also has 403 issue but was missed in the earlier fix.

https://github.com/beancount/beancount/issues/667