### PR TITLE
Fix build breakage

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -67,7 +67,7 @@ def _cppbase_dependencies():
         name = "com_google_absl",
         url = "https://github.com/abseil/abseil-cpp/archive/refs/heads/lts_2022_06_23.tar.gz",
         strip_prefix = "abseil-cpp-lts_2022_06_23",
-        sha256 = "5acf752f4c9a6b4d935e73581ebc86c21722d72bc054b1cc8949a55ae179bc59",
+        sha256 = "9c32fdb4a7d8c38f74145aa0d9d33ca639822022968732143fcd2cc5aee86701",
         updated = "2022-09-06",
     )
 

--- a/beancount/core/BUILD
+++ b/beancount/core/BUILD
@@ -22,9 +22,6 @@ package(default_visibility = [
 py_library(
     name = "account",
     srcs = ["account.py"],
-    deps = [
-        "//beancount/utils:regexp_utils",
-    ],
 )
 
 py_test(

--- a/beancount/utils/BUILD
+++ b/beancount/utils/BUILD
@@ -140,17 +140,6 @@ py_test(
 )
 
 py_library(
-    name = "regexp_utils",
-    srcs = ["regexp_utils.py"],
-)
-
-py_test(
-    name = "regexp_utils_test",
-    srcs = ["regexp_utils_test.py"],
-    deps = [":regexp_utils"],
-)
-
-py_library(
     name = "snoop",
     srcs = ["snoop.py"],
 )


### PR DESCRIPTION
I tried building following [the instructions](https://beancount.github.io/docs/installing_beancount_v3.html) but the build failed:
- The checksum for the Abseil LTS seems to have changed
- https://github.com/beancount/beancount/pull/775 removed `regexp_utils` but didn't update other code that depended on it

I also needed to use the `--noenable_bzlmod` flag.