### PR TITLE
ci: enable python 3.14

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,7 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+          - '3.14'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/beancount/parser/lexer_test.py
+++ b/beancount/parser/lexer_test.py
@@ -272,7 +272,11 @@ class TestLexer(unittest.TestCase):
             tokens,
         )
         self.assertTrue(errors)
-        self.assertRegex(errors[0].message, "out of range|month must be|day must be in")
+        self.assertRegex(
+            errors[0].message,
+            # Python 3.14 changed the ValueError wording to include the day number.
+            r"out of range|month must be|day .*must be in",
+        )
 
     @lex_tokens
     def test_date_followed_by_number(self, tokens, errors):

--- a/beancount/parser/parser_test.py
+++ b/beancount/parser/parser_test.py
@@ -182,6 +182,9 @@ class TestTestUtils(unittest.TestCase):
 
 
 @unittest.skipUnless(hasattr(sys, "getrefcount"), "requires sys.getrefcount()")
+@unittest.skipIf(
+    sys.version_info >= (3, 14), "sys.getrefcount() semantics changed in Python 3.14+"
+)
 class TestReferenceCounting(unittest.TestCase):
     def test_parser_lex(self):
         # Do not use a string to avoid issues due to string interning.


### PR DESCRIPTION
close https://github.com/beancount/beancount/issues/984

IMO, refcount is internal details of cpython can we should not has assertion on it

