### PR TITLE
Bug fix: keep entries when doing beancount.ops.balance check

### DIFF
--- a/beancount/ops/balance.py
+++ b/beancount/ops/balance.py
@@ -108,6 +108,7 @@ def check(entries, options_map):
             # Check that the currency of the balance check is one of the allowed
             # currencies for that account.
             expected_amount = entry.amount
+            open = None
             try:
                 open, _ = open_close_map[entry.account]
             except KeyError:
@@ -118,7 +119,6 @@ def check(entries, options_map):
                         entry,
                     )
                 )
-                continue
 
             if (
                 expected_amount is not None

--- a/beancount/ops/balance_test.py
+++ b/beancount/ops/balance_test.py
@@ -5,7 +5,7 @@ import unittest
 
 from beancount.core.number import D
 from beancount.core.amount import A
-from beancount.ops import balance
+from beancount.ops import balance, validation
 from beancount import loader
 
 
@@ -309,7 +309,11 @@ class TestBalance(unittest.TestCase):
 
         2013-05-10 balance Assets:Invest:Invalid   0 HOOL
         """
-        self.assertEqual([balance.BalanceError], list(map(type, errors)))
+        self.assertEqual([balance.BalanceError, validation.ValidationError], list(map(type, errors)))
+        # balance check shouldn't "eat" the balance entry.
+        self.assertEqual(len(entries), 3)
+        entry = entries[2]
+        self.assertTrue(isinstance(entry, balance.Balance))
 
 
 class TestBalancePrecision(unittest.TestCase):


### PR DESCRIPTION
The check op was removing balance entries in the case where the account does not exist. I think it is better to keep the entry and it to fail validation, this makes it more consistent with other entry types.