### PR TITLE
Fix CURRENCY_RE to align with rules in lexer.l

### DIFF
--- a/beancount/core/amount.py
+++ b/beancount/core/amount.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 # Note: This is kept in sync with "beancount/parser/lexer.l".
 CURRENCY_RE = "|".join(
     [
-        r"[A-Z][A-Z0-9\'\.\_\-]*[A-Z0-9]?\b",
+        r"[A-Z](?:[A-Z0-9\'\.\_\-]*[A-Z0-9])?\b",
         r"/[A-Z0-9\'\.\_\-]*[A-Z](?:[A-Z0-9\'\.\_\-]*[A-Z0-9])?",
     ]
 )


### PR DESCRIPTION
`CURRENCY_RE` in amount.py allows a currency symbol to be ended with a special character.

This behavior does not match with the lexier.l specification here:  https://github.com/beancount/beancount/blob/994c8a705aa724501c49a5c7ab2df9f6d7c6c456/beancount/parser/lexer.l#L206-L208