### PR TITLE
Sort entries by time field in metadata

### DIFF
--- a/beancount/core/data.py
+++ b/beancount/core/data.py
@@ -24,7 +24,6 @@ from beancount.core.number import D
 from beancount.core.position import Cost
 from beancount.core.position import CostSpec
 from beancount.utils.bisect_key import bisect_left_with_key
-from beancount.utils.date_utils import parse_time
 
 # Type declarations.
 Account = str
@@ -706,9 +705,53 @@ def get_entry(posting_or_entry: Directive | TxnPosting) -> Directive:
 SORT_ORDER = {Open: -2, Balance: -1, Document: 1, Close: 2}
 
 
-DEFAULT_ENTRY_TIME = datetime.time(12, 0, 0, tzinfo=datetime.timezone.utc)
+def parse_time(time_str: str, entry_date: datetime.date, default_tz) -> datetime.datetime:
+    """
+    Parse an ISO8601 time string that contains only time information and no date.
+    Time zone handling:
+      1. If the string ends with 'Z', treat it as UTC.
+      2. If the string contains an offset (e.g. '+08:00'), use that offset.
+      3. If no timezone info is provided, assume local time and apply default_tz.
 
-def entry_sortkey(entry):
+    The parsed time is combined with the provided entry_date so that the returned datetime is comparable.
+
+    Args:
+      time_str (str): The ISO8601 time string to parse. If empty or None, a minimal time (00:00:00) is assumed.
+      entry_date (datetime.date): The date component to combine with the time.
+      default_tz: The default timezone to apply if no timezone info is present in the time string.
+
+    Returns:
+      datetime.datetime: The resulting datetime object combining entry_date and the parsed time, or a default minimal datetime with default_tz if time_str is empty.
+    """
+    import datetime
+
+    if not time_str:
+        # Return a default minimal datetime (00:00:00) on entry_date with default_tz
+        return datetime.datetime.combine(entry_date, datetime.time.min).replace(tzinfo=default_tz)
+
+    # If the string ends with 'Z', remove the 'Z' and parse, then attach UTC
+    if time_str.endswith("Z"):
+        try:
+            t = datetime.time.fromisoformat(time_str[:-1])
+        except ValueError as e:
+            raise ValueError(f"Invalid time format: {time_str}") from e
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=datetime.timezone.utc)
+        return datetime.datetime.combine(entry_date, t)
+
+    try:
+        t = datetime.time.fromisoformat(time_str)
+    except ValueError as e:
+        raise ValueError(f"Invalid time format: {time_str}") from e
+
+    # If the parsed time is naive, apply the default_tz
+    if t.tzinfo is None:
+        t = t.replace(tzinfo=default_tz)
+
+    return datetime.datetime.combine(entry_date, t)
+
+
+def entry_sortkey(entry, default_tz):
     """Sort-key for entries. We sort by date, except that checks
     should be placed in front of every list of entries of that same day,
     in order to balance linearly. We also sort by time if the entry has
@@ -717,19 +760,15 @@ def entry_sortkey(entry):
     Args:
       entry: An entry instance.
     Returns:
-      A tuple of (date, integer, datetime.time, integer), that forms the
+      A tuple of (date, integer, datetime.datetime, integer), that forms the
       sort key for the entry.
     """
-    time_value = DEFAULT_ENTRY_TIME
-    if "time" in entry.meta:
-        time_value = parse_time(entry.meta["time"])
+    time = parse_time(entry.meta.get("time"), entry.date, default_tz)
 
-    # We sort by time after the type to ensure Open, Close, and Document
-    # directives appear in the right order.
     return (
         entry.date,
         SORT_ORDER.get(type(entry), 0),
-        time_value,
+        time,
         entry.meta["lineno"],
     )
 
