### PR TITLE
Enable mypy for beancount scripts

### DIFF
--- a/beancount/core/realization.py
+++ b/beancount/core/realization.py
@@ -42,7 +42,7 @@ from beancount.core.data import Transaction
 from beancount.core.data import TxnPosting
 
 
-class RealAccount(dict):
+class RealAccount(dict): # noqa: PLW1641
     """A realized account, inserted in a tree, that contains the list of realized entries.
 
     Attributes:

--- a/beancount/loader.py
+++ b/beancount/loader.py
@@ -88,7 +88,7 @@ _load_file: Callable[
 
 def load_file(
     filename: str | Path,
-    log_timings: Any = None,
+    log_timings: Callable[[str], None] | None = None,
     log_errors: Any = None,
     extra_validations: list[Any] | None = None,
     encoding: str | None = None,

--- a/beancount/loader_test.py
+++ b/beancount/loader_test.py
@@ -109,7 +109,7 @@ class TestLoader(unittest.TestCase):
         )
         self.assertEqual(0, len(trans_errors))
 
-    def test_load(self):
+    def test_load(self) -> None:
         with test_utils.capture():
             with test_utils.temp_file() as tmpfile:
                 tmpfile.write_text(TEST_INPUT)

--- a/beancount/scripts/check.py
+++ b/beancount/scripts/check.py
@@ -19,7 +19,7 @@ from beancount.utils import misc_utils
 @click.option("--cache-filename", type=click.Path(), help="Override the cache filename.")
 @click.option("--auto", "-a", is_flag=True, help="Implicitly enable auto-plugins.")
 @click.version_option(message=VERSION)
-def main(filename: str, verbose: bool, no_cache: bool, cache_filename: str, auto: bool):
+def main(filename: str, verbose: bool, no_cache: bool, cache_filename: str, auto: bool) -> None:
     """Parse, check and realize a beancount ledger.
 
     This also measures the time it takes to run all these steps.

--- a/beancount/scripts/deps.py
+++ b/beancount/scripts/deps.py
@@ -7,7 +7,6 @@ __copyright__ = "Copyright (C) 2014-2021, 2023-2024  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import sys
-import types
 
 
 def list_dependencies(file=sys.stderr):
@@ -40,7 +39,6 @@ def check_dependencies():
     """
     return [
         check_python(),
-        check_cdecimal(),
         check_import("dateutil"),
     ]
 
@@ -57,40 +55,6 @@ def check_python():
         ".".join(map(str, sys.version_info[:3])),
         sys.version_info[:2] >= (3, 7),
     )
-
-
-def is_fast_decimal(decimal_module):
-    "Return true if a fast C decimal implementation is installed."
-    return isinstance(decimal_module.Decimal().sqrt, types.BuiltinFunctionType)
-
-
-def check_cdecimal():
-    """Check that Python 3.3 or above is installed.
-
-    Returns:
-      A triple of (package-name, version-number, sufficient) as per
-      check_dependencies().
-    """
-    # Note: this code mirrors and should be kept in-sync with that at the top of
-    # beancount.core.number.
-
-    # Try the built-in installation.
-    import decimal
-
-    if is_fast_decimal(decimal):
-        return ("cdecimal", "{} (built-in)".format(decimal.__version__), True)
-
-    # Try an explicitly installed version.
-    try:
-        import cdecimal
-
-        if is_fast_decimal(cdecimal):
-            return ("cdecimal", getattr(cdecimal, "__version__", "OKAY"), True)
-    except ImportError:
-        pass
-
-    # Not found.
-    return ("cdecimal", None, False)
 
 
 def check_python_magic():
@@ -152,7 +116,7 @@ def check_import(package_name, min_version=None, module_name=None):
     return (package_name, version, is_sufficient)
 
 
-def parse_version(version_str: str) -> str:
+def parse_version(version_str: str) -> list[int]:
     """Parse the version string into a comparable tuple."""
     return [int(v) for v in version_str.split(".")]
 

--- a/beancount/scripts/deps.py
+++ b/beancount/scripts/deps.py
@@ -70,7 +70,7 @@ def check_python_magic():
       check_dependencies().
     """
     try:
-        import magic
+        import magic # noqa: PLC0415, I001
 
         # Check that python-magic and not filemagic is installed.
         if not hasattr(magic, "from_file"):

--- a/beancount/scripts/doctor.py
+++ b/beancount/scripts/doctor.py
@@ -350,8 +350,8 @@ def linked(filename, location_spec):
 
 
 def resolve_region_to_entries(
-    entries: list[data.Entries], filename: str, region: tuple[str, int, int]
-) -> list[data.Entries]:
+    entries: data.Entries, filename: str, region: tuple[str, int, int]
+) -> data.Entries:
     """Resolve a filename and region to a list of entries."""
 
     search_filename, first_lineno, last_lineno = region
@@ -360,7 +360,7 @@ def resolve_region_to_entries(
 
     # Find all the entries in the region. (To be clear, this isn't like the
     # 'linked' command, none of the links are followed.)
-    region_entries = [
+    region_entries: data.Entries = [
         entry
         for entry in data.filter_txns(entries)
         if (
@@ -380,7 +380,7 @@ def resolve_region_to_entries(
     type=click.Choice(["value", "cost"]),
     help="Convert balances output to market value or cost.",
 )
-def region(filename, region, conversion):
+def region(filename, region, conversion) -> None:
     """Print out a list of transactions within REGION and compute balances.
 
     The REGION argument is either a stard:end line numbers tuple or a

--- a/beancount/utils/misc_utils.py
+++ b/beancount/utils/misc_utils.py
@@ -121,7 +121,7 @@ def import_curses():
     # Also, consider just using 'blessings' instead, which provides this across
     # multiple platforms.
 
-    import curses
+    import curses  # noqa: PLC0415
 
     return curses
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,6 @@ cache_dir = ".venv/.mypy_cache"
 module = "beancount.projects.*"
 ignore_errors = true
 
-[[tool.mypy.overrides]]
-module = "beancount.scripts.*"
-ignore_errors = true
-
 [tool.black]
 line-length = 92
 # Please note: We use 'ruff format' to autoformat buffers.


### PR DESCRIPTION
Fix a few typings and enable `mypy` for `beancount/scripts`. The build stays red due to #968, but no new errors are introduced.

The obsolete `cdecimal` check is removed in order to avoid:
```
beancount/scripts/deps.py:85: error: Cannot find implementation or library stub for module named "cdecimal"  [import-not-found]
```

A few existing `ruff` failures are decorated with `noqa`; possibly new checks since the last successful build.