### PR TITLE
Make file type logic work with both magic libraries

### DIFF
--- a/beancount/scripts/deps.py
+++ b/beancount/scripts/deps.py
@@ -111,8 +111,9 @@ def check_python_magic():
 
     python-magic is an interface to libmagic, which is used by the 'file' tool
     and UNIX to identify file types. Note that there are two Python wrappers
-    which provide the 'magic' import: python-magic and filemagic. The former is
-    what we need, which appears to be more recently maintained.
+    which provide the 'magic' import: python-magic and filemagic. We support
+    both, but the former is recommended, as it appears to be more recently
+    maintained.
 
     Returns:
       A triple of (package-name, version-number, sufficient) as per
@@ -120,10 +121,6 @@ def check_python_magic():
     """
     try:
         import magic
-        # Check that python-magic and not filemagic is installed.
-        if not hasattr(magic, 'from_file'):
-            # 'filemagic' is installed; install python-magic.
-            raise ImportError
         return ('python-magic', 'OK', True)
     except (ImportError, OSError):
         return ('python-magic', None, False)

--- a/beancount/utils/file_type.py
+++ b/beancount/utils/file_type.py
@@ -20,12 +20,6 @@ import mimetypes
 # some file types may not be detected..
 try:
     import magic
-    # If 'filemagic' is installed, ignore it. We require the 'python-magic'
-    # wrapper.
-    if not hasattr(magic, 'from_file'):
-        warnings.warn("You have installed 'filemagic' instead of 'python-magic'; "
-                      "disabling.")
-        magic = None # pylint: disable=invalid-name
 except (ImportError, OSError):
     magic = None
 
@@ -60,7 +54,7 @@ def guess_file_type(filename):
 
     # Try out libmagic, if it is installed.
     if magic:
-        filetype = magic.from_file(filename, mime=True)
+        filetype = magic.detect_from_filename(filename).mime_type
         if isinstance(filetype, bytes):
             filetype = filetype.decode('utf8')
         return filetype


### PR DESCRIPTION
The current implementation only works with python-magic because it uses its specific API. However, python-magic includes a [compatibility API](https://github.com/ahupp/python-magic/blob/master/COMPAT.md) as of 0.4.19, so we can use that instead to make the logic compatible with both python-magic and python-file-magic.