### PR TITLE
ci: re-enable pre-commit

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -13,8 +13,18 @@ jobs:
         with:
           python-version: '3.13'
       - uses: astral-sh/setup-uv@v5
-      - run: pip install ruff
       - run: make lint
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - uses: astral-sh/setup-uv@v7
+      - run: uv tool install pre-commit --
+      - run: pre-commit run --all-files --show-diff-on-failure --color=always
 
   mypy:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,8 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # when we update this version, need also update schema-store to match it.
-    rev: v0.8.1
+    rev: 'v0.14.10'
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [ --fix ]
       - id: ruff-format

--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,10 @@ constraints dep-constraints: build/beancount.deps
 
 
 # Run the linter on all source code.
+# keep the version in sync with ruff version we have in pre-commit-config.yaml
 ruff lint:
-	NO_COLOR=1 uv tool run ruff check .
-	NO_COLOR=1 uv tool run ruff format .
+	NO_COLOR=1 uv tool run 'ruff==0.14.10' check .
+	NO_COLOR=1 uv tool run 'ruff==0.14.10' format .
 
 mypy typecheck:
 	NO_COLOR=1 uv run --with mypy --with types-python-dateutil --with types-regex mypy .

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Documentation can be found at:
   https://beancount.github.io/docs/
 
 Documentation authoring happens on Google Docs, where you can contribute by
-requesting access or commenting on individual documents. 
+requesting access or commenting on individual documents.
 An index of all source documents is available here:
 
   http://furius.ca/beancount/doc/index

--- a/experiments/docs/bean-transaction-types
+++ b/experiments/docs/bean-transaction-types
@@ -7,7 +7,9 @@ ledger and identify all the types of transactions to discuss in the cookbook.
 __copyright__ = "Copyright (C) 2013-2018  Martin Blais"
 __license__ = "GNU GPLv2"
 
+import argparse
 import collections
+import logging
 import random
 
 from beancount import loader
@@ -32,9 +34,6 @@ def rename_accounts(entry, rename_map):
 
 
 def main():
-    import argparse
-    import logging
-
     logging.basicConfig(level=logging.INFO, format="%(levelname)-8s: %(message)s")
     parser = argparse.ArgumentParser(description=__doc__.strip())
 


### PR DESCRIPTION
We now have 2 ruff entry in projects, one is in pre-commit hooks, with pinned version, and one is in ci (called from `make lint`), without any version specification.

So when someone running pre-commit, the files got formatted by a old version of ruff.

Also we have pre-commit-config.yaml  and did't valid it in ci, cause it `out-of-sync` in project files and pre-commit hooks. This will cause trouble for developer that use pre-commit. And for users that don't use ruff, they have no idea which ruff version should they pick to run `make lint`, the ruff version will changes over time.

It should be more proper that we also use pre-commit hooks to do the linting in CI. (and maybe also in `make lint`?)


