### PR TITLE
setup: Fix typo for extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ setup(
         "python-magic>=0.4.12; sys_platform != 'win32'",
     ],
 
-    extra_require = {
+    extras_require = {
         "test": [
             "pytest",
         ],


### PR DESCRIPTION
This is a fixup for dc761f986c32bbb109cb719969ae55d6eb7247ae to make extras work correctly.