### PR TITLE
Updating Readme.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,18 +26,18 @@ reports from them, and provides a web interface.
 Documentation
 =============
 
-Documentation can be read at:
+Documentation can be found at:
 
   https://beancount.github.io/docs/
 
 Documentation authoring happens on Google Docs, where you can contribute by
-requesting access or commenting on individual documents. An index of all source
-documents is available here:
+requesting access or commenting on individual documents. 
+An index of all source documents is available here:
 
   http://furius.ca/beancount/doc/index
 
 There's a `mailing-list dedicated to Beancount
-<https://groups.google.com/forum/#!forum/beancount>`_, please post questions
+<https://groups.google.com/forum/#!forum/beancount>`_. Please post questions
 there, so others can share in the responses. More general discussions about
 command-line accounting also occur on the `Ledger mailing-list
 <https://groups.google.com/forum/#!forum/ledger-cli>`_ so you might be
@@ -51,7 +51,7 @@ You can obtain the source code from the official Git repository on Github:
 
   | https://github.com/beancount/beancount/
 
-See the `Installing Beancount`__ document for more details.
+See `Installing Beancount`__ for more details.
 
 __ http://furius.ca/beancount/doc/install
 

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Tickets can be filed at on the Github project page:
 Copyright and License
 =====================
 
-Copyright (C) 2007-2024  Martin Blais.  All Rights Reserved.
+Copyright (C) 2007-2025  Martin Blais.  All Rights Reserved.
 
 This code is distributed under the terms of the "GNU GPLv2 only".
 See COPYING file for details.


### PR DESCRIPTION
Two commits in this pull request:

1. Update the readme copyright notice year from 2024 to 2025
2. Did a little proof reading and rejigged the grammar and wording a tiny bit so that it reads better.