### PR TITLE
Make parse_file retain original file order

### DIFF
--- a/beancount/parser/grammar.py
+++ b/beancount/parser/grammar.py
@@ -36,7 +36,6 @@ from beancount.core.data import EMPTY_SET
 from beancount.parser import lexer
 from beancount.parser import options
 from beancount.core import account
-from beancount.core import data
 
 
 ParserError = collections.namedtuple('ParserError', 'source message entry')
@@ -176,9 +175,9 @@ class Builder(lexer.LexBuilder):
         """Return the accumulated entries.
 
         Returns:
-          A list of sorted directives.
+          A list of directives.
         """
-        return sorted(self.entries, key=data.entry_sortkey)
+        return list(self.entries)
 
     def get_options(self):
         """Return the final options map.

--- a/beancount/parser/grammar_test.py
+++ b/beancount/parser/grammar_test.py
@@ -229,6 +229,21 @@ class TestParserEntryTypes(unittest.TestCase):
                          txns[0].values)
 
 
+class TestOrder(unittest.TestCase):
+    """Test the ordering of results."""
+
+    @parser.parse_doc()
+    def test_order_matches_original_file_rather_than_date_order(self, entries, errors, _):
+        """
+          2013-01-01 open Equity:Other
+
+          2010-01-01 open Assets:Investments
+        """
+        self.assertEqual(2, len(entries))
+        self.assertEqual('Equity:Other', entries[0].account)
+        self.assertEqual('Assets:Investments', entries[1].account)
+
+
 class TestWhitespace(unittest.TestCase):
     """Tests for handling of whitespace and indent."""
 


### PR DESCRIPTION
The discussion in #649 suggests that there's no specific reason for sorting directly after parsing. Looking at the code, it appears to be a relatively surface-level decision to sort the results. This PR adds a small test for ordering, and removes the sorting from `get_entries`.

The original discussion [says](https://github.com/beancount/beancount/issues/649#issuecomment-825893407):
> A deep code inspection would be required through.

While this change doesn't cause any tests to fail, I'm unclear on whether there are other subtleties here that I've missed.

resolves #649