### PR TITLE
Fix parser.printer Balance tolerance condition

### DIFF
--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -321,7 +321,7 @@ class EntryPrinter:
 
         # Render optional tolerance.
         tolerance = ""
-        if entry.tolerance:
+        if entry.tolerance is not None:
             tolerance_fmt = self.dformat.format(entry.tolerance, entry.amount.currency)
             tolerance = "~ {tolerance} ".format(tolerance=tolerance_fmt)
 

--- a/beancount/parser/printer_test.py
+++ b/beancount/parser/printer_test.py
@@ -281,6 +281,7 @@ class TestEntryPrinter(cmptest.TestCase):
           Assets:Cash          -199.95 USD
 
         2014-06-04 balance Assets:Account1     200.00 ~0.05 USD
+        2014-06-05 balance Assets:Account1     199.95 ~0 USD
         """
         with self.subTest("RoundTrip test via StringIO"):
             self.assertRoundTrip(entries, errors)


### PR DESCRIPTION
Dear reviewer:

I am new to this project and have not tested this change in context, so if it is not immediately obvious why the change is correct, please feel free to send this back for me to (figure out how to) write tests.

`entry.tolerance` can be specified as `decimal.Decimal(0)`, and this should be printed but the current condition treats it as falsy. This fix changes the condition to explicitly check for `None`, which I assume will result in the correct behavior given that `tolerance` is expected to be `Optional[decimal.Decimal]`.

Please see https://github.com/beancount/beangulp/issues/192 for further context (i.e. why 0 tolerance should be printed).