### PR TITLE
fix!: escape filename in document filename

### DIFF
--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -351,8 +351,8 @@ class EntryPrinter:
 
     def Document(self, entry: Document, oss):
         oss.write(
-            '{e.date} document {e.account} "{filename}"'.format(
-                e=entry, filename=entry.filename.replace("\\", r"\\")
+            "{e.date} document {e.account} {filename}".format(
+                e=entry, filename=misc_utils.quote_string(entry.filename)
             )
         )
         if entry.tags or entry.links:

--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -21,6 +21,7 @@ from beancount.core import account
 from beancount.core import data
 from beancount.core import interpolate
 from beancount.core import display_context
+from beancount.core.data import Document
 from beancount.utils import misc_utils
 
 
@@ -348,8 +349,12 @@ class EntryPrinter:
         oss.write("\n")
         self.write_metadata(entry.meta, oss)
 
-    def Document(self, entry, oss):
-        oss.write('{e.date} document {e.account} "{e.filename}"'.format(e=entry))
+    def Document(self, entry: Document, oss):
+        oss.write(
+            '{e.date} document {e.account} "{filename}"'.format(
+                e=entry, filename=entry.filename.replace("\\", r"\\")
+            )
+        )
         if entry.tags or entry.links:
             oss.write(" ")
             for tag in sorted(entry.tags):

--- a/beancount/parser/printer_test.py
+++ b/beancount/parser/printer_test.py
@@ -286,33 +286,15 @@ class TestEntryPrinter(cmptest.TestCase):
             self.assertRoundTripViaRealFile(entries, errors)
 
     def test_Document(self):
-        # The beancount parser processes escaped characters in all strings,
-        # including the file path in the ``document`` directive.  Windows uses
-        # backslashes as file path separator character.  Unless these are
-        # escaped, the path separators are threated as the beginning of an
-        # escape sequence by the parser, producing the wrong result.
-        #
-        # The path separator characters can be escaped as double backslashes.
-        # However ``beancount.parser.print_entries()`` does not do that,
-        # breaking the round-trip test.  To change ``print_entries()`` to escape
-        # special characters would be an incompatible change.
-        #
-        # The solution could be to use a simple file name in the test, however,
-        # the beancount loader transforms all relative paths into absolute
-        # paths, introducing path separator characters.  Windows also accepts
-        # forward slashes as path separators, therefore, the solution is to
-        # craft the test to use absolute paths with forward slashes on all
-        # platforms.
-        path = os.path.join(os.path.dirname(__file__), "document.pdf").replace("\\", "/")
-
         ledger = textwrap.dedent("""\
         option "plugin_processing_mode" "raw"
         2014-06-01 open Assets:Account1
-        2014-06-08 document Assets:Account1 "{path}"
-        2014-06-08 document Assets:Account1 "{path}" #tag1 #tag2 ^link1 ^link2
-        2014-06-08 document Assets:Account1 "{path}" #tag1
-        2014-06-08 document Assets:Account1 "{path}" ^link1
-        """).format(path=path)
+        2014-06-08 document Assets:Account1 "/path/to/document.pdf"
+        2014-06-08 document Assets:Account1 "path/to/document.csv"
+        2014-06-08 document Assets:Account1 "path/to/document2.csv" #tag1 #tag2 ^link1 ^link2
+        2014-06-08 document Assets:Account1 "path/to/document2.csv" #tag1
+        2014-06-08 document Assets:Account1 "path/to/document2.csv" ^link1
+        """)
         entries, errors, __ = loader.load_string(ledger)
 
         with self.subTest("RoundTrip test via StringIO"):

--- a/beancount/utils/misc_utils.py
+++ b/beancount/utils/misc_utils.py
@@ -5,6 +5,7 @@ Generic utility packages and functions.
 __copyright__ = "Copyright (C) 2014-2017  Martin Blais"
 __license__ = "GNU GPLv2"
 
+import json
 from collections import defaultdict
 from time import time
 import collections
@@ -279,6 +280,12 @@ def compute_unique_clean_ids(strings):
         return None  # Could not find a unique mapping.
 
     return idmap
+
+
+def quote_string(string: str) -> str:
+    """quote a string with characters escaped"""
+    # we use same escaping rule
+    return json.dumps(string, ensure_ascii=False)
 
 
 def escape_string(string):


### PR DESCRIPTION
The intention of our printer is to generate same syntax the parser accept.

Since we expect backslash in filename to be escaped, it's rational that we also escape it in our printer.

This should not have huge impact because it's current output in this case is already broken.
