### PR TITLE
Fix 968 display context update from

### DIFF
--- a/beancount/core/display_context.py
+++ b/beancount/core/display_context.py
@@ -257,7 +257,9 @@ class DisplayContext:
     """
 
     def __init__(self) -> None:
-        self.ccontexts: dict[Currency, _ContextBase] = collections.defaultdict(_CurrencyContext)
+        self.ccontexts: dict[Currency, _ContextBase] = collections.defaultdict(
+            _CurrencyContext
+        )
         self.ccontexts["__default__"] = _CurrencyContext()
         self.commas = False
 

--- a/beancount/core/display_context.py
+++ b/beancount/core/display_context.py
@@ -259,7 +259,7 @@ class DisplayContext:
     """
 
     def __init__(self) -> None:
-        self.ccontexts: dict[str, _ContextBase] = collections.defaultdict(_CurrencyContext)
+        self.ccontexts: dict[Currency, _ContextBase] = collections.defaultdict(_CurrencyContext)
         self.ccontexts["__default__"] = _CurrencyContext()
         self.commas = False
 
@@ -290,7 +290,12 @@ class DisplayContext:
           other: Another DisplayContext.
         """
         for currency, ccontext in other.ccontexts.items():
-            self.ccontexts[currency].update_from(ccontext)
+            if isinstance(ccontext, _CurrencyContext):
+                self.ccontexts[currency].update_from(ccontext)
+            elif isinstance(ccontext, _FixedPrecisionContext):
+                self.set_fixed_precision(currency, ccontext.fractional_digits)
+            else:
+                pass
 
     def set_fixed_precision(self, currency: Currency, fractional_digits: int) -> None:
         self.ccontexts[currency] = _FixedPrecisionContext(fractional_digits)

--- a/beancount/core/display_context.py
+++ b/beancount/core/display_context.py
@@ -70,7 +70,6 @@ import io
 from decimal import Decimal
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import cast
 
 from beancount.core import distribution
 
@@ -162,7 +161,7 @@ class _ContextBase:
         integer_digits = len(num_tuple.digits) + num_tuple.exponent  # type: ignore[operator]
         self.integer_max = max(self.integer_max, integer_digits)
 
-    def update_from(self, other: _ContextBase) -> None:
+    def update_from(self, other: _CurrencyContext) -> None:
         self.has_sign = self.has_sign or other.has_sign
         self.integer_max = max(self.integer_max, other.integer_max)
 
@@ -204,10 +203,9 @@ class _CurrencyContext(_ContextBase):
         num_tuple = number.as_tuple()
         self.fractional_dist.update(-num_tuple.exponent)  # type: ignore[operator]
 
-    def update_from(self, other: _ContextBase) -> None:
+    def update_from(self, other: _CurrencyContext) -> None:
         super().update_from(other)
-        other_ = cast("_CurrencyContext", other)
-        self.fractional_dist.update_from(other_.fractional_dist)
+        self.fractional_dist.update_from(other.fractional_dist)
 
     def get_fractional(self, precision: Precision) -> int | None:
         """

--- a/beancount/core/display_context_test.py
+++ b/beancount/core/display_context_test.py
@@ -128,6 +128,7 @@ class TestDisplayContext(DisplayContextBaseTest):
 
         dcontext2.set_fixed_precision("A", 1)
         dcontext.update_from(dcontext2)
+        self.assertIsInstance(dcontext.ccontexts["A"], _FixedPrecisionContext)
 
 
 class TestDisplayContextNatural(DisplayContextBaseTest):

--- a/beancount/core/display_context_test.py
+++ b/beancount/core/display_context_test.py
@@ -122,6 +122,13 @@ class TestDisplayContext(DisplayContextBaseTest):
         dformat_xyz = dcontext_replace.build(alignment=Align.NATURAL)
         self.assertEqual(dformat_xyz.format(Decimal("1.23456"), "XYZ"), "1.235")
 
+    def test_set_fixed_precision_can_apply_to_update_from(self):
+        dcontext = display_context.DisplayContext()
+        dcontext2 = display_context.DisplayContext()
+
+        dcontext2.set_fixed_precision("A", 1)
+        dcontext.update_from(dcontext2)
+
 
 class TestDisplayContextNatural(DisplayContextBaseTest):
     alignment = Align.NATURAL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 types = [
     "mypy==1.4.0",
+    "types-python-dateutil",
     "types-regex",
 ]
 


### PR DESCRIPTION
Add some class checking in `update_from` to avoid an `AttributeError` when the other context includes a `_FixedPrecisionContext`.