### PR TITLE
Correct order of beancount.ops.pad in loader

### DIFF
--- a/beancount/loader.py
+++ b/beancount/loader.py
@@ -42,7 +42,6 @@ LoadError = collections.namedtuple('LoadError', 'source message entry')
 
 # List of default plugins to run.
 PLUGINS_PRE = [
-    ("beancount.ops.pad", None),
     ("beancount.ops.documents", None),
     ]
 
@@ -54,6 +53,7 @@ DEFAULT_PLUGINS_AUTO = [
 PLUGINS_AUTO = []
 
 PLUGINS_POST = [
+    ("beancount.ops.pad", None),
     ("beancount.ops.balance", None),
     ]
 


### PR DESCRIPTION
The present language syntax specifies the following for the pad directive:

> A padding directive automatically inserts a transaction that will make the subsequent balance assertion succeed, if it is needed

However, the present padding behaviour does not satisfy this. This issue has been raised in the google groups at
https://groups.google.com/g/beancount/c/d4AaX1HqXwI.

This commit adds a test to the padding test already present in the repository showing this behaviour. The added test uses a tempfile so I'm not sure if cleanup is needed, however it is similar to the tempfile used in loader_test.py.

This commit also adds the proposed change to loader.py which should correct the behaviour. With the proposed change, all the tests pass.

Should fix #742, but the forecast plugin is no longer in the repository.