### PR TITLE
remove merge conflict artefacts

### DIFF
--- a/beancount/plugins/close_tree.py
+++ b/beancount/plugins/close_tree.py
@@ -1,12 +1,6 @@
-<<<<<<< HEAD
 """This plugin inserts close directives for all of an account's descendants when
 an account is closed. Unopened parent accounts can also be closed. Any
 explicitly specified close is left untouched.
-=======
-"""This plugin inserts close directives for all of an account's descendants when an account
-is closed. Unopened parent accounts can also be closed. Any explicitly specified close is
-left untouched.
->>>>>>> github/master
 
 For example, given this::
 


### PR DESCRIPTION
https://github.com/beancount/beancount/commit/44019a8786909480243f12577a1ff0b866ba8554#diff-654e5780b75900b5d82d75dc75cf4ca74f95744d8512781e142925c6fa5be952R5

Looks like there were some merge conflicts text got accidentally merged. Removing them. 