### PR TITLE
cleanup config for old python version

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -38,7 +38,7 @@ jobs:
       - run: pipx run cibuildwheel==2.19.1
         env:
           # CIBW_BUILD: cp313-*
-          CIBW_SKIP: pp* cp36-* cp37-* *-musllinux*
+          CIBW_SKIP: pp* *-musllinux*
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_ARCHS_WINDOWS: ${{ matrix.architecture }}

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
             "treeify = beancount.tools.treeify:main",
         ]
     },
-    python_requires=">=3.6",
+    python_requires=">=3.8",
 )
 
 


### PR DESCRIPTION
remove py36 and py37 from supported version since they have reached EOL and we don't build wheel for them

There is a lint error but I don't think it's caused be this PR

```text
ruff check .
experiments/docs_rst/convert_docs.py:260:13: PLR1704 Redefining argument with the local name `root`
    |
258 | def FindDocxFiles(root: str):
make: *** [Makefile:218: lint] Error 1
259 |     if path.isdir(root):
260 |         for root, _, files in os.walk(root):
    |             ^^^^ PLR[17](https://github.com/beancount/beancount/actions/runs/9735120460/job/26863956850?pr=833#step:5:18)04
261 |             for filename in files:
262 |                 if re.search(r".docx$", filename):
    |

Found 1 error.
Error: Process completed with exit code 2.
```