### PR TITLE
Optionally write a source for entry in printer.print_entries and printer.print_entry

### DIFF
--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -434,7 +434,8 @@ def print_entry(entry, dcontext=None, render_weights=False, file=None,
     output = file or (codecs.getwriter("utf-8")(sys.stdout.buffer)
                       if hasattr(sys.stdout, 'buffer') else
                       sys.stdout)
-    output.write(format_entry(entry, dcontext, render_weights))
+    output.write(format_entry(entry, dcontext, render_weights,
+                              write_source=write_source))
     output.write('\n')
 
 

--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -186,7 +186,7 @@ class EntryPrinter:
         if prefix is None:
             prefix = self.prefix
 
-        oss.write('\n{}; source: {}\n'.format(prefix, render_source(meta)))
+        oss.write('{}; source: {}\n'.format(prefix, render_source(meta)))
 
     def Transaction(self, entry, oss):
         # Compute the string for the payee and narration line.
@@ -470,7 +470,7 @@ def print_entries(entries, dcontext=None, render_weights=False, file=None, prefi
         # of the same type.
         entry_type = type(entry)
         if (entry_type in (data.Transaction, data.Commodity) or
-            entry_type is not previous_type):
+            entry_type is not previous_type or write_source):
             output.write('\n')
             previous_type = entry_type
 

--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -113,6 +113,7 @@ class EntryPrinter:
         self.min_width_account = min_width_account
         self.prefix = prefix or '  '
         self.stringify_invalid_types = stringify_invalid_types
+        self.write_source = write_source
 
     def __call__(self, obj):
         """Render a directive.

--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -124,6 +124,10 @@ class EntryPrinter:
           A string, the rendered directive.
         """
         oss = io.StringIO()
+
+        # We write optional entry source for every entry type, hence writing it here
+        self.write_entry_source(obj.meta, oss, prefix="")
+
         method = getattr(self, obj.__class__.__name__)
         method(obj, oss)
         return oss.getvalue()

--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -171,14 +171,14 @@ class EntryPrinter:
 
     def write_entry_source(self, meta, oss, prefix=None):
         """Write source file and line number in a format interpretable as a message
-        location for Emacs, VSCode or other editors. This information will be
-        commented out by a semicolon. Which will prevent it from being interpreted
-        as as a metadata, if the output is parsed again. Useful for debugging
-        especially in multi-file setups.
+        location for Emacs, VSCode or other editors. As this is for
+        "debugging" purposes, this information will be commented out by a
+        semicolon.
 
         Args:
           meta: A dict that contains the metadata for this directive.
           oss: A file object to write to.
+          prefix: User-specific prefix for custom indentation
         """
         if not self.write_source:
             return
@@ -395,18 +395,19 @@ def render_flag(inflag: Optional[str]) -> str:
     return inflag
 
 
-def format_entry(entry, dcontext=None, render_weights=False, prefix=None, write_source=False):
+def format_entry(entry, dcontext=None, render_weights=False, prefix=None,
+                 write_source=False):
     """Format an entry into a string in the same input syntax the parser accepts.
 
     Args:
       entry: An entry instance.
       dcontext: An instance of DisplayContext used to format the numbers.
       render_weights: A boolean, true to render the weights for debugging.
-      write_source: If true a source file and line number will be written for each
-        entry in a format interpretable as a message location for Emacs, VSCode or
-        other editors. This information will be commented out by a semicolon. Which
-        will prevent it from being interpreted as as a metadata, if the output is
-        parsed again. Useful for debugging especially in multi-file setups.
+      write_source: If true a source file and line number will be written for
+        each entry in a format interpretable as a message location for Emacs,
+        VSCode or other editors. As this is for
+        "debugging" purposes, this information will be commented out by a
+        semicolon.
     Returns:
       A string, the formatted entry.
     """
@@ -423,11 +424,10 @@ def print_entry(entry, dcontext=None, render_weights=False, file=None,
       dcontext: An instance of DisplayContext used to format the numbers.
       render_weights: A boolean, true to render the weights for debugging.
       file: An optional file object to write the entries to.
-      write_source: If true a source file and line number will be written for each
-        entry in a format interpretable as a message location for Emacs, VSCode or
-        other editors. This information will be commented out by a semicolon. Which
-        will prevent it from being interpreted as as a metadata, if the output is
-        parsed again. Useful for debugging especially in multi-file setups.
+      write_source: If true a source file and line number will be written for
+        each entry in a format interpretable as a message location for Emacs,
+        VSCode or other editors. This is usefull for "debugging" peurposes,
+        especially in a multi-file setup
     """
     # TODO(blais): DO remove this now, it's a huge annoyance not to be able to
     # print in-between other statements.
@@ -451,11 +451,10 @@ def print_entries(entries, dcontext=None, render_weights=False, file=None, prefi
       render_weights: A boolean, true to render the weights for debugging.
       file: An optional file object to write the entries to.
       prefix: User-specific prefix for custom indentation (for Fava).
-      write_source: If true a source file and line number will be written for each
-        entry in a format interpretable as a message location for Emacs, VSCode or
-        other editors. This information will be commented out by a semicolon. Which
-        will prevent it from being interpreted as as a metadata, if the output is
-        parsed again. Useful for debugging especially in multi-file setups.
+      write_source: If true a source file and line number will be written for
+        each entry in a format interpretable as a message location for Emacs,
+        VSCode or other editors. This is usefull for "debugging" peurposes,
+        especially in a multi-file setup
     """
     assert isinstance(entries, list), "Entries is not a list: {}".format(entries)
     output = file or (codecs.getwriter("utf-8")(sys.stdout.buffer)

--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -395,13 +395,18 @@ def render_flag(inflag: Optional[str]) -> str:
     return inflag
 
 
-def format_entry(entry, dcontext=None, render_weights=False, prefix=None):
+def format_entry(entry, dcontext=None, render_weights=False, prefix=None, write_source=False):
     """Format an entry into a string in the same input syntax the parser accepts.
 
     Args:
       entry: An entry instance.
       dcontext: An instance of DisplayContext used to format the numbers.
       render_weights: A boolean, true to render the weights for debugging.
+      write_source: If true a source file and line number will be written for each
+        entry in a format interpretable as a message location for Emacs, VSCode or
+        other editors. This information will be commented out by a semicolon. Which
+        will prevent it from being interpreted as as a metadata, if the output is
+        parsed again. Useful for debugging especially in multi-file setups.
     Returns:
       A string, the formatted entry.
     """

--- a/beancount/parser/printer_test.py
+++ b/beancount/parser/printer_test.py
@@ -2,10 +2,12 @@ __copyright__ = "Copyright (C) 2014-2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import io
+import os
 from datetime import date
 import unittest
 import re
 import textwrap
+import tempfile
 
 from beancount.parser import printer
 from beancount.parser import cmptest
@@ -70,6 +72,122 @@ class TestEntryPrinter(cmptest.TestCase):
         # Compare the two output texts.
         self.assertEqual(oss2.getvalue(), oss1.getvalue())
 
+    def assertRoundTripViaRealFile(self, entries1, errors1,
+                                   test_write_source=True):
+        """
+        The same as assertRoundTrip, but the 1st time saves ledger in string
+        format to a real file as an opposite to io.StringIO().
+        This ensures, that when parsed back from file, entries will contain file
+        name and line number metadata.
+
+        Args:
+            test_write_source - if True, will test funtionality write_source,
+            which activates printing of the source file and line number for
+            every transaction
+        """
+        self.assertFalse(errors1)
+
+        # Not using context manager to make this test compatible with Windows
+        # Contex manager can be used as of python 3.12
+        # see https://github.com/python/cpython/issues/58451
+        # https://github.com/beancount/beancount/issues/222
+        oss1 = tempfile.NamedTemporaryFile('w', suffix='.beancount',
+                                           delete=False)
+
+        oss1.write('option "plugin_processing_mode" "raw"\n')
+        printer.print_entries(entries1, file=oss1)
+
+        oss1.close()
+
+        with open(oss1.name, "r") as file:
+            oss1_value = file.read()
+
+        # entries2 will contain information about filename and line number in
+        # metadata
+        entries2, errors, __ = loader.load_file(oss1.name)
+
+        self.assertEqualEntries(entries1, entries2)
+        self.assertFalse(errors)
+
+        oss2 = io.StringIO()
+        oss2.write('option "plugin_processing_mode" "raw"\n')
+
+        # converting entries2 to string now also with the commented out source
+        # information
+        printer.print_entries(entries2, file=oss2, write_source=test_write_source)
+        oss2_value = oss2.getvalue()
+        entries3, errors, __ = loader.load_string(oss2_value)
+
+        # testing, that qnt of '; source' subscrings  is equal to qnt of
+        # entries
+        if test_write_source:
+            self.assertEqual(oss2_value.count("; source"), len(entries3))
+
+        self.assertEqualEntries(entries1, entries3)
+        self.assertFalse(errors)
+
+        if test_write_source:
+            self.assertNotEqual(oss2_value, oss1_value)
+        else:
+            self.assertEqual(oss2.getvalue(), oss1_value)
+
+        # Finally deleting temporary file
+        os.unlink(oss1.name)
+
+    def test_write_source(self):
+        """
+        Targeted testing of the write_source, functionality which activates
+        printing of the source file and line number for every transaction in
+        a commented out form
+        """
+        ORIGINAL_LEDGER = textwrap.dedent("""\
+        2014-01-01 open Assets:Account1
+        2014-01-01 open Assets:Cash
+        
+        2014-06-08 *
+          Assets:Account1       111.00 BEAN
+          Assets:Cash          -111.00 BEAN
+        """)
+
+        # note:this multistring contains some training white spaces
+        EXPECTED_OUTPUT_LEDGER_TEMPL = textwrap.dedent("""
+        ; source: __path_to_file__:1:      
+        2014-01-01 open Assets:Account1
+        
+        ; source: __path_to_file__:2:      
+        2014-01-01 open Assets:Cash
+        
+        ; source: __path_to_file__:4:      
+        2014-06-08 * 
+          Assets:Account1   111.00 BEAN
+          Assets:Cash      -111.00 BEAN
+        """)
+
+
+        # Not using context manager to make this test compatible with Windows
+        # Contex manager can be used as of python 3.12
+        # see https://github.com/python/cpython/issues/58451
+        # https://github.com/beancount/beancount/issues/222
+        oss1 = tempfile.NamedTemporaryFile('w', suffix='.beancount',
+                                           delete=False)
+        oss1.write(ORIGINAL_LEDGER)
+        oss1.close()
+        # entries2 will contain the file name and line number in metadata
+        entries2, errors, __ = loader.load_file(oss1.name)
+        self.assertFalse(errors)
+
+        expected_output_ledger = EXPECTED_OUTPUT_LEDGER_TEMPL.replace(
+            '__path_to_file__',oss1.name)
+
+        # Print out those reparsed and parse them back in.
+        oss2 = io.StringIO()
+        # Getting original ledger but with the source location information
+        printer.print_entries(entries2, file=oss2, write_source=True)
+
+        self.maxDiff=1000
+        self.assertEqual(expected_output_ledger, oss2.getvalue())
+
+
     @loader.load_doc()
     def test_Transaction(self, entries, errors, __):
         """
@@ -123,7 +241,11 @@ class TestEntryPrinter(cmptest.TestCase):
 
         2014-06-20 custom "budget" Assets:Account2 "balance < 200.00 USD" 200.00 10.00 USD
         """
-        self.assertRoundTrip(entries, errors)
+        with self.subTest("RoundTrip test via StringIO"):
+            self.assertRoundTrip(entries, errors)
+
+        with self.subTest("RoundTrip test via real file"):
+            self.assertRoundTripViaRealFile(entries, errors)
 
     @loader.load_doc()
     def test_Balance(self, entries, errors, __):
@@ -131,7 +253,11 @@ class TestEntryPrinter(cmptest.TestCase):
         2014-06-01 open Assets:Account1
         2014-06-08 balance Assets:Account1     0.00 USD
         """
-        self.assertRoundTrip(entries, errors)
+        with self.subTest("RoundTrip test via StringIO"):
+            self.assertRoundTrip(entries, errors)
+
+        with self.subTest("RoundTrip test via real file"):
+            self.assertRoundTripViaRealFile(entries, errors)
 
     @loader.load_doc()
     def test_BalanceTolerance(self, entries, errors, __):
@@ -145,7 +271,11 @@ class TestEntryPrinter(cmptest.TestCase):
 
         2014-06-04 balance Assets:Account1     200.00 ~0.05 USD
         """
-        self.assertRoundTrip(entries, errors)
+        with self.subTest("RoundTrip test via StringIO"):
+            self.assertRoundTrip(entries, errors)
+
+        with self.subTest("RoundTrip test via real file"):
+            self.assertRoundTripViaRealFile(entries, errors)
 
     @loader.load_doc()
     def test_Note(self, entries, errors, __):
@@ -153,7 +283,11 @@ class TestEntryPrinter(cmptest.TestCase):
         2014-06-01 open Assets:Account1
         2014-06-08 note Assets:Account1 "Note"
         """
-        self.assertRoundTrip(entries, errors)
+        with self.subTest("RoundTrip test via StringIO"):
+            self.assertRoundTrip(entries, errors)
+
+        with self.subTest("RoundTrip test via real file"):
+            self.assertRoundTripViaRealFile(entries, errors)
 
     @loader.load_doc()
     def test_Document(self, entries, errors, __):
@@ -167,14 +301,22 @@ class TestEntryPrinter(cmptest.TestCase):
         2014-06-08 document Assets:Account1 "path/to/document2.csv" #tag1
         2014-06-08 document Assets:Account1 "path/to/document2.csv" ^link1
         """
-        self.assertRoundTrip(entries, errors)
+        with self.subTest("RoundTrip test via StringIO"):
+            self.assertRoundTrip(entries, errors)
+
+        with self.subTest("RoundTrip test via real file"):
+            self.assertRoundTripViaRealFile(entries, errors)
 
     @loader.load_doc()
     def test_Query(self, entries, errors, __):
         """
         2014-06-08 query "cash" "SELECT sum(position) WHERE currency = 'USD'"
         """
-        self.assertRoundTrip(entries, errors)
+        with self.subTest("RoundTrip test via StringIO"):
+            self.assertRoundTrip(entries, errors)
+
+        with self.subTest("RoundTrip test via real file"):
+            self.assertRoundTripViaRealFile(entries, errors)
 
     @loader.load_doc()
     def test_Pad(self, entries, errors, __):
@@ -184,7 +326,11 @@ class TestEntryPrinter(cmptest.TestCase):
         2014-06-08 pad Assets:Account1 Assets:Account2
         2014-10-01 balance Assets:Account1  1 USD
         """
-        self.assertRoundTrip(entries, errors)
+        with self.subTest("RoundTrip test via StringIO"):
+            self.assertRoundTrip(entries, errors)
+
+        with self.subTest("RoundTrip test via real file"):
+            self.assertRoundTripViaRealFile(entries, errors)
 
     @loader.load_doc()
     def test_Open(self, entries, errors, __):
@@ -194,7 +340,11 @@ class TestEntryPrinter(cmptest.TestCase):
         2014-06-08 open Assets:Account3  USD,CAD,EUR
         2014-06-08 open Assets:Account4  HOOL   "NONE"
         """
-        self.assertRoundTrip(entries, errors)
+        with self.subTest("RoundTrip test via StringIO"):
+            self.assertRoundTrip(entries, errors)
+
+        with self.subTest("RoundTrip test via real file"):
+            self.assertRoundTripViaRealFile(entries, errors)
 
     @loader.load_doc()
     def test_Close(self, entries, errors, __):
@@ -202,7 +352,11 @@ class TestEntryPrinter(cmptest.TestCase):
         2014-01-01 open  Assets:Account1
         2014-06-08 close Assets:Account1
         """
-        self.assertRoundTrip(entries, errors)
+        with self.subTest("RoundTrip test via StringIO"):
+            self.assertRoundTrip(entries, errors)
+
+        with self.subTest("RoundTrip test via real file"):
+            self.assertRoundTripViaRealFile(entries, errors)
 
     @loader.load_doc()
     def test_Price(self, entries, errors, __):
@@ -210,7 +364,11 @@ class TestEntryPrinter(cmptest.TestCase):
         2014-06-08 price  BEAN   53.24 USD
         2014-06-08 price  USD   1.09 CAD
         """
-        self.assertRoundTrip(entries, errors)
+        with self.subTest("RoundTrip test via StringIO"):
+            self.assertRoundTrip(entries, errors)
+
+        with self.subTest("RoundTrip test via real file"):
+            self.assertRoundTripViaRealFile(entries, errors)
 
     @loader.load_doc()
     def test_Event(self, entries, errors, __):
@@ -218,7 +376,11 @@ class TestEntryPrinter(cmptest.TestCase):
         2014-06-08 event "location" "New York, NY, USA"
         2014-06-08 event "employer" "Four Square"
         """
-        self.assertRoundTrip(entries, errors)
+        with self.subTest("RoundTrip test via StringIO"):
+            self.assertRoundTrip(entries, errors)
+
+        with self.subTest("RoundTrip test via real file"):
+            self.assertRoundTripViaRealFile(entries, errors)
 
     def test_metadata(self):
         meta = data.new_metadata('beancount/core/testing.beancount', 12345)
@@ -226,6 +388,7 @@ class TestEntryPrinter(cmptest.TestCase):
         oss = io.StringIO()
         printer.EntryPrinter().write_metadata(meta, oss)
         self.assertEqual('  something: "a\\"\\\\c"\n', oss.getvalue())
+
 
 
 def characterize_spaces(text):

--- a/beancount/parser/printer_test.py
+++ b/beancount/parser/printer_test.py
@@ -244,6 +244,7 @@ class TestEntryPrinter(cmptest.TestCase):
         with self.subTest("RoundTrip test via StringIO"):
             self.assertRoundTrip(entries, errors)
 
+        #TODO: This test fails on Windows for the entry with escaped symbols
         with self.subTest("RoundTrip test via real file"):
             self.assertRoundTripViaRealFile(entries, errors)
 


### PR DESCRIPTION
This is a pull request to address the new feature discussed here https://github.com/beancount/beancount/issues/807

It adds an optional `write_source` parameter to the `printer.print_entry` and `printer.print_entries` functions to be able to add source file and line number in a format interpretable as a message location for Emacs, VSCode.

This is very useful for "debugging" of beancount ledger especially in multi file setup. as it allows to immediately go to the file and line number in question by clicking on the message location.

**Examples:**

In VSCode terminal

![image](https://github.com/beancount/beancount/assets/59611075/a56de046-d041-44f0-a7cc-e317d2c62030)

In VSCode jupyter notebook

![image](https://github.com/beancount/beancount/assets/59611075/b025b8df-4440-45d5-9ebc-3869f311d043)


