### PR TITLE
Fix onecommodity plugin

### DIFF
--- a/beancount/plugins/onecommodity.py
+++ b/beancount/plugins/onecommodity.py
@@ -83,7 +83,7 @@ def validate_one_commodity(entries, unused_options_map, config=None):
                 if cost:
                     cost_map[posting.account].add(cost.currency)
                     if len(cost_map[posting.account]) > 1:
-                        units_source_map[posting.account] = entry
+                        cost_source_map[posting.account] = entry
 
         elif isinstance(entry, data.Balance):
             if entry.account in skip_accounts:


### PR DESCRIPTION
The `onecommodity` plugin failed for me with a `KeyError` when an account is used with duplicate cost currencies. It seems that the issue is due to a copy-paste-error, where the variable name has not been updated to match the variable tracking the error.

I have not performed extensive testing, but when running the modified plugin in Fava, it seemed the error has been fixed.