### PR TITLE
Fix syntax errors on Windows due to missing ssize_t

### DIFF
--- a/beancount/parser/tokens.h
+++ b/beancount/parser/tokens.h
@@ -9,6 +9,10 @@
 #include "beancount/parser/decimal.h"
 #include "beancount/parser/macros.h"
 
+#ifdef _MSC_VER
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
+#endif
 
 /**
  * Dispatch to token values build functions.


### PR DESCRIPTION
pick https://github.com/beancount/beancount/pull/679 for v2