### PR TITLE
Enable addition and subtraction on two Amounts.

### DIFF
--- a/beancount/core/amount.py
+++ b/beancount/core/amount.py
@@ -42,6 +42,20 @@ class Amount(_Amount):
     valid_types_number = (Decimal, type, type(None))
     valid_types_currency = (str, type, type(None))
 
+    def __add__(self, other):
+        return add(self, other)
+
+    def __sub__(self, other):
+        return sub(self, other)
+
+    def __mul__(self, other):
+        return mul(self, other)
+
+    __rmul__ = __mul__
+
+    def __truediv__(self, other):
+        return div(self, other)
+
     def __new__(cls, number, currency):
         """Constructor from a number and currency.
 
@@ -163,8 +177,8 @@ def mul(amount, number):
     """
     assert isinstance(amount.number, Decimal), (
         "Amount's number is not a Decimal instance: {}".format(amount.number))
-    assert isinstance(number, Decimal), (
-        "Number is not a Decimal instance: {}".format(number))
+    assert isinstance(number,(int, Decimal)), (
+        "Number is not an int or Decimal instance: {}".format(number))
     return Amount(amount.number * number, amount.currency)
 
 def div(amount, number):
@@ -178,8 +192,8 @@ def div(amount, number):
     """
     assert isinstance(amount.number, Decimal), (
         "Amount's number is not a Decimal instance: {}".format(amount.number))
-    assert isinstance(number, Decimal), (
-        "Number is not a Decimal instance: {}".format(number))
+    assert isinstance(number, (int, Decimal)), (
+        "Number is not an int or Decimal instance: {}".format(number))
     return Amount(amount.number / number, amount.currency)
 
 def add(amount1, amount2):

--- a/beancount/query/query_compile_test.py
+++ b/beancount/query/query_compile_test.py
@@ -6,10 +6,12 @@ import unittest
 from decimal import Decimal
 
 from beancount.core.number import D
+from beancount.core.amount import A
+
 from beancount.query import query_parser as qp
 from beancount.query import query_compile as qc
 from beancount.query import query_env as qe
-
+from beancount.core import amount
 
 class TestCompileExpression(unittest.TestCase):
 
@@ -171,20 +173,39 @@ class TestCompileDataTypes(unittest.TestCase):
         self.assertEqual(bool, c_or.dtype)
 
     def test_compile_EvalMul(self):
-        c_plus = qc.EvalMul(qc.EvalConstant(17), qc.EvalConstant(18))
+        c_plus = qc.EvalMul(qc.EvalConstant(D(17)), qc.EvalConstant(D(18)))
         self.assertEqual(Decimal, c_plus.dtype)
 
     def test_compile_EvalDiv(self):
-        c_plus = qc.EvalDiv(qc.EvalConstant(17), qc.EvalConstant(18))
+        c_plus = qc.EvalDiv(qc.EvalConstant(D(17)), qc.EvalConstant(D(18)))
         self.assertEqual(Decimal, c_plus.dtype)
 
     def test_compile_EvalAdd(self):
-        c_plus = qc.EvalAdd(qc.EvalConstant(17), qc.EvalConstant(18))
+        c_plus = qc.EvalAdd(qc.EvalConstant(D(17)), qc.EvalConstant(D(18)))
         self.assertEqual(Decimal, c_plus.dtype)
 
     def test_compile_EvalSub(self):
-        c_plus = qc.EvalSub(qc.EvalConstant(17), qc.EvalConstant(18))
+        c_plus = qc.EvalSub(qc.EvalConstant(D(17)), qc.EvalConstant(D(18)))
         self.assertEqual(Decimal, c_plus.dtype)
+
+    def test_compile_EvalAddAmount(self):
+        c_plus = qc.EvalAdd(qc.EvalConstant(A('1.11 USD')), qc.EvalConstant(A('3.55 USD')))
+        self.assertEqual(amount.Amount, c_plus.dtype)
+
+    def test_compile_EvalSubAmount(self):
+        c_plus = qc.EvalSub(qc.EvalConstant(A('1.11 USD')), qc.EvalConstant(A('3.55 USD')))
+        self.assertEqual(amount.Amount, c_plus.dtype)
+
+    def test_compile_EvalMultAmount(self):
+        c_plus = qc.EvalMul(qc.EvalConstant(A('1.11 USD')), qc.EvalConstant(D('2.31')))
+        self.assertEqual(amount.Amount, c_plus.dtype)
+        c_plus = qc.EvalMul(qc.EvalConstant(D('2.31')), qc.EvalConstant(A('1.11 USD')))
+        self.assertEqual(amount.Amount, c_plus.dtype)
+
+    def test_compile_EvalDivAmount(self):
+        c_plus = qc.EvalDiv(qc.EvalConstant(A('1.11 USD')), qc.EvalConstant(D('2.31')))
+        self.assertEqual(amount.Amount, c_plus.dtype)
+
 
 
 class TestCompileMisc(unittest.TestCase):


### PR DESCRIPTION
I would like to be able to do addition and subtraction of Amounts in the bql language. This code lets python know how to add and subtract Amounts using add/sub functions that already exist but weren't linked to the class. EvalAdd and EvalSub no longer force the output to be Decimal as they can now be Amounts (or maybe Positions as well in the future).  To test, I added a EvalAmount to create an Amount similar to how EvalConstant is defined. 