### PR TITLE
Revert "Bug fix: keep entries when doing beancount.ops.balance check"

### DIFF
--- a/beancount/ops/balance.py
+++ b/beancount/ops/balance.py
@@ -108,7 +108,6 @@ def check(entries, options_map):
             # Check that the currency of the balance check is one of the allowed
             # currencies for that account.
             expected_amount = entry.amount
-            open = None
             try:
                 open, _ = open_close_map[entry.account]
             except KeyError:
@@ -119,6 +118,7 @@ def check(entries, options_map):
                         entry,
                     )
                 )
+                continue
 
             if (
                 expected_amount is not None

--- a/beancount/ops/balance_test.py
+++ b/beancount/ops/balance_test.py
@@ -310,10 +310,6 @@ class TestBalance(unittest.TestCase):
         2013-05-10 balance Assets:Invest:Invalid   0 HOOL
         """
         self.assertEqual([balance.BalanceError], list(map(type, errors)))
-        # balance check shouldn't "eat" the balance entry.
-        self.assertEqual(len(entries), 3)
-        entry = entries[2]
-        self.assertTrue(isinstance(entry, balance.Balance))
 
 
 class TestBalancePrecision(unittest.TestCase):


### PR DESCRIPTION
Reverts beancount/beancount#835
Tests fail in #834