### PR TITLE
Remove unused utility code and clarify dependency on python-dateutil

### DIFF
--- a/beancount/utils/date_utils.py
+++ b/beancount/utils/date_utils.py
@@ -8,8 +8,6 @@ import datetime
 import os
 import time
 
-import dateutil.parser
-
 
 def iter_dates(start_date, end_date):
     """Yield all the dates between 'start_date' and 'end_date'.
@@ -25,24 +23,6 @@ def iter_dates(start_date, end_date):
     while date < end_date:
         yield date
         date += oneday
-
-
-def parse_date_liberally(string, parse_kwargs_dict=None):
-    """Parse arbitrary strings to dates.
-
-    This function is intended to support liberal inputs, so that we can use it
-    in accepting user-specified dates on command-line scripts.
-
-    Args:
-      string: A string to parse.
-      parse_kwargs_dict: Dict of kwargs to pass to dateutil parser.
-    Returns:
-      A datetime.date object.
-    """
-    # At the moment, rely on the most excellent dateutil.
-    if parse_kwargs_dict is None:
-        parse_kwargs_dict = {}
-    return dateutil.parser.parse(string, **parse_kwargs_dict).date()
 
 
 def render_ofx_date(dtime):

--- a/beancount/utils/date_utils_test.py
+++ b/beancount/utils/date_utils_test.py
@@ -18,24 +18,6 @@ class TestDateUtils(unittest.TestCase):
                          list(date_utils.iter_dates(date1, date2)))
         self.assertEqual([], list(date_utils.iter_dates(date2, date1)))
 
-    def test_parse_date_liberally(self):
-        const_date = datetime.date(2014, 12, 7)
-        test_cases = (
-            ('12/7/2014',),
-            ('7-Dec-2014',),
-            ('7/12/2014', {'parserinfo': dateutil.parser.parserinfo(dayfirst=True)}),
-            ('12/7', {'default': datetime.datetime(2014, 1, 1)}),
-            ('7.12.2014', {'dayfirst': True}),
-            ('14 12 7', {'yearfirst': True}),
-            ('Transaction of 7th December 2014', {'fuzzy': True}),
-        )
-        for case in test_cases:
-            if len(case) == 2:
-                parse_date = date_utils.parse_date_liberally(case[0], case[1])
-            else:
-                parse_date = date_utils.parse_date_liberally(case[0])
-            self.assertEqual(const_date, parse_date)
-
     def test_next_month(self):
         self.assertEqual(datetime.date(2015, 11, 1),
                          date_utils.next_month(datetime.date(2015, 10, 1)))

--- a/beancount/utils/date_utils_test.py
+++ b/beancount/utils/date_utils_test.py
@@ -3,7 +3,6 @@ __license__ = "GNU GPLv2"
 
 import unittest
 import datetime
-import dateutil
 
 from beancount.utils import date_utils
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ authors = [
 license = { text = "GPL-2.0-only" }
 requires-python = ">=3.7"
 dependencies = [
-    "click",
-    "python-dateutil",
+    "click >=7.0",
+    "python-dateutil >=2.6.0",
 ]
 dynamic = ["version"]
 

--- a/setup.py
+++ b/setup.py
@@ -139,8 +139,7 @@ setup(
     install_requires=[
         # Command line parsing.
         "click",
-        # We use dateutil for timezone database definitions. See this
-        # article for context: https://assert.cc/posts/dateutil-preferred/
+        # Used to generate recurring events in beancounr.scripts.example.
         "python-dateutil",
     ],
     entry_points={


### PR DESCRIPTION
`beancount.utils.date_utils.parse_date_liberally()` is not used in the codebase. The only user was beanquery, which does not use this function anymore.

Clarify the reason for the dependency on `python-dateutil`.