### PR TITLE
Change Posting.units type to Optional[Amount]

### DIFF
--- a/beancount/core/data.py
+++ b/beancount/core/data.py
@@ -190,7 +190,8 @@ class Posting(NamedTuple):
 
     Attributes:
       account: A string, the account that is modified by this posting.
-      units: An Amount, the units of the position.
+      units: An Amount, the units of the position, or None if it is to be
+        inferred from the other postings in the transaction.
       cost: A Cost or CostSpec instances, the units of the position.
       price: An Amount, the price at which the position took place, or
         None, where not relevant. Providing a price member to a posting
@@ -205,7 +206,7 @@ class Posting(NamedTuple):
         of the instances will be unlikely to have metadata.
     """
     account: Account
-    units: Amount
+    units: Optional[Amount]
     cost: Optional[Union[Cost, CostSpec]]
     price: Optional[Amount]
     flag: Optional[Flag]


### PR DESCRIPTION
See [mailing list discussion](https://groups.google.com/g/beancount/c/PkeAxHwN-8U/m/Z3AY2R3XCAAJ?utm_medium=email&utm_source=footer) for background.

I tried running tests, but bazel fails link something from protobuf on my Mac M1 🤷 so only a handful pass.