### PR TITLE
perf: Don't do many copies without need

### DIFF
--- a/beancount/parser/booking_full.py
+++ b/beancount/parser/booking_full.py
@@ -554,8 +554,10 @@ def book_reductions(entry, group_postings, balances,
         # Also note that if there is no existing balance, then won't be any lot
         # reduction because none of the postings will be able to match against
         # any currencies of the balance.
-        previous_balance = balances.get(account, empty)
-        balance = local_balances.setdefault(account, copy.copy(previous_balance))
+        if account not in local_balances:
+            previous_balance = balances.get(account, empty)
+            local_balances[account] = copy.copy(previous_balance)
+        balance = local_balances[account]
 
         # Check if this is a lot held at cost.
         if costspec is None or units.number is MISSING:


### PR DESCRIPTION
I have a single account with 5000+ different commodities (MTG collection)
This copy makes my `bean-check` take 92s

With this change it now takes 38.5s (going from 87545 copies to 59130)

Before: 
![before](https://user-images.githubusercontent.com/1478103/139320893-ea417795-bf9d-4d74-90dd-89274a18da30.png)
After:
![after](https://user-images.githubusercontent.com/1478103/139320891-2d55029b-36b5-4a71-8129-e22b9a59625c.png)
