### PR TITLE
fix: create_simple_posting_with_cost produces 0001-01-01 as date

### DIFF
--- a/beancount/core/convert.py
+++ b/beancount/core/convert.py
@@ -28,6 +28,7 @@ from beancount.core import prices
 from beancount.core.amount import Amount
 from beancount.core.number import MISSING
 from beancount.core.position import Cost
+from beancount.core.position import CostSpec
 from beancount.core.position import Position
 
 
@@ -88,6 +89,9 @@ def get_weight(pos):
     # It the object has a cost, use that as the weight, to balance.
     if isinstance(cost, Cost) and isinstance(cost.number, Decimal):
         weight = Amount(cost.number * pos.units.number, cost.currency)
+    # CostSpec is also an acceptable source of cost
+    elif isinstance(cost, CostSpec) and isinstance(cost.number_per, Decimal):
+        weight = Amount(cost.number_per * pos.units.number, cost.currency)
     else:
         # Otherwise use the postings.
         weight = units

--- a/beancount/core/data.py
+++ b/beancount/core/data.py
@@ -590,7 +590,7 @@ def create_simple_posting_with_cost(
     if cost_number is not None and not isinstance(cost_number, Decimal):
         cost_number = D(cost_number)
     units = Amount(number, currency)
-    cost = Cost(cost_number, cost_currency, datetime.date(1, 1, 1), None)
+    cost = CostSpec(cost_number, None, cost_currency, None, None, None)
     posting = Posting(account, units, cost, None, None, None)
     if entry is not None:
         entry.postings.append(posting)


### PR DESCRIPTION
After upgrading from 3.0.0 to 3.1.0, I find that my scripts which uses `create_simple_posting_with_cost()` function now produces lots with `0001-01-01` as date.

It turns out that commit 0f8798110 replaces the `None` value for date with hard-coded `date(1, 1, 1)`.

This PR fixes the issue by replacing `Cost` with `CostSpec`, which accepts `Optional[datetime.date]` as date.