### PR TITLE
ci: run pre-commit hooks in lint ci instead of latest ruff

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -11,10 +11,36 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
-      - uses: astral-sh/setup-uv@v5
-      - run: pip install ruff
-      - run: make lint
+          python-version: "3.13"
+
+      - name: Get Current Python Version
+        shell: python
+        id: py
+        run: |
+          import os
+          import sys
+          import hashlib
+
+          v = hashlib.sha3_224(sys.version.encode()).hexdigest()
+
+          with open(os.environ["GITHUB_OUTPUT"], 'a+', encoding="utf-8") as f:
+              env = f.write(f"\nPY={v}\n")
+
+      - uses: actions/cache@v5
+        id: cache
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3-${{ steps.py.outputs.PY }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-3-${{ steps.py.outputs.PY }}-
+
+      - run: pipx run pre-commit run --all-files --show-diff-on-failure --color=always
+
+      - name: Run this action with only post
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: gacts/run-and-post-run@v1
+        with:
+          post: pipx run pre-commit gc
 
   mypy:
     runs-on: ubuntu-latest
@@ -22,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: "3.13"
 
       # pip doesn't support this
       - uses: astral-sh/setup-uv@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,8 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # when we update this version, need also update schema-store to match it.
-    rev: v0.8.1
+    rev: 'v0.14.10'
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [ --fix ]
       - id: ruff-format

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Documentation can be found at:
   https://beancount.github.io/docs/
 
 Documentation authoring happens on Google Docs, where you can contribute by
-requesting access or commenting on individual documents. 
+requesting access or commenting on individual documents.
 An index of all source documents is available here:
 
   http://furius.ca/beancount/doc/index

--- a/experiments/docs/bean-transaction-types
+++ b/experiments/docs/bean-transaction-types
@@ -7,7 +7,9 @@ ledger and identify all the types of transactions to discuss in the cookbook.
 __copyright__ = "Copyright (C) 2013-2018  Martin Blais"
 __license__ = "GNU GPLv2"
 
+import argparse
 import collections
+import logging
 import random
 
 from beancount import loader
@@ -32,9 +34,6 @@ def rename_accounts(entry, rename_map):
 
 
 def main():
-    import argparse
-    import logging
-
     logging.basicConfig(level=logging.INFO, format="%(levelname)-8s: %(message)s")
     parser = argparse.ArgumentParser(description=__doc__.strip())
 


### PR DESCRIPTION
We now have 2 ruff in projects, one is in pre-commit hooks, with pinned version, and one is in ci, without any version specification.

So when someone running pre-commit, the files got formatted by a old version of ruff.

It should be more proper that we also use pre-commit hooks to do the linting in CI.