### PR TITLE
build: Search win_flex and win_bison as alternatives for flex and bison

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('beancount', 'c', version: files('beancount/VERSION'), meson_version: '>=1.1')
 
-bison = find_program('bison', version: '>=3.8.0')
-flex = find_program('flex', version: '>=2.6.4')
+bison = find_program('bison', 'win_bison', version: '>=3.8.0')
+flex = find_program('flex', 'win_flex', version: '>=2.6.4')
 
 py = import('python').find_installation(pure: false)
 


### PR DESCRIPTION
The WinFlexBison package https://github.com/lexxmark/winflexbison/ is probably the easiest way to install flex and bison on Windows. However, this packages installs flex and bison as win_flex and win_bison respectively. Fall back to these if flex or bison are not found under the canonical names. This makes compilation on Windows a bit easier.