@@ -742,7 +781,7 @@ def sorted(entries: Directives) -> Directives:
     Returns:
       A sorted list of directives.
     """
-    return builtins.sorted(entries, key=entry_sortkey)
+    return builtins.sorted(entries, key=lambda entry: entry_sortkey(entry, datetime.timezone.utc))
 
 
 def posting_sortkey(entry: Directive | TxnPosting) -> tuple[datetime.date, int, int]:

--- a/beancount/core/data_test.py
+++ b/beancount/core/data_test.py
@@ -158,7 +158,7 @@ class TestData(unittest.TestCase):
 
     def test_entry_sortkey(self):
         entries = self.create_sort_data()
-        sorted_entries = sorted(entries, key=data.entry_sortkey)
+        sorted_entries = data.sorted(entries)
         self.check_sorted(sorted_entries)
 
     def test_sort(self):

--- a/beancount/core/prices.py
+++ b/beancount/core/prices.py
@@ -40,7 +40,7 @@ def get_last_price_entries(entries, date):
         if isinstance(entry, Price):
             base_quote = (entry.currency, entry.amount.currency)
             price_entry_map[base_quote] = entry
-    return sorted(price_entry_map.values(), key=data.entry_sortkey)
+    return data.sorted(price_entry_map.values())
 
 
 class PriceMap(dict):

--- a/beancount/loader.py
+++ b/beancount/loader.py
@@ -596,7 +596,9 @@ def _load(
         entries, parse_errors, options_map = _parse_recursive(
             sources, log_timings, encoding
         )
-        entries.sort(key=data.entry_sortkey)
+        from zoneinfo import ZoneInfo
+        tz_info = ZoneInfo(options_map["default_timezone"])
+        entries.sort(key=lambda entry: data.entry_sortkey(entry, tz_info))
 
     # Run interpolation on incomplete entries.
     with misc_utils.log_time("booking", log_timings, indent=1):
@@ -734,7 +736,9 @@ def run_transformations(
 
             # Ensure that the entries are sorted. Don't trust the plugins
             # themselves.
-            entries.sort(key=data.entry_sortkey)
+            from zoneinfo import ZoneInfo
+            tz_info = ZoneInfo(options_map["default_timezone"])
+            entries.sort(key=lambda entry: data.entry_sortkey(entry, tz_info))
 
     return entries, errors
 

--- a/beancount/ops/documents.py
+++ b/beancount/ops/documents.py
@@ -62,7 +62,9 @@ def process_documents(entries, options_map):
 
     # Merge the two lists of entries and errors. Keep the entries sorted.
     entries.extend(autodoc_entries)
-    entries.sort(key=data.entry_sortkey)
+    from zoneinfo import ZoneInfo
+    tz_info = ZoneInfo(options_map["default_timezone"])
+    entries.sort(key=lambda entry: data.entry_sortkey(entry, tz_info))
 
     return (entries, autodoc_errors)
 

--- a/beancount/ops/summarize.py
+++ b/beancount/ops/summarize.py
@@ -509,9 +509,7 @@ def summarize(
     open_entries = get_open_entries(entries, date)
 
     # Compute entries before the date and preserve the entries after the date.
-    before_entries = sorted(
-        open_entries + price_entries + summarizing_entries, key=data.entry_sortkey
-    )
+    before_entries = data.sorted(open_entries + price_entries + summarizing_entries)
     after_entries = entries[index:]
 
     # Return a new list of entries and the index that points after the entries

--- a/beancount/parser/grammar.py
+++ b/beancount/parser/grammar.py
@@ -215,7 +215,9 @@ class Builder(lexer.LexBuilder):
         Returns:
           A list of sorted directives.
         """
-        return sorted(self.entries, key=data.entry_sortkey)
+        from zoneinfo import ZoneInfo
+        tz_info = ZoneInfo(self.options["default_timezone"])
+        return sorted(self.entries, key=lambda entry: data.entry_sortkey(entry, tz_info))
 
     def get_options(self):
         """Return the final options map.

--- a/beancount/parser/options.py
+++ b/beancount/parser/options.py
@@ -148,6 +148,27 @@ def options_validate_leaf_account(value):
     return value
 
 
+def options_validate_timezone(value):
+    """
+    Validate a timezone string.
+
+    Args:
+      value: A string representing the timezone.
+
+    Returns:
+      The timezone string if valid.
+
+    Raises:
+      ValueError: If the timezone string is not recognized.
+    """
+    from zoneinfo import ZoneInfo
+    try:
+        ZoneInfo(value)
+        return value
+    except Exception:
+        raise ValueError("Invalid timezone: " + value)
+
+
 class OptDesc(NamedTuple):
     """An option description.
 
