### PR TITLE
Support total prices in parsing and printing.

### DIFF
--- a/beancount/parser/grammar.py
+++ b/beancount/parser/grammar.py
@@ -20,6 +20,7 @@ from beancount.core import account
 from beancount.core import data
 from beancount.core import display_context
 from beancount.core.amount import Amount
+from beancount.core.amount import TotalAmount
 from beancount.core.data import EMPTY_SET
 from beancount.core.data import Balance
 from beancount.core.data import Booking
@@ -884,13 +885,8 @@ class Builder(lexer.LexBuilder):
                     )
                 )
                 price = None
-            else:
-                price_number = price.number
-                if price_number is not MISSING:
-                    price_number = (
-                        ZERO if units.number == ZERO else price_number / abs(units.number)
-                    )
-                    price = Amount(price_number, price.currency)
+            elif price.number is not MISSING:
+                price = TotalAmount(units, price)
 
         # Note: Allow zero prices because we need them for round-trips for
         # conversion entries.

--- a/beancount/parser/grammar_test.py
+++ b/beancount/parser/grammar_test.py
@@ -16,6 +16,7 @@ from unittest import mock
 from beancount.core import amount
 from beancount.core import data
 from beancount.core.amount import Amount
+from beancount.core.amount import TotalAmount
 from beancount.core.amount import from_string as A
 from beancount.core.number import MISSING
 from beancount.core.number import ZERO
@@ -1332,7 +1333,9 @@ class TestTotalsAndSigns(unittest.TestCase):
           Assets:Investments:Cash  -2000.00 USD
         """
         posting = entries[0].postings[0]
+        self.assertIsInstance(posting.price, TotalAmount)
         self.assertEqual(amount.from_string("200 USD"), posting.price)
+        self.assertEqual(amount.from_string("2000.00 USD"), posting.price.total)
         self.assertEqual(None, posting.cost)
 
     @parser.parse_doc()
@@ -1343,7 +1346,9 @@ class TestTotalsAndSigns(unittest.TestCase):
           Assets:Investments:Cash  20000.00 USD
         """
         posting = entries[0].postings[0]
+        self.assertIsInstance(posting.price, TotalAmount)
         self.assertEqual(amount.from_string("200 USD"), posting.price)
+        self.assertEqual(amount.from_string("2000.00 USD"), posting.price.total)
         self.assertEqual(None, posting.cost)
 
     @parser.parse_doc(expect_errors=True)

--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -294,7 +294,10 @@ class EntryPrinter:
             position_str = ""
 
         if posting.price is not None:
-            position_str += " @ {}".format(posting.price.to_string(self.dformat_max))
+            if isinstance(posting.price, amount.TotalAmount):
+                position_str += " @@ {}".format(posting.price.total.to_string(self.dformat_max))
+            else:
+                position_str += " @ {}".format(posting.price.to_string(self.dformat_max))
 
         return flag_account, position_str, weight_str
 

--- a/beancount/parser/printer_test.py
+++ b/beancount/parser/printer_test.py
@@ -249,6 +249,10 @@ class TestEntryPrinter(cmptest.TestCase):
           Assets:Account1       111.00 BEAN
           Assets:Cash          -111.00 BEAN
 
+        2014-06-10 * "Entry with total price"
+          Assets:Account1      -111.00 BEAN @@ 50.12 USD
+          Assets:Cash            50.12 USD
+
         2014-06-20 custom "budget" Assets:Account2 "balance < 200.00 USD" 200.00 10.00 USD
         """
         with self.subTest("RoundTrip test via StringIO"):


### PR DESCRIPTION
Given such bank statement:
```csv
"Date","Payee","Account number","Transaction type","Payment reference","Amount (EUR)","Amount (Foreign Currency)","Type Foreign Currency"
"2022-08-08","SCANDIC GDANSK - RECE","","MasterCard Zahlung","-","-255.83","-1201.8","PLN"
```

I want to see such beancount transaction:
```
2022-08-08 * "SCANDIC GDANSK - RECE"
  Assets:Card:N26   -1201.8 PLN @@ 255.83 EUR
  Expenses:Travel:Hotel                        
```

Both prices in the entry should come directly from the CSV, however currently the importer has to calculate unit price and `-1201.8 PLN @ 0.2128723581 USD` would be printed.