### PR TITLE
Fix transaction alignment in parser (ValueError: '=' alignment not allowed in string format specifier)

### DIFF
--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -197,7 +197,7 @@ class EntryPrinter:
                                if self.render_weight and width_weight > 0
                                else False)
         if non_trivial_balance:
-            fmt = "{0}{{:{1}}}  {{:{2}}}  ; {{:{3}}}\n".format(
+            fmt = "{0}{{:<{1}}}  {{:<{2}}}  ; {{:<{3}}}\n".format(
                 self.prefix, width_account, width_position, width_weight).format
             for posting, account, position_str, weight_str in zip(entry.postings,
                                                                   strs_account,


### PR DESCRIPTION
I encounter the following error using the ```context``` command of bean-doctor:
```
[...]
  File "[...]\venv\lib\site-packages\beancount\parser\printer.py", line 210, in Transaction
    oss.write(fmt(account,
ValueError: '=' alignment not allowed in string format specifier
```
I did not manage to locate the precise source of the error but adding [left justifier specifiers](https://docs.python.org/3/library/string.html#formatspec) ```<``` to the formatter string seems to solve the issue.