### PR TITLE
format: add support for parenthesized expressions

### DIFF
--- a/beancount/scripts/format.py
+++ b/beancount/scripts/format.py
@@ -11,6 +11,7 @@ from beancount.core import amount
 from beancount.core import account
 from beancount.parser.version import VERSION
 
+NUMBER_RE = r'[-+]?\s*[\d,]+(?:\.\d*)?'
 
 def align_beancount(contents, prefix_width=None, num_width=None, currency_column=None):
     """Reformat Beancount input to align all the numbers at the same column.
@@ -36,8 +37,9 @@ def align_beancount(contents, prefix_width=None, num_width=None, currency_column
     match_pairs = []
     for line in contents.splitlines():
         match = re.match(
-            r'(^\d[^";]*?|\s+{})\s+([-+]?\s*[\d,]+(?:\.\d*)?)\s+((?:{})\b.*)'.format(
-                account.ACCOUNT_RE, amount.CURRENCY_RE), line)
+            rf'(^\d[^";]*?|\s+{account.ACCOUNT_RE})\s+({NUMBER_RE})\s+((?:{amount.CURRENCY_RE})\b.*)',
+            line,
+        )
         if match:
             prefix, number, rest = match.groups()
             match_pairs.append((prefix, number, rest))

--- a/beancount/scripts/format.py
+++ b/beancount/scripts/format.py
@@ -12,6 +12,7 @@ from beancount.core import account
 from beancount.parser.version import VERSION
 
 NUMBER_RE = r'[-+]?\s*[\d,]+(?:\.\d*)?'
+PARENTHESIZED_BINARY_OP_RE = rf'\({NUMBER_RE}\s*[-+*/]\s*{NUMBER_RE}\)'
 
 def align_beancount(contents, prefix_width=None, num_width=None, currency_column=None):
     """Reformat Beancount input to align all the numbers at the same column.
@@ -37,7 +38,7 @@ def align_beancount(contents, prefix_width=None, num_width=None, currency_column
     match_pairs = []
     for line in contents.splitlines():
         match = re.match(
-            rf'(^\d[^";]*?|\s+{account.ACCOUNT_RE})\s+({NUMBER_RE})\s+((?:{amount.CURRENCY_RE})\b.*)',
+            rf'(^\d[^";]*?|\s+{account.ACCOUNT_RE})\s+({PARENTHESIZED_BINARY_OP_RE}|{NUMBER_RE})\s+((?:{amount.CURRENCY_RE})\b.*)',
             line,
         )
         if match:

--- a/beancount/scripts/format_test.py
+++ b/beancount/scripts/format_test.py
@@ -244,6 +244,44 @@ class TestScriptFormat(test_utils.ClickTestCase):
 
         """), result.stdout)
 
+    @test_utils.docfile
+    def test_parenthesized_binary_expressions(self, filename):
+        """
+        2016-08-01 open Expenses:Test
+        2016-08-01 open Assets:Test
+
+        2016-08-02 * "" ""
+          Expenses:Test     10.0 USD
+          Expenses:Test (10.0/2) USD
+          Expenses:Test (10.0+2) USD
+          Expenses:Test (10.0-2) USD
+          Expenses:Test (10.0*2) USD
+          Expenses:Test (-10.0*+2) USD
+          Expenses:Test (-1,000.0*+2.0) USD
+          Assets:Test
+
+        2016-08-03 balance Assets:Test 12.27 USD
+        2016-08-03 balance Assets:Test (12.27 + 1.00) USD
+        """
+        result = self.run_with_args(format.main, filename)
+        self.assertEqual(textwrap.dedent("""
+        2016-08-01 open Expenses:Test
+        2016-08-01 open Assets:Test
+
+        2016-08-02 * "" ""
+          Expenses:Test                            10.0 USD
+          Expenses:Test                        (10.0/2) USD
+          Expenses:Test                        (10.0+2) USD
+          Expenses:Test                        (10.0-2) USD
+          Expenses:Test                        (10.0*2) USD
+          Expenses:Test                      (-10.0*+2) USD
+          Expenses:Test                 (-1,000.0*+2.0) USD
+          Assets:Test
+
+        2016-08-03 balance Assets:Test            12.27 USD
+        2016-08-03 balance Assets:Test   (12.27 + 1.00) USD
+        """), result.stdout)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #714 with *very* limited support for arithmetic expressions: only parenthesized, binary operations are matched.