### PR TITLE
Fix syntax errors on Windows due to missing ssize_t

### DIFF
--- a/beancount/parser/tokens.h
+++ b/beancount/parser/tokens.h
@@ -9,6 +9,11 @@
 #include "beancount/parser/decimal.h"
 #include "beancount/parser/macros.h"
 
+#ifdef _MSC_VER
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
``pip install beancount`` on Windows & Python 3.10 returns the following results:

```
...
  C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\HostX86\x64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -DBEANCOUNT_VERSION=2.3.4 -DVC_CHANGESET= -DVC_TIMESTAMP=0 -DPARSER_SOURCE_HASH -I. -IC:\Users\dweng\AppData\Local\Programs\Python\Python310\include -IC:\Users\dweng\AppData\Local\Programs\Python\Python310\Include -IC:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include -IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\ucrt -IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\shared -IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um -IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\winrt -IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\cppwinrt /Tcbeancount/parser/grammar.c /Fobuild\temp.win-amd64-3.10\Release\beancount/parser/grammar.obj -DYY_NO_UNISTD_H
  grammar.c
  C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\HostX86\x64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -DBEANCOUNT_VERSION=2.3.4 -DVC_CHANGESET= -DVC_TIMESTAMP=0 -DPARSER_SOURCE_HASH -I. -IC:\Users\dweng\AppData\Local\Programs\Python\Python310\include -IC:\Users\dweng\AppData\Local\Programs\Python\Python310\Include -IC:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include -IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\ucrt -IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\shared -IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um -IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\winrt -IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\cppwinrt /Tcbeancount/parser/lexer.c /Fobuild\temp.win-amd64-3.10\Release\beancount/parser/lexer.obj -DYY_NO_UNISTD_H
  lexer.c
  .\beancount/parser/tokens.h(52): error C2061: 语法错误: 标识符“validate_decimal_number”
  .\beancount/parser/tokens.h(52): error C2059: 语法错误:“;”
  .\beancount/parser/tokens.h(52): error C2059: 语法错误:“<parameter-list>”
  .\beancount/parser/tokens.h(75): error C2061: 语法错误: 标识符“cunescape”
  .\beancount/parser/tokens.h(75): error C2059: 语法错误:“;”
  .\beancount/parser/tokens.h(75): error C2059: 语法错误:“<parameter-list>”
  beancount/parser/lexer.l(420): warning C4267: “=”: 从“size_t”转换到“int”，可能丢失数据
  error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX86\\x64\\cl.exe' failed with exit code 2
  ----------------------------------------
  ERROR: Failed building wheel for beancount
```

The above messages (reported in Chinese due to locale settings) indicate that there were syntax errors with ``validate_decimal_number`` and ``cunescape`` in the file ``beancount/parser/tokens.h``. I googled it up and found that similar issues were also reported in other libraries (https://github.com/jpype-project/jpype/issues/1009) because Python 3.10 seemed to have dropped support for ``ssize_t`` on Windows. So I wrote this fix based on this issue (https://groups.google.com/g/snappy-compression/c/xzKxBNeAREc) and now it would compile on Windows.