### PR TITLE
tests: fix deprecated use of positional count arg to re.subn

### DIFF
--- a/beancount/parser/cmptest_test.py
+++ b/beancount/parser/cmptest_test.py
@@ -158,30 +158,30 @@ class TestTestCase(cmptest.TestCase):
         self.assertEqualEntries(self.ledger_text, entries)
 
         # Try out various modifications and ensure comparison fails.
-        mod_ledger_text, _ = re.subn(r" \* ", " ! ", self.ledger_text, 1)
+        mod_ledger_text, _ = re.subn(r" \* ", " ! ", self.ledger_text, count=1)
         with self.assertRaises(AssertionError):
             self.assertEqualEntries(entries, mod_ledger_text)
 
         mod_ledger_text, _ = re.subn(
-            r"UNION MARKET", "WHOLE FOODS MARKET", self.ledger_text, 1
+            r"UNION MARKET", "WHOLE FOODS MARKET", self.ledger_text, count=1
         )
         with self.assertRaises(AssertionError):
             self.assertEqualEntries(entries, mod_ledger_text)
 
-        mod_ledger_text, _ = re.subn(r"2014-01-27", "2014-01-28", self.ledger_text, 1)
+        mod_ledger_text, _ = re.subn(r"2014-01-27", "2014-01-28", self.ledger_text, count=1)
         with self.assertRaises(AssertionError):
             self.assertEqualEntries(entries, mod_ledger_text)
 
-        mod_ledger_text, _ = re.subn(r"73.64 USD", "73.65 USD", self.ledger_text, 1)
+        mod_ledger_text, _ = re.subn(r"73.64 USD", "73.65 USD", self.ledger_text, count=1)
         with self.assertRaises(AssertionError):
             self.assertEqualEntries(entries, mod_ledger_text)
 
-        mod_ledger_text, _ = re.subn(r"73.64 USD", "73.64 CAD", self.ledger_text, 1)
+        mod_ledger_text, _ = re.subn(r"73.64 USD", "73.64 CAD", self.ledger_text, count=1)
         with self.assertRaises(AssertionError):
             self.assertEqualEntries(entries, mod_ledger_text)
 
         mod_ledger_text, _ = re.subn(
-            r"Expenses:Food:Grocery", "Expenses:Food:Groceries", self.ledger_text, 1
+            r"Expenses:Food:Grocery", "Expenses:Food:Groceries", self.ledger_text, count=1
         )
         with self.assertRaises(AssertionError):
             self.assertEqualEntries(entries, mod_ledger_text)


### PR DESCRIPTION
(these are new deprecations on Python 3.13)