### PR TITLE
Add HIFO booking method

### DIFF
--- a/beancount/core/data.py
+++ b/beancount/core/data.py
@@ -52,6 +52,8 @@ class Booking(enum.Enum):
     # Last-in first-out in the case of ambiguity.
     LIFO = 'LIFO'
 
+    # Highest-in first-out in the case of ambiguity.
+    HIFO = 'HIFO'
 
 def new_directive(clsname, fields: List[Tuple]) -> NamedTuple:
     """Create a directive class. Do not include default fields.

--- a/beancount/parser/booking_full_test.py
+++ b/beancount/parser/booking_full_test.py
@@ -1653,6 +1653,30 @@ class TestBookReductions(_BookingTestBase):
           Assets:Account           25 HOOL {116.00 USD, 2016-01-16}
         """
 
+    @book_test(Booking.HIFO)
+    def test_reduce__multiple_reductions_hifo(self, _, __):
+        """
+        2016-01-01 * #ante
+          Assets:Account           50 HOOL {115.00 USD, 2016-01-15}
+          Assets:Account           50 HOOL {116.00 USD, 2016-01-16}
+          Assets:Account           50 HOOL {114.00 USD, 2016-01-17}
+
+        2016-05-02 * #apply
+          Assets:Account          -40 HOOL {}
+          Assets:Account          -35 HOOL {}
+          Assets:Account          -30 HOOL {}
+
+        2016-05-02 * #booked
+          Assets:Account          -40 HOOL {116.00 USD, 2016-01-16}
+          Assets:Account          -10 HOOL {116.00 USD, 2016-01-16}
+          Assets:Account          -25 HOOL {115.00 USD, 2016-01-15}
+          Assets:Account          -25 HOOL {115.00 USD, 2016-01-15}
+          Assets:Account           -5 HOOL {114.00 USD, 2016-01-17}
+
+        2016-01-01 * #ex
+          Assets:Account           45 HOOL {114.00 USD, 2016-01-17}
+        """
+
     @book_test(Booking.STRICT)
     def test_reduce__multiple_reductions__competing__with_error(self, _, __):
         """

--- a/beancount/parser/booking_method.py
+++ b/beancount/parser/booking_method.py
@@ -111,15 +111,20 @@ def booking_method_STRICT(entry, posting, matches):
 
 def booking_method_FIFO(entry, posting, matches):
     """FIFO booking method implementation."""
-    return _booking_method_xifo(entry, posting, matches, False)
+    return _booking_method_xifo(entry, posting, matches, "date", False)
 
 
 def booking_method_LIFO(entry, posting, matches):
     """LIFO booking method implementation."""
-    return _booking_method_xifo(entry, posting, matches, True)
+    return _booking_method_xifo(entry, posting, matches, "date", True)
 
 
-def _booking_method_xifo(entry, posting, matches, reverse_order):
+def booking_method_HIFO(entry, posting, matches):
+    """HIFO booking method implementation."""
+    return _booking_method_xifo(entry, posting, matches, "number", True)
+
+
+def _booking_method_xifo(entry, posting, matches, sortattr, reverse_order):
     """FIFO and LIFO booking method implementations."""
     booked_reductions = []
     booked_matches = []
@@ -129,41 +134,8 @@ def _booking_method_xifo(entry, posting, matches, reverse_order):
     # Each up the positions.
     sign = -1 if posting.units.number < ZERO else 1
     remaining = abs(posting.units.number)
-    for match in sorted(matches, key=lambda p: p.cost and p.cost.date,
+    for match in sorted(matches, key=lambda p: p.cost and getattr(p.cost, sortattr),
                         reverse=reverse_order):
-        if remaining <= ZERO:
-            break
-
-        # If the inventory somehow ended up with mixed lots, skip this one.
-        if match.units.number * sign > ZERO:
-            continue
-
-        # Compute the amount of units we can reduce from this leg.
-        size = min(abs(match.units.number), remaining)
-        booked_reductions.append(
-            posting._replace(units=Amount(size * sign, match.units.currency),
-                             cost=match.cost))
-        booked_matches.append(match)
-        remaining -= size
-
-    # If we couldn't eat up all the requested reduction, return an error.
-    insufficient = (remaining > ZERO)
-
-    return booked_reductions, booked_matches, errors, insufficient
-
-
-def booking_method_HIFO(entry, posting, matches):
-    """HIFO booking method implementations"""
-    booked_reductions = []
-    booked_matches = []
-    errors = []
-    insufficient = False
-
-    # Each up the positions.
-    sign = -1 if posting.units.number < ZERO else 1
-    remaining = abs(posting.units.number)
-    for match in sorted(matches, key=lambda p: p.cost and p.cost.number, reverse=True):
-        print(match.cost)
         if remaining <= ZERO:
             break
 


### PR DESCRIPTION
This adds a new booking method called HIFO (Highest In, First Out). With HIFO you sell the lots with the highest cost basis first. HIFO is commonly used for crypto, which in many countries has arbitrary booking requirements for tax reporting. HIFO is often a better choice than other booking methods since it leads to the lowest gains and largest losses, thus minimizing taxes for for the year you are reporting.