### PR TITLE
minor type fix

### DIFF
--- a/beancount/core/data.py
+++ b/beancount/core/data.py
@@ -18,7 +18,6 @@ from typing import NamedTuple
 from typing import Protocol
 from typing import Union
 from typing import overload
-from typing import runtime_checkable
 
 from beancount.core.account import has_component
 from beancount.core.amount import Amount
@@ -34,9 +33,8 @@ Flag = str
 Meta = Dict[str, Any]
 
 
-@runtime_checkable
 class BeancountError(Protocol):
-    """Beancount errors are classes with these attributes."""
+    """Beancount errors are objects with these attributes"""
 
     @property
     def source(self) -> Meta: ...

--- a/beancount/loader.py
+++ b/beancount/loader.py
@@ -22,6 +22,7 @@ import time
 import traceback
 import warnings
 from os import path
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import NamedTuple
@@ -34,6 +35,9 @@ from beancount.parser import parser
 from beancount.parser import printer
 from beancount.utils import encryption
 from beancount.utils import misc_utils
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 OptionsMap = Any
 
@@ -83,7 +87,7 @@ _load_file: Callable[
 
 
 def load_file(
-    filename: str,
+    filename: str | Path,
     log_timings: Any = None,
     log_errors: Any = None,
     extra_validations: list[Any] | None = None,
@@ -125,7 +129,7 @@ def load_file(
 
 
 def load_encrypted_file(
-    filename: str,
+    filename: str | Path,
     log_timings: Any = None,
     log_errors: Any = None,
     extra_validations: list[Any] | None = None,

--- a/beancount/utils/encryption.py
+++ b/beancount/utils/encryption.py
@@ -12,7 +12,7 @@ from os import path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import pathlib
+    from pathlib import Path
 
 
 def is_gpg_installed() -> bool:
@@ -33,7 +33,7 @@ def is_gpg_installed() -> bool:
         return False
 
 
-def is_encrypted_file(filename: str | pathlib.Path) -> bool:
+def is_encrypted_file(filename: str | Path) -> bool:
     """Return true if the given filename contains an encrypted file.
 
     Args:
@@ -54,7 +54,7 @@ def is_encrypted_file(filename: str | pathlib.Path) -> bool:
     return False
 
 
-def read_encrypted_file(filename: str | pathlib.Path) -> str:
+def read_encrypted_file(filename: str | Path) -> str:
     """Decrypt and read an encrypted file without temporary storage.
 
     Args:


### PR DESCRIPTION
add `pathlib.Path` on `load_file`, which we are already using it in our tests.

remove `@runtime_checkable` from `BeancountError`

Our errors do not actually inherit BeancountError, and `runtime_checkable` has very stanage runtime behavior (in my opinion) and there is also no need to do `isinstance(..., BeancountError)`

```python
from typing import Any
from typing import NamedTuple

from beancount.core.data import BeancountError


class AnySomeOtherNamedTupleWithSameName(NamedTuple):
    source: Any
    message: Any
    entry: Any


assert isinstance(AnySomeOtherNamedTupleWithSameName(1, 2, 3), BeancountError)
```