### PR TITLE
ci: setup trusted publishing

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -96,6 +96,11 @@ jobs:
     needs:
       - wheels
       - sdist
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -104,6 +109,3 @@ jobs:
           path: dist
       - run: python -m pip install twine
       - run: python -m twine upload --skip-existing dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
> This approach eliminates the security risks associated with long-lived write tokens, which can be compromised, accidentally exposed in logs, or require manual rotation. (https://docs.npmjs.com/trusted-publishers#how-trusted-publishing-works)

An administrator of the PyPI package will need to finish setting this up on PyPI: https://docs.pypi.org/trusted-publishers/adding-a-publisher/