### PR TITLE
[BUGFIX] Value function should return cost basis for positions without a price

### DIFF
--- a/beancount/core/convert.py
+++ b/beancount/core/convert.py
@@ -152,7 +152,9 @@ def get_value(pos, price_map, date=None, output_date_prices=None):
         if price_number is not None:
             return Amount(units.number * price_number, value_currency)
 
-    # We failed to infer a conversion rate; return the units.
+    # We failed to infer a conversion rate; return the cost if available, else units.
+    if isinstance(cost, Cost) and isinstance(cost.number, Decimal):
+        return Amount(cost.number * units.number, cost.currency)
     return units
 
 

--- a/beancount/core/convert_test.py
+++ b/beancount/core/convert_test.py
@@ -144,7 +144,7 @@ class TestPositionConversions(unittest.TestCase):
     def test_value__currency_from_cost(self):
         pos = self._pos(A("100 HOOL"), Cost(D("514.00"), "USD", None, None))
         self.assertEqual(A("53000.00 USD"), convert.get_value(pos, self.PRICE_MAP_HIT))
-        self.assertEqual(A("100 HOOL"), convert.get_value(pos, self.PRICE_MAP_EMPTY))
+        self.assertEqual(A("51400.00 USD"), convert.get_value(pos, self.PRICE_MAP_EMPTY))
 
     #
     # Conversion to another currency.
@@ -337,7 +337,7 @@ class TestMarketValue(unittest.TestCase):
         market_value = balances.reduce(
             convert.get_value, self.price_map, datetime.date(2013, 6, 6)
         )
-        self.assertEqual(inventory.from_string("2 MSFT"), market_value)
+        self.assertEqual(inventory.from_string("0.02 USD"), market_value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For bean queries, according to the documentation, if a position has a cost basis but not a price, the value function should return the cost basis. this makes sense as if the user is retrieving values for securities a cost basis is much 'closer' to the actual value than a result like `354.3 RANDOM-STOCK`. See [the docs](https://beancount.github.io/docs/beancount_query_language.html):

```
# Quantities of Positions and Inventories

...

Refer to the table below for explicit examples of each type of posting and how it would get converted and rendered.
posting	raw (full detail)	units	cost	weight	market
Simple	50.00 USD	50.00 USD	50.00 USD	50.00 USD	50.00 USD
With Price Conversion	50.00 USD @ 1.35 CAD	50.00 USD	50.00 USD	67.50 CAD	50.00 USD
Held at Cost	50 VEA {1.35 CAD}	50 VEA	67.50 CAD	67.50 CAD	67.50 CAD
Held at Cost with Price	50 VEA {1.35 CAD} @ 1.45 CAD	50 VEA	67.50 CAD	67.50 CAD	72.50 CAD
```

Here's a more concrete example:
```
2020-01-01 * "Test" "Test"
    Assets:Stock 1 STOCK {100 USD}
    Equity:OpeningBalance
```

for the query `bean-query test.beancount "balances at value"`

should display:
```
       account         SUM(valu
---------------------  --------
Assets:Stock            100 USD
Equity:OpeningBalance  -100 USD
```

but actually displays:
```       account         SUM(value(position
---------------------  ------------------
Assets:Stock            1 STOCK
Equity:OpeningBalance            -100 USD
```

This PR fixes this bug