### PR TITLE
ci: Fix workflow to upload wheels to PyPI

### DIFF
--- a/.github/workflows/pypi-wheel.yaml
+++ b/.github/workflows/pypi-wheel.yaml
@@ -23,7 +23,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.TAG }}
-      - run: test "$TAG" = "$(cat beancount/VERSION)"
+      - run: git describe --tags
+      - run: |
+          # Check that release tag and package version agree.
+          import os, sys
+          tag = os.getenv('TAG')
+          print(f'git tag: {tag}')
+          version = open('beancount/VERSION').read().strip()
+          print(f'package version: {version}')
+          if tag != version:
+              sys.exit(1)
+        shell: python
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}


### PR DESCRIPTION
Ok, this time is the good one. I tested the previous version, but only on macOS and of course the default shell on Windows is not bash but powershell... Writing the test in python is the simplest way out.

And I am very happy to have written the version check: the 2.3.5 tag points to the wrong place! It points to a recent commit on the master branch and not to the tip of the v2 branch.