### PR TITLE
ci: Fix workflow to upload wheels to PyPI

### DIFF
--- a/.github/workflows/pypi-wheel.yaml
+++ b/.github/workflows/pypi-wheel.yaml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         python: ['3.6', '3.7', '3.8', '3.9', '3.10']
         os: [windows, macos]
-      env:
-        # The newly pushed tag or the tag specified in the workflow dispatch.
-        TAG: ${{ github.event.push.tag || github.event.inputs.tag }}
+    env:
+      # The newly pushed tag or the tag specified in the workflow dispatch.
+      TAG: ${{ github.event.push.tag || github.event.inputs.tag }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Fix for the fix. I somehow botched the indentation of the yaml file. @blais the workflow would have to be triggered manually once more.