@@ -645,6 +666,19 @@ PUBLIC_OPTION_GROUPS = [
       the PYTHONPATH.
     """,
         [Opt("insert_pythonpath", False, "TRUE", converter=options_validate_boolean)],
+    ),
+    OptGroup(
+        """
+      The default timezone to use for dates without timezone information.
+    """,
+        [
+            Opt(
+                "default_timezone",
+                "America/New_York",
+                "America/New_York",
+                converter=options_validate_timezone,
+            )
+        ],
     ),
 ]
 

--- a/beancount/plugins/auto_accounts.py
+++ b/beancount/plugins/auto_accounts.py
@@ -13,7 +13,7 @@ from beancount.core import getters
 __plugins__ = ("auto_insert_open",)
 
 
-def auto_insert_open(entries, unused_options_map):
+def auto_insert_open(entries, options_map):
     """Insert Open directives for accounts not opened.
 
     Open directives are inserted at the date of the first entry. Open directives
@@ -37,7 +37,9 @@ def auto_insert_open(entries, unused_options_map):
 
     if new_entries:
         new_entries.extend(entries)
-        new_entries.sort(key=data.entry_sortkey)
+        from zoneinfo import ZoneInfo
+        tz_info = ZoneInfo(options_map["default_timezone"])
+        new_entries.sort(key=lambda entry: data.entry_sortkey(entry, tz_info))
     else:
         new_entries = entries
 


### PR DESCRIPTION
This PR provides a temporary quick fix for the issue #332 [(More discussion)](https://groups.google.com/g/beancount/c/zZiFBPU1V8Y). It offers a simple way to add time support to transactions using metadata, addressing a specific scenario where the order of transactions matters across different files.

## Example Use Case
Consider the following two transactions in different .bean files:

First .bean file:
```beancount
2020-03-01 * "transfer"
  Assets:Crypto:Coinbase                   -1 ETH {164.06915 USD, 2019-04-13}
  Assets:Crypto:CoinbasePro                 1 ETH {164.06915 USD, 2019-04-13}
```
Second .bean file:
```beancount
2020-03-01 * "transfer"
  Assets:Crypto:CoinbasePro                -1 ETH {164.06915 USD, 2019-04-13}
  Assets:Crypto:CoinbasePro              1000 USD
  Income:Crypto
```
The first transaction needs to be processed before the second one. If these transactions are in the same file, the order is preserved, and no error occurs. However, when the transactions are in separate files, they are sorted by their line numbers within each file, which can cause processing errors.

## Proposed Solution
With this change, users can add a time field to the transaction metadata, allowing finer control over transaction order across multiple files. For example:

First .bean file:
```beancount
2020-03-01 * "transfer"
  time: "22:47:17"
  Assets:Crypto:Coinbase                   -1 ETH {164.06915 USD, 2019-04-13}
  Assets:Crypto:CoinbasePro                 1 ETH {164.06915 USD, 2019-04-13}
```
Second .bean file:
```beancount
2020-03-01 * "transfer"
  time: "22:57:08"
  Assets:Crypto:CoinbasePro                -1 ETH {164.06915 USD, 2019-04-13}
  Assets:Crypto:CoinbasePro              1000 USD
  Income:Crypto
```

## Timezone Handling (updated 2025 February)
Following the ISO 8601 standard, there are three types of time strings supported:
1. Explicit offset – e.g., `12:34:56+08:00`
2. Zulu time (UTC, denoted by Z) – e.g., `12:34:56Z`
3. Local time – The default timezone specified in the default_timezone option will be used – e.g., `12:34:56`

In the future, support for account-level or even entry/posting-level time and timezone settings may be added.