### PR TITLE
parser: Remove line count limit from strings

### DIFF
--- a/beancount/parser/lexer_test.py
+++ b/beancount/parser/lexer_test.py
@@ -293,20 +293,6 @@ class TestLexer(unittest.TestCase):
         self.assertTrue(errors)
         self.assertRegex(errors[0].message, r'\bcheck\b')
 
-    def test_string_too_long_warning(self):
-        test_input = """
-          ;; This is a typical error that should get detected for long strings.
-          2014-01-01 note Assets:Temporary "Bla bla" "
-          2014-02-01 open Liabilities:US:BankWithLongName:Credit-Card:Account01
-        """ + "\n" * 2048 + """
-          2014-02-02 note Assets:Temporary "Bla bla"
-        """
-        builder = lexer.LexBuilder()
-        tokens = list(lexer.lex_iter_string(textwrap.dedent(test_input), builder))
-        self.assertLessEqual(1, len(builder.errors))
-        self.assertRegex(builder.errors[0].message,
-                         'ValueError: String too long (.* lines)')
-
     def test_very_long_string(self):
         # This tests lexing with a string of 256k.
         test_input = '"' + ('1234567890ABCDEF' * (256*64)) + '"'

--- a/beancount/parser/tokens.h
+++ b/beancount/parser/tokens.h
@@ -76,7 +76,7 @@ PyObject* pydecimal_from_cstring(const char* str);
  * string contains is not valid, -ENOMEM if the output string cannot
  * be allocated.
  */
-ssize_t cunescape(const char* string, size_t len, int strict, char** ret, int* lines);
+ssize_t cunescape(const char* string, size_t len, int strict, char** ret);
 
 
 /**

--- a/beancount/parser/tokens_test.c
+++ b/beancount/parser/tokens_test.c
@@ -78,34 +78,29 @@ void test_cunescape()
 {
     char* unescaped;
     ssize_t len;
-    int lines;
     char* s;
 
     s = "a";
-    len = cunescape(s, strlen(s), true, &unescaped, &lines);
+    len = cunescape(s, strlen(s), true, &unescaped);
     assert(len == 1);
-    assert(lines == 1);
     assert(memcmp(unescaped, "a", len) == 0);
     free(unescaped);
 
     s = "something longer";
-    len = cunescape(s, strlen(s), true, &unescaped, &lines);
+    len = cunescape(s, strlen(s), true, &unescaped);
     assert(len == (ssize_t)strlen(s));
-    assert(lines == 1);
     assert(memcmp(unescaped, "something longer", len) == 0);
     free(unescaped);
 
     s = "more\nthan\none\nline";
-    len = cunescape(s, strlen(s), true, &unescaped, &lines);
+    len = cunescape(s, strlen(s), true, &unescaped);
     assert(len == (ssize_t)strlen(s));
-    assert(lines == 4);
     assert(memcmp(unescaped, "more\nthan\none\nline", len) == 0);
     free(unescaped);
 
     s = "escaping\\n\\r";
-    len = cunescape(s, strlen(s), true, &unescaped, &lines);
+    len = cunescape(s, strlen(s), true, &unescaped);
     assert(len == (ssize_t)strlen(s) - 2);
-    assert(lines == 1);
     assert(memcmp(unescaped, "escaping\n\r", len) == 0);
     free(unescaped);
 }


### PR DESCRIPTION
The idea behind enforcing the limit was to detect instances where the user forgot a closing quote. However, for how a beancount ledger is usually structured, it is very hard to hit the line count limit before the ledger contains an unrelated quote character that get interpreted as the closing quote.

There are multiple reports about the limit being to low to for valid input, for example in the case of long plugin configuration strings, and the limit is not effective in detecting invalid ledgers. Remove the limit.