### PR TITLE
match pre-commit hooks version and lock schema-store

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,13 @@ repos:
     rev: v0.22
     hooks:
       - id: validate-pyproject
-        additional_dependencies: [ "validate-pyproject-schema-store[all]" ]
+        # schema-store include schema for ruff config,
+        # need to match ruff hook version
+        additional_dependencies: [ "validate-pyproject-schema-store[all]==2024.11.25" ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    # when we update this version, need also update schema-store to match it.
+    rev: v0.8.1
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ ignore = [
 ]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+fixable = ["ALL"]
 unfixable = []
 
 per-file-ignores = { }


### PR DESCRIPTION
`validate-pyproject` may validate all ruff rules in ignore/selected are defined in json schema and it may not match the ruff version we are using in pre-commit hooks, and it will fail even ruff config is still valid.

for example, ruff will rename rule TCH to TC in v0.8, and using TC will make ruff v0.7.2 not happy, use TCH will make `validate-pyproject` not happy.
