### PR TITLE
ci(v2): add python 3.10 and remove 3.6

### DIFF
--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -17,14 +17,22 @@ jobs:
           python-version: ${{ matrix.python }}
       - run: pip install -r requirements_dev.txt
       - run: python setup.py build_ext -i
+      - run: make test
+
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - run: pip install -r requirements_dev.txt
+      - run: python setup.py build_ext -i
       - run: make ctest
         env:
           LD_LIBRARY_PATH: ${{ env.pythonLocation }}/lib
         # The Makefile does not handle older python-config versions.
         # These tests are however about the pure C code, thus there is
         # little value in running them for different Python version.
-        if: ${{ matrix.python == '3.9' }}
-      - run: make test
       - run: make lint
-        # There is no need to run pylint with all Python versions.
-        if: ${{ matrix.python == '3.9' }}

--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/pypi-wheel.yaml
+++ b/.github/workflows/pypi-wheel.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10']
         os: [windows, macos]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pypi-wheel.yaml
+++ b/.github/workflows/pypi-wheel.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
         os: [windows, macos]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.pylintrc
+++ b/.pylintrc
@@ -130,7 +130,8 @@ disable=locally-disabled,
   global-variable-not-assigned,
   useless-suppression,
   unused-private-member,
-  use-maxsplit-arg
+  use-maxsplit-arg,
+  unnecessary-lambda-assignment
 
 
 # Notes:

--- a/.pylintrc
+++ b/.pylintrc
@@ -32,11 +32,6 @@ load-plugins=pylint_protobuf
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
-
 # Tells whether to display a full report or only the messages
 reports=no
 
@@ -86,8 +81,6 @@ disable=locally-disabled,
   too-many-function-args,
   unsubscriptable-object,
   too-many-nested-blocks,
-  no-self-use,
-  redefined-variable-type,
   duplicate-code,
   too-few-public-methods,
   too-many-public-methods,
@@ -121,7 +114,6 @@ disable=locally-disabled,
   c-extension-no-member,
   cyclic-import,
   isinstance-second-argument-not-valid-type,
-  bad-continuation,
   consider-using-f-string,
   consider-using-with,
   unspecified-encoding,
@@ -132,10 +124,6 @@ disable=locally-disabled,
   unused-private-member,
   use-maxsplit-arg,
   unnecessary-lambda-assignment
-
-
-# Notes:
-#   bad-continuation: Is buggy, see https://github.com/PyCQA/pylint/issues/3512
 
 
 [VARIABLES]
@@ -188,10 +176,6 @@ notes=FIXME,XXX,TODO
 
 
 [BASIC]
-
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=
-
 # Good variable names which should always be accepted, separated by a comma
 good-names=f,i,j,k,ex,Run,_
 
@@ -208,62 +192,32 @@ include-naming-hint=no
 # Regular expression matching correct module names
 module-rgx=(([a-z_][a-z0-9_\-]*)|([A-Z][a-zA-Z0-9]+))$
 
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
 # Regular expression matching correct method names
 method-rgx=[a-z_][a-zA-Z0-9_]{2,72}$
-
-# Naming hint for method names
-method-name-hint=[a-z_][a-zA-Z0-9_]{2,64}$
 
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
-
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{1,30}|(__.*__))$
-
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{1,30}|(__.*__))$
 
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
-
 # Regular expression matching correct variable names
 variable-rgx=(_?[a-z_][a-z0-9_]{1,30}|__|mu|no)$
-
-# Naming hint for variable names
-variable-name-hint=[a-z_][a-z0-9_]{1,30}$
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
 # Regular expression matching correct attribute names
 attr-rgx=[a-z_][a-z0-9_]{1,30}$
-
-# Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{1,30}$
 
 # Regular expression matching correct argument names
 argument-rgx=(_?[a-z_][a-z0-9_]{1,30}|__|mu)$
 
-# Naming hint for argument names
-argument-name-hint=[a-z_][a-z0-9_]{1,30}$
-
 # Regular expression matching correct function names
 function-rgx=_?[a-z_][a-zA-Z0-9_]{2,64}$
-
-# Naming hint for function names
-function-name-hint=[a-z_][a-zA-Z0-9_]{2,64}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
@@ -285,9 +239,6 @@ ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 single-line-if-stmt=no
-
-# List of optional constructs for which whitespace checking is disabled
-no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
 max-module-lines=1000

--- a/beancount/tools/treeify.py
+++ b/beancount/tools/treeify.py
@@ -290,9 +290,9 @@ def _main():
 
     args = parser.parse_args()
 
-    if sum([1 if expr else 0 for expr in (args.filenames,
+    if sum(1 if expr else 0 for expr in (args.filenames,
                                           args.loose_accounts,
-                                          args.pattern)]) > 1:
+                                          args.pattern)) > 1:
         parser.error("Conflicted pattern options")
 
     if args.pattern is None:

--- a/beancount/utils/defdict.py
+++ b/beancount/utils/defdict.py
@@ -43,7 +43,7 @@ class ImmutableDictWithDefault(dict):
         return value
 
     def get(self, key, _=None):
-        return self.__getitem__(key)
+        return self[key]
 
     # The next three methods are present in order to support pickling. Note that
     # because this class is a specialization of dict, and that dict has a

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ httplib2>=0.10
 requests>=2.0
 beautifulsoup4>=4
 python-magic>=0.4.12; sys_platform != 'win32'
+chardet>=5.0.0


### PR DESCRIPTION
some options are removed from pylint's new version, also remove them from pylintrc.