### PR TITLE
allow balance postings on non-leaf accounts

### DIFF
--- a/beancount/plugins/leafonly_test.py
+++ b/beancount/plugins/leafonly_test.py
@@ -49,6 +49,23 @@ class TestLeafOnly(unittest.TestCase):
         for error in errors:
             self.assertRegex(error.message, "Expenses:Food")
 
+    @loader.load_doc(expect_errors=False)
+    def test_leaf_only3(self, _, errors, __):
+        """
+        plugin "beancount.plugins.leafonly"
+
+        2011-01-01 open Expenses:Food
+        2011-01-01 open Expenses:Food:Restaurant
+        2011-01-01 open Assets:Other
+
+        2011-05-17 * "Something"
+          Expenses:Food:Restaurant   1.00 USD
+          Assets:Other              -1.00 USD
+
+        2011-05-18 balance Expenses:Food 1.00 USD  ;; Allowed balance posting.
+        """
+        self.assertEqual(0, len(errors))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Adjust logic to allow balance postings for non-leaf accounts.
- Refactor LeafOnly plugin
- Add unit test to verify the updated behavior and ensure correctness.

closes #396 