### PR TITLE
Let bean-identify catch UnicodeDecodeError

### DIFF
--- a/beancount/ingest/identify.py
+++ b/beancount/ingest/identify.py
@@ -63,6 +63,8 @@ def find_imports(importer_config, files_or_directories, logfile=None):
                 matched = importer.identify(file)
                 if matched:
                     matching_importers.append(importer)
+            except UnicodeDecodeError:
+                pass
             except Exception as exc:
                 logging.exception("Importer %s.identify() raised an unexpected error: %s",
                                   importer.name(), exc)


### PR DESCRIPTION
Right now you have to provide an encoding parameter to most importers, signifying how to interpret the file that is being imported. However, when you have multiple importers and *multiple files with different encodings*, all importers start complaining loudly during identify, showing `UnicodeDecodeError`s.

The import will still succeed, but the terminal output is a mess and not readable anymore.

This PR mitigates that by simply ignoring those exceptions. This means if an importer raises a `UnicodeDecodeError`, the file under investigation is simply considered a non-match for this importer, and will have to be imported by another one.