### PR TITLE
build: make meson build_ext target optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -254,18 +254,22 @@ parser = py.extension_module(
 # meson setup build
 # ninja -C build build_ext
 # ```
-custom_target(
-    'build extension and copy back to source tree',
-    input: parser,
-    output: 'build_ext',
-    depends: parser,
-    command: [
-        'cp',
-        parser.full_path(),
-        join_paths(meson.project_source_root(), 'beancount/parser/'),
-    ],
-    build_by_default: false,
-)
+
+cp = find_program('cp', required: false)
+if cp.found()
+    custom_target(
+        'build extension and copy back to source tree',
+        input: parser,
+        output: 'build_ext',
+        depends: parser,
+        command: [
+            cp,
+            parser.full_path(),
+            join_paths(meson.project_source_root(), 'beancount/parser/'),
+        ],
+        build_by_default: false,
+    )
+endif
 
 if get_option('tests').enabled()
     cc = meson.get_compiler('c')


### PR DESCRIPTION
looks like meson are being "too smart" to validate every command, for our `build_ext` target it will check if external program `cp` exists, which will fail on windows without git-bash or binutils.

Let's check `cp` with `find_program` and skip this target if it doesn't exists.

https://github.com/beancount/beancount/discussions/921#discussioncomment-11716559