### PR TITLE
Fix implicit price date from cost

### DIFF
--- a/beancount/plugins/implicit_prices.py
+++ b/beancount/plugins/implicit_prices.py
@@ -79,7 +79,7 @@ def add_implicit_prices(entries, unused_options_map):
                     # reducing leg?  Check.
                     meta = data.new_metadata(entry.meta["filename"], entry.meta["lineno"])
                     meta[METADATA_FIELD] = "from_cost"
-                    price_entry = data.Price(meta, entry.date,
+                    price_entry = data.Price(meta, cost.date,
                                              units.currency,
                                              amount.Amount(cost.number, cost.currency))
                 else:


### PR DESCRIPTION
I noticed that when transferring assets having a cost AND a date, the plugin would wrongly infer the transfer date as the price date, instead of the one specified in the cost.

In the following example, it would add a new price for 1 EUR dated 2023-02-14.

```beancount
2023-02-14 * "Move"
    Assets:A                              -50 B {1 EUR, 2021-05-23}
    Assets:C
```

If this is wrong, the fix is pretty simple.