### PR TITLE
enable mypy

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -27,3 +27,17 @@ jobs:
         with:
           python-version: '3.12'
       - uses: pre-commit/action@v3.0.1
+
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # pip doesn't support this
+      - uses: astral-sh/setup-uv@v4
+      - run: uv pip install -r ./pyproject.toml --extra types --system
+
+      - run: mypy .

--- a/beancount/core/account.py
+++ b/beancount/core/account.py
@@ -225,7 +225,8 @@ def parent_matcher(account_name: Account) -> Callable[[Account], bool]:
       A callable, which, when called, will return true if the given account is a
       child of ``account_name``.
     """
-    return re.compile(r"{}($|{})".format(re.escape(account_name), sep)).match
+    pattern = re.compile(r"{}($|{})".format(re.escape(account_name), sep))
+    return lambda s: bool(pattern.match(s))
 
 
 def parents(account_name: Account) -> Iterator[Account]:

--- a/beancount/core/data.py
+++ b/beancount/core/data.py
@@ -264,9 +264,9 @@ class Transaction(NamedTuple):
 
     meta: Meta
     date: datetime.date
-    flag: Flag
+    flag: Flag | None
     payee: str | None
-    narration: str
+    narration: str | None
     tags: frozenset[str]
     links: frozenset[str]
     postings: list[Posting]
@@ -593,14 +593,14 @@ def create_simple_posting_with_cost(
     if cost_number is not None and not isinstance(cost_number, Decimal):
         cost_number = D(cost_number)
     units = Amount(number, currency)
-    cost = Cost(cost_number, cost_currency, None, None)
+    cost = Cost(cost_number, cost_currency, datetime.date(1, 1, 1), None)
     posting = Posting(account, units, cost, None, None, None)
     if entry is not None:
         entry.postings.append(posting)
     return posting
 
 
-NoneType = type(None)
+NoneType: type = type(None)
 
 
 def sanity_check_types(

--- a/beancount/core/getters.py
+++ b/beancount/core/getters.py
@@ -10,6 +10,8 @@ __license__ = "GNU GPLv2"
 from collections import OrderedDict
 from collections import defaultdict
 from typing import TYPE_CHECKING
+from typing import Dict
+from typing import Tuple
 
 from beancount.core import account
 from beancount.core.data import Close
@@ -32,7 +34,7 @@ if TYPE_CHECKING:
     from beancount.core.data import Note
     from beancount.core.data import Pad
 
-    AccountsUseMap = tuple[dict[Account, datetime.date], dict[Account, datetime.date]]
+    AccountsUseMap = Tuple[Dict[Account, datetime.date], Dict[Account, datetime.date]]
 
 
 class GetAccounts:

--- a/beancount/core/prices.py
+++ b/beancount/core/prices.py
@@ -192,7 +192,7 @@ def project(
         return orig_price_map
 
     # Avoid mutating the input map.
-    price_map = {key: list(value) for key, value in orig_price_map.items()}
+    price_map = PriceMap({key: list(value) for key, value in orig_price_map.items()})
 
     # Process the entire database (it's not indexed by quote currency).
     currency_pair = (from_currency, to_currency)

--- a/beancount/loader.py
+++ b/beancount/loader.py
@@ -462,7 +462,7 @@ def _parse_recursive(
                 if encoding:
                     if isinstance(source, bytes):
                         source = source.decode(encoding)
-                    source = source.encode("ascii", "replace")
+                    source = source.encode("ascii", "replace")  # type: ignore[assignment]
 
                 # Parse a string buffer from memory.
                 with misc_utils.log_time(

--- a/beancount/parser/booking_full.py
+++ b/beancount/parser/booking_full.py
@@ -268,7 +268,7 @@ def get_bucket_currency(refer):
 class Refer(NamedTuple):
     """A named tuple to hold currency references for a posting."""
 
-    index: int
+    index: int  # type: ignore[assignment]
     units_currency: str | None
     cost_currency: str | None
     price_currency: str | None

--- a/beancount/parser/booking_method.py
+++ b/beancount/parser/booking_method.py
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
 
     from beancount.core.position import Cost
 
+if TYPE_CHECKING:
+    from decimal import Decimal
+
 
 class AmbiguousMatchError(NamedTuple):
     """An error raised if we failed to reduce the inventory balance unambiguously."""

--- a/beancount/plugins/currency_accounts.py
+++ b/beancount/plugins/currency_accounts.py
@@ -91,7 +91,7 @@ def group_postings_by_weight_currency(entry: Transaction):
     curmap = collections.defaultdict(list)
     has_price = False
     for posting in entry.postings:
-        currency = posting.units.currency
+        currency = posting.units.currency  # type:ignore[union-attr]
         if posting.cost:
             currency = posting.cost.currency
             if posting.price:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+types = [
+    "mypy==1.4.0",
+    "types-regex",
+]
+
 [project.scripts]
 bean-check = "beancount.scripts.check:main"
 bean-doctor = "beancount.scripts.doctor:main"
@@ -42,6 +48,13 @@ treeify = "beancount.tools.treeify:main"
 homepage = "https://beancount.github.io/"
 documentation = "https://beancount.github.io/docs/"
 repository = "https://github.com/beancount/beancount"
+
+[tool.mypy]
+mypy_path = '$MYPY_CONFIG_FILE_DIR'
+exclude = ["tools", "experiments", ".venv", "build", "__pycache__"]
+check_untyped_defs = false
+python_version = '3.8'
+cache_dir = ".venv/.mypy_cache"
 
 [[tool.mypy.overrides]]
 module = "beancount.projects.*"


### PR DESCRIPTION
enable mypy on beancount

1. Add `mypy` and `types-regex` to `types` extra `project.optional-dependencies`
2. add mypy ci job to run mypy checks


this PR add mypy options `check_untyped_defs = false` so it only check function body with arguments/return type checks. untyped function like `def test_a(self):` will not be checked.

use `uv` in ci job there is no way to only install deps without building project from pyproject.toml with pip.

