### PR TITLE
Handle edge case

### DIFF
--- a/beancount/prices/sources/yahoo.py
+++ b/beancount/prices/sources/yahoo.py
@@ -120,8 +120,11 @@ class Source(source.Source):
         meta = result['meta']
         timezone = datetime.timezone(datetime.timedelta(hours=meta['gmtoffset'] / 3600),
                                      meta['exchangeTimezoneName'])
-
+        
+        if 'timestamp' not in result:
+            raise YahooError('Could not find price on {} for {}'.format(time, ticker))
         timestamp_array = result['timestamp']
+        
         close_array = result['indicators']['quote'][0]['close']
         series = [(datetime.datetime.fromtimestamp(timestamp, tz=timezone), D(price))
                   for timestamp, price in zip(timestamp_array, close_array)]


### PR DESCRIPTION
the return value doesn't have a `timestamp` field for stock **515050.SS** on date **2020-01-01** for example