### PR TITLE
refactor: make our subclass of namedtuple have attributes types

### DIFF
--- a/beancount/core/amount.py
+++ b/beancount/core/amount.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 __copyright__ = "Copyright (C) 2013-2017  Martin Blais"
 __license__ = "GNU GPLv2"
 
+from collections import namedtuple
 import re
 
 from decimal import Decimal
-from typing import NamedTuple, Optional
+from typing import Optional
 
 from beancount.core.display_context import DEFAULT_FORMATTER
 from beancount.core.number import ZERO
@@ -33,15 +34,15 @@ CURRENCY_RE = "|".join(
 )
 
 
-_Amount = NamedTuple("_Amount", [("number", Optional[Decimal]), ("currency", str)])
-
-
-class Amount(_Amount):
+class Amount(namedtuple("Amount", ["number", "currency"])):
     """An 'Amount' represents a number of a particular unit of something.
 
     It's essentially a typed number, with corresponding manipulation operations
     defined on it.
     """
+
+    number: Optional[Decimal]
+    currency: str
 
     __slots__ = ()  # Prevent the creation of new attributes.
 
@@ -57,7 +58,7 @@ class Amount(_Amount):
         """
         assert isinstance(number, Amount.valid_types_number), repr(number)
         assert isinstance(currency, Amount.valid_types_currency), repr(currency)
-        return _Amount.__new__(cls, number, currency)
+        return super().__new__(cls, number, currency)
 
     def to_string(self, dformat=DEFAULT_FORMATTER):
         """Convert an Amount instance to a printable string.

--- a/beancount/core/position.py
+++ b/beancount/core/position.py
@@ -6,6 +6,7 @@ See types below for details.
 __copyright__ = "Copyright (C) 2013-2017  Martin Blais"
 __license__ = "GNU GPLv2"
 
+from collections import namedtuple
 import copy
 import datetime
 import re
@@ -151,10 +152,7 @@ def to_string(pos, dformat=DEFAULT_FORMATTER, detail=True):
     return pos_str
 
 
-_Position = NamedTuple("_Position", [("units", Amount), ("cost", Cost)])
-
-
-class Position(_Position):
+class Position(namedtuple("Position", ["units", "cost"])):
     """A 'Position' is a pair of units and optional cost.
     This is used to track inventories.
 
@@ -162,6 +160,9 @@ class Position(_Position):
       units: An Amount, the number of units and its currency.
       cost: A Cost that represents the lot, or None.
     """
+
+    units: Amount
+    cost: Cost
 
     __slots__ = ()  # Prevent the creation of new attributes.
 
@@ -175,7 +176,7 @@ class Position(_Position):
         assert cost is None or isinstance(
             cost, Position.cost_types
         ), "Expected a Cost for cost; received '{}'".format(cost)
-        return _Position.__new__(cls, units, cost)
+        return super().__new__(cls, units, cost)
 
     def __hash__(self):
         """Compute a hash for this position.


### PR DESCRIPTION
it's not possible to have our own `__new__` to call `super().__new__` with inherit from `NamedTuple`, but it's possible to inhert `namedtuple(...)` to do this