### PR TITLE
replace `chdir` with thread-safe root_dir aware glob search  

### DIFF
--- a/beancount/loader.py
+++ b/beancount/loader.py
@@ -31,7 +31,6 @@ from beancount.parser import options
 from beancount.parser import printer
 from beancount.ops import validation
 from beancount.utils import encryption
-from beancount.utils import file_utils
 
 
 OptionsMap = Any
@@ -467,21 +466,24 @@ def _parse_recursive(sources, log_timings, encoding=None):
             # Add includes to the list of sources to process. chdir() for glob,
             # which uses it indirectly.
             include_expanded = []
-            with file_utils.chdir(cwd):
-                for include_filename in src_options_map["include"]:
-                    matched_filenames = glob.glob(include_filename, recursive=True)
-                    if matched_filenames:
-                        include_expanded.extend(matched_filenames)
-                    else:
-                        parse_errors.append(
-                            LoadError(
-                                data.new_metadata("<load>", 0),
-                                'File glob "{}" does not match any files'.format(
-                                    include_filename
-                                ),
-                                None,
-                            )
+            for include_filename in src_options_map["include"]:
+                # TODO(trim21): use `glob.glob(root_dir=cwd)` after we drop py<3.10
+                search_path = include_filename
+                if not os.path.isabs(include_filename):
+                    search_path = os.path.join(cwd, include_filename)
+                matched_filenames = glob.glob(search_path, recursive=True)
+                if matched_filenames:
+                    include_expanded.extend(matched_filenames)
+                else:
+                    parse_errors.append(
+                        LoadError(
+                            data.new_metadata("<load>", 0),
+                            'File glob "{}" does not match any files'.format(
+                                include_filename
+                            ),
+                            None,
                         )
+                    )
             for include_filename in include_expanded:
                 if not path.isabs(include_filename):
                     include_filename = path.join(cwd, include_filename)

--- a/beancount/utils/file_utils.py
+++ b/beancount/utils/file_utils.py
@@ -4,7 +4,6 @@ __copyright__ = "Copyright (C) 2014-2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
 from os import path
-import contextlib
 import logging
 import os
 import time
@@ -99,20 +98,3 @@ def touch_file(filename, *otherfiles):
         new_stat = os.stat(filename)
         if new_stat.st_mtime_ns > orig_mtime_ns:
             break
-
-
-@contextlib.contextmanager
-def chdir(directory):
-    """Temporarily chdir to the given directory.
-
-    Args:
-      directory: The directory to switch do.
-    Returns:
-      A context manager which restores the cwd after running.
-    """
-    cwd = os.getcwd()
-    os.chdir(directory)
-    try:
-        yield cwd
-    finally:
-        os.chdir(cwd)

--- a/beancount/utils/file_utils.py
+++ b/beancount/utils/file_utils.py
@@ -4,9 +4,12 @@ __copyright__ = "Copyright (C) 2014-2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
 from os import path
+import contextlib
 import logging
 import os
 import time
+
+import typing_extensions
 
 
 def find_files(fords, ignore_dirs=(".hg", ".svn", ".git"), ignore_files=(".DS_Store",)):
@@ -98,3 +101,21 @@ def touch_file(filename, *otherfiles):
         new_stat = os.stat(filename)
         if new_stat.st_mtime_ns > orig_mtime_ns:
             break
+
+
+@typing_extensions.deprecated("use contextlib.chdir or community-backport instead")
+@contextlib.contextmanager
+def chdir(directory):
+    """Temporarily chdir to the given directory.
+
+    Args:
+      directory: The directory to switch do.
+    Returns:
+      A context manager which restores the cwd after running.
+    """
+    cwd = os.getcwd()
+    os.chdir(directory)
+    try:
+        yield cwd
+    finally:
+        os.chdir(cwd)

--- a/beancount/utils/file_utils.py
+++ b/beancount/utils/file_utils.py
@@ -4,12 +4,9 @@ __copyright__ = "Copyright (C) 2014-2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
 from os import path
-import contextlib
 import logging
 import os
 import time
-
-import typing_extensions
 
 
 def find_files(fords, ignore_dirs=(".hg", ".svn", ".git"), ignore_files=(".DS_Store",)):
@@ -101,21 +98,3 @@ def touch_file(filename, *otherfiles):
         new_stat = os.stat(filename)
         if new_stat.st_mtime_ns > orig_mtime_ns:
             break
-
-
-@typing_extensions.deprecated("use contextlib.chdir or community-backport instead")
-@contextlib.contextmanager
-def chdir(directory):
-    """Temporarily chdir to the given directory.
-
-    Args:
-      directory: The directory to switch do.
-    Returns:
-      A context manager which restores the cwd after running.
-    """
-    cwd = os.getcwd()
-    os.chdir(directory)
-    try:
-        yield cwd
-    finally:
-        os.chdir(cwd)

--- a/beancount/utils/file_utils_test.py
+++ b/beancount/utils/file_utils_test.py
@@ -7,7 +7,6 @@ from os import path
 import os
 import re
 import unittest
-import tempfile
 
 from beancount.utils import test_utils
 from beancount.utils import file_utils
@@ -84,11 +83,6 @@ class TestMiscFileUtils(unittest.TestCase):
             ("/tmp/tmp.ju3h4h/bla", ".tar.gz"),
             file_utils.path_greedy_split("/tmp/tmp.ju3h4h/bla.tar.gz"),
         )
-
-    def test_chdir_contextmanager(self):
-        with file_utils.chdir(tempfile.gettempdir()) as tmpdir:
-            self.assertIsInstance(tmpdir, str)
-            self.assertEqual(path.realpath(tempfile.gettempdir()), os.getcwd())
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "click >=7.0",
     "python-dateutil >=2.6.0",
     "regex >=2022.9.13",
+    'typing-extensions>=4.5',
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "click >=7.0",
     "python-dateutil >=2.6.0",
     "regex >=2022.9.13",
-    'typing-extensions>=4.5',
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
python 3.10 add `glob.glob(root_dir=...)`, before we drop py<3.10 we need to build abs path from root.

We should delay this after we can run loader_test on win32 to see if it works on win32 too