### PR TITLE
add back DefaultDictWithKey for beangulp compatibility

### DIFF
--- a/beancount/utils/defdict.py
+++ b/beancount/utils/defdict.py
@@ -7,6 +7,20 @@ adding this in eventually.
 __copyright__ = "Copyright (C) 2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
+import collections
+
+
+# Deprecated and only kept around for compatibility with beangulp 0.1
+class DefaultDictWithKey(collections.defaultdict):
+    """A version of defaultdict whose factory accepts the key as an argument.
+    Note: collections.defaultdict would be improved by supporting this directly,
+    this is a common occurrence.
+    """
+
+    def __missing__(self, key):
+        self[key] = value = self.default_factory(key)
+        return value
+
 
 NOTFOUND = object()
 

--- a/beancount/utils/defdict_test.py
+++ b/beancount/utils/defdict_test.py
@@ -2,8 +2,21 @@ __copyright__ = "Copyright (C) 2016  Martin Blais"
 __license__ = "GNU GPLv2"
 import pickle
 import unittest
+from unittest import mock
 
 from beancount.utils import defdict
+
+
+class TestDefDictWithKey(unittest.TestCase):
+    def test_defdict_with_key(self):
+        factory = mock.MagicMock()
+        testdict = defdict.DefaultDictWithKey(factory)
+
+        testdict["a"]
+        testdict["b"]
+        self.assertEqual(2, len(factory.mock_calls))
+        self.assertEqual(("a",), factory.mock_calls[0][1])
+        self.assertEqual(("b",), factory.mock_calls[1][1])
 
 
 class TestImmutableDictWithDefault(unittest.TestCase):


### PR DESCRIPTION
This is still used in the latest released version of beangulp so
beancount master is incompatible with that. This is just a couple of
lines of well-aged code, so I do not think there is a rush to remove
it.
