### PR TITLE
tests: Fix random test failures in core/number_test.py

### DIFF
--- a/beancount/core/number_test.py
+++ b/beancount/core/number_test.py
@@ -67,7 +67,7 @@ class TestToDecimal(unittest.TestCase):
 class TestInferQuantization(unittest.TestCase):
 
     def setUp(self):
-        rn = [random.random() * 10000 for _ in range(100)]
+        rn = [random.uniform(1, 10000) for _ in range(100)]
         self.ir = list(map(int, rn))
         self.fr = [(x - ix - 0.5) for (x, ix) in zip(rn, self.ir)]
 


### PR DESCRIPTION
Some of the quantization tests assume that all numbers in the test
corpus have a non zero integer part. Fix the generation of the random
numbers composing the test corpus to always be larger than one.