### PR TITLE
Use `Optional[T]` instead of `T | None` for Python 3.9 compatibility

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -7,10 +7,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -34,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: '3.12'
 
       # pip doesn't support this
       - uses: astral-sh/setup-uv@v4

--- a/beancount/core/data.py
+++ b/beancount/core/data.py
@@ -13,6 +13,7 @@ from decimal import Decimal
 from typing import Any
 from typing import Iterator
 from typing import NamedTuple
+from typing import Optional
 from typing import Protocol
 from typing import Union
 from typing import overload
@@ -111,7 +112,7 @@ class Open(NamedTuple):
     date: datetime.date
     account: Account
     currencies: list[Currency]
-    booking: Booking | None
+    booking: Optional[Booking]
 
 
 class Close(NamedTuple):
@@ -198,8 +199,8 @@ class Balance(NamedTuple):
     date: datetime.date
     account: Account
     amount: Amount
-    tolerance: Decimal | None
-    diff_amount: Amount | None
+    tolerance: Optional[Decimal]
+    diff_amount: Optional[Amount]
 
 
 class Posting(NamedTuple):
@@ -228,11 +229,11 @@ class Posting(NamedTuple):
     """
 
     account: Account
-    units: Amount | None
-    cost: Cost | CostSpec | None
-    price: Amount | None
-    flag: Flag | None
-    meta: Meta | None
+    units: Optional[Amount]
+    cost: Optional[Union[Cost, CostSpec]]
+    price: Optional[Amount]
+    flag: Optional[Flag]
+    meta: Optional[Meta]
 
 
 class Transaction(NamedTuple):
@@ -261,8 +262,8 @@ class Transaction(NamedTuple):
     meta: Meta
     date: datetime.date
     flag: Flag
-    payee: str | None
-    narration: str | None
+    payee: Optional[str]
+    narration: Optional[str]
     tags: frozenset[str]
     links: frozenset[str]
     postings: list[Posting]
@@ -305,8 +306,8 @@ class Note(NamedTuple):
     date: datetime.date
     account: Account
     comment: str
-    tags: frozenset[str] | None
-    links: frozenset[str] | None
+    tags: Optional[frozenset[str]]
+    links: Optional[frozenset[str]]
 
 
 class Event(NamedTuple):
@@ -419,8 +420,8 @@ class Document(NamedTuple):
     date: datetime.date
     account: Account
     filename: str
-    tags: frozenset[str] | None
-    links: frozenset[str] | None
+    tags: Optional[frozenset[str]]
+    links: Optional[frozenset[str]]
 
 
 class Custom(NamedTuple):

--- a/beancount/core/data_test.py
+++ b/beancount/core/data_test.py
@@ -3,6 +3,7 @@ __license__ = "GNU GPLv2"
 
 import datetime
 import pickle
+import typing
 import unittest
 from datetime import date
 
@@ -432,6 +433,20 @@ class TestPickle(unittest.TestCase):
         pickled_str = pickle.dumps(txn1)
         txn2 = pickle.loads(pickled_str)
         self.assertEqual(txn1, txn2)
+
+
+class TestAnnotations(unittest.TestCase):
+    def test_directive_typed_named_tuples(self):
+        # While most typing annotations are consumed only by type
+        # checkers, a handful of them provide information that can be
+        # useful at runtime. For example, beanquery uses typing
+        # annotations for the fields of the named tuples holding
+        # ledger directive represenations derive table column types.
+        #
+        # Verify that these annotations can interpreted.
+        for cls in data.ALL_DIRECTIVES:
+            with self.subTest(cls=cls.__name__):
+                typing.get_type_hints(cls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This converts the spelling to the latter form only for type declarations consumed in beanquery, the others are left as an exercise for someone else.