### PR TITLE
Remove redundant `w` from version 1 description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ There are three versions
   more.
 
 - **Version 1** (`branch v1 <http://github.com/beancount/beancount/tree/v1>`_):
-w  The original version of Beancount. Development on this version halted in 2013.
+  The original version of Beancount. Development on this version halted in 2013.
   This initial version was intended to be similar to and partially compatible
   with Ledger. Do not use this.
 


### PR DESCRIPTION
The `w` prefix in the description of version 1 was unnecessary and confusing. This pull request removes it for clarity. via [code](https://github.com/beancount/beancount/blob/477b8a49f08a9a87ce1c4261dfed50ab076a5b41/README.rst?plain=1#L75-L78)