### PR TITLE
ci: upgrade cibuildwheel for python3.14

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -5,34 +5,40 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
+  pull_request:
+    # trigger on self change to validation config
+    paths:
+      - .github/workflows/wheels.yaml
+
 jobs:
   wheels:
     name: Build wheels
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu
+          - os: ubuntu-latest
             architecture: x86_64
-          - os: ubuntu
+          - os: ubuntu-24.04-arm
             architecture: aarch64
-          - os: macos
+          - os: macos-15-intel
             architecture: x86_64
-          - os: macos
+          - os: macos-15
             architecture: arm64
-          - os: windows
+          - os: windows-latest
             architecture: AMD64
-          - os: windows
+          - os: windows-latest
             architecture: x86
-          - os: windows
+          - os: windows-latest
             architecture: ARM64
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v2
+
+      - uses: actions/setup-python@v5
         with:
-          platforms: arm64
-        if: runner.os == 'Linux' && matrix.architecture == 'aarch64'
+          # install a new python so we can use new version of cibuildwheel
+          python-version: '3.14'
 
       - uses: bus1/cabuild/action/msdevshell@v1
         with:
@@ -43,19 +49,22 @@ jobs:
           architecture: x86
         if: runner.os == 'Windows' && matrix.architecture == 'x86'
 
-      - run: pipx run cibuildwheel~=2.21.0
+
+      - run: pip install cibuildwheel~=3.3.0
+
+      - run: cibuildwheel
         env:
-          CIBW_SKIP: pp* *-musllinux*
+          CIBW_SKIP: '*-musllinux*'
           CIBW_ARCHS: ${{ matrix.architecture }}
           CIBW_BEFORE_ALL_LINUX: |
             curl -sSfO https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.xz
             tar xJf bison-3.8.2.tar.xz
             cd bison-3.8.2 && ./configure && make && make install
-            curl -sSfLO https://github.com/westes/flex/files/981163/flex-2.6.4.tar.gz
+            curl -sSfLO https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
             tar xzf flex-2.6.4.tar.gz
-            cd flex-2.6.4 && ./configure && make && make install
+            cd flex-2.6.4 && ./configure CFLAGS="-D_GNU_SOURCE" && make && make install
           CIBW_ENVIRONMENT_MACOS: |
-            PATH="/opt/homebrew/opt/bison/bin:$PATH"
+            PATH="/usr/local/opt/bison/bin:/opt/homebrew/opt/bison/bin:$PATH"
           CIBW_BEFORE_ALL_MACOS: |
             brew install bison
           CIBW_ENVIRONMENT_WINDOWS: |
@@ -65,7 +74,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.architecture }}
+          name: wheels-${{ runner.os }}-${{ matrix.architecture }}
           path: wheelhouse/*.whl
 
   sdist:
@@ -82,6 +91,8 @@ jobs:
 
   upload:
     name: Upload to PyPI
+    # only push to pypi on new tag
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs:
       - wheels
       - sdist


### PR DESCRIPTION
we need new cibuildwheel to build wheels for python3.14

also some minor change because it use new manylinux docker image, shipped with a different version of GCC.