### PR TITLE
elide position string if it was interpolated

### DIFF
--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -239,7 +239,10 @@ class EntryPrinter:
         # Render a string with the amount and cost and optional price, if
         # present. Also render a string with the weight.
         weight_str = ''
-        if isinstance(posting.units, amount.Amount):
+        if posting.meta and interpolate.AUTOMATIC_META in posting.meta
+            # Position was interpolated, leave it blank when printing.
+            position_str = ''
+        elif isinstance(posting.units, amount.Amount):
             position_str = position.to_string(posting, self.dformat)
             # Note: we render weights at maximum precision, for debugging.
             if posting.cost is None or (isinstance(posting.cost, position.Cost) and


### PR DESCRIPTION
If I try to print a transaction entry that was parsed with an interpolated amount, I’d prefer that it not insert that interpolated amount in the printed posting—but to leave it blank as parsed.  Would this be okay?

Parsing:
```
2014-05-05 txn "Cafe Mogador" "Lamb tagine with wine"
  Liabilities:CreditCard:CapitalOne         -37.45 USD
  Expenses:Restaurant
```

Printing:
```
2014-05-05 txn "Cafe Mogador" "Lamb tagine with wine"
  Liabilities:CreditCard:CapitalOne         -37.45 USD
  Expenses:Restaurant                        37.45 USD    # <--- I’d prefer this to be left blank
```