### PR TITLE
Ensure there is (empty) metadata on postings when generating pad transaction #767

### DIFF
--- a/beancount/ops/pad.py
+++ b/beancount/ops/pad.py
@@ -136,12 +136,12 @@ def pad(entries, options_map):
                         new_entry.postings.append(
                             data.Posting(active_pad.account,
                                          diff_position.units, diff_position.cost,
-                                         None, None, None))
+                                         None, None, {}))
                         neg_diff_position = -diff_position
                         new_entry.postings.append(
                             data.Posting(active_pad.source_account,
                                          neg_diff_position.units, neg_diff_position.cost,
-                                         None, None, None))
+                                         None, None, {}))
 
                         # Save it for later insertion after the active pad.
                         new_entries[id(active_pad)].append(new_entry)

--- a/beancount/ops/pad_test.py
+++ b/beancount/ops/pad_test.py
@@ -46,6 +46,8 @@ class TestPadding(cmptest.TestCase):
 
         """, entries)
 
+        self.assertTrue(all(isinstance(p.meta, dict) for p in entries[3].postings))
+
     @loader.load_doc()
     def test_pad_to_zero(self, entries, errors, __):
         """


### PR DESCRIPTION
I'm proposing this as a fix to v2 for the missing metadata on the postings in the pad transactions. This fixes an invariant error (missing metadata). As discussed on bug report #767 ; `beanquery` has already been fixed with commit [2284f1](https://github.com/beancount/beanquery/commit/2284f11637856cac0fedd44f1a3d72d12a36f12a). 