### PR TITLE
build abi3 wheels for unix platform

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
 
   pull_request:
+    branches:
+      - master
     # trigger on self change to validation config
     paths:
       - .github/workflows/wheels.yaml
@@ -20,12 +22,28 @@ jobs:
         include:
           - os: ubuntu-latest
             architecture: x86_64
+            cibw_build: 'cp39-*'
+            # abi3 wheels
+            build_settings: "setup-args=-Dpython.allow_limited_api=true"
+
           - os: ubuntu-24.04-arm
             architecture: aarch64
+            cibw_build: 'cp39-*'
+            # abi3 wheels
+            build_settings: "setup-args=-Dpython.allow_limited_api=true"
+
           - os: macos-15-intel
             architecture: x86_64
+            cibw_build: 'cp39-*'
+            # abi3 wheels
+            build_settings: "setup-args=-Dpython.allow_limited_api=true"
+
+          # abi3 wheels
           - os: macos-15
             architecture: arm64
+            cibw_build: 'cp39-*'
+            build_settings: "setup-args=-Dpython.allow_limited_api=true"
+
           - os: windows-latest
             architecture: AMD64
           - os: windows-latest
@@ -56,6 +74,8 @@ jobs:
         env:
           CIBW_SKIP: '*-musllinux*'
           CIBW_ARCHS: ${{ matrix.architecture }}
+          CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_BUILD_SETTINGS: ${{ matrix.build_settings }}
           CIBW_BEFORE_ALL_LINUX: |
             curl -sSfO https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.xz
             tar xJf bison-3.8.2.tar.xz
@@ -74,7 +94,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ runner.os }}-${{ matrix.architecture }}
+          name: wheels-${{ runner.os }}-${{ matrix.architecture }}-${{ strategy.job-index }}
           path: wheelhouse/*.whl
 
   sdist:

--- a/beancount/parser/lexer.l
+++ b/beancount/parser/lexer.l
@@ -447,7 +447,6 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size)
     PyObject* read = NULL;
     int ret = 0;
 
-#ifdef PYPY_VERSION_NUM
     Py_ssize_t length;
     char* buffer;
 
@@ -468,28 +467,6 @@ int pyfile_read_into(PyObject *file, char *buf, size_t max_size)
     assert(length <= max_size);
     memcpy(buf, buffer, length);
     ret = length;
-
-#else
-    /* This function could be optimized in two ways: avoiding to
-     * allocate a new memory view object for every block read and
-     * caching the lookup of the readinto method of the file
-     * object. */
-
-    dest = PyMemoryView_FromMemory(buf, max_size, PyBUF_WRITE);
-    if (!dest) {
-	goto error;
-    }
-
-    read = PyObject_CallMethod(file, "readinto", "O", dest);
-    if (!read) {
-	goto error;
-    }
-
-    ret = PyLong_AsSize_t(read);
-    if (PyErr_Occurred()) {
-	ret = 0;
-    }
-#endif
 
 error:
     Py_XDECREF(dest);

--- a/beancount/parser/tokens.h
+++ b/beancount/parser/tokens.h
@@ -126,7 +126,7 @@ PyObject* pydate_from_cstring(const char* string);
 /**
  * Initialize the local datetime globals.
  */
-void initialize_datetime();
+int initialize_datetime();
 
 #ifdef __cplusplus
 }

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,10 @@
-project('beancount', 'c', version: files('beancount/VERSION'), meson_version: '>=1.1')
+project(
+    'beancount',
+    'c',
+    version: files('beancount/VERSION'),
+    default_options: ['python.allow_limited_api=false'],
+    meson_version: '>=1.3.0',
+)
 
 bison = find_program('bison', 'win_bison', version: '>=3.8.0')
 flex = find_program('flex', 'win_flex', version: '>=2.6.4')
@@ -234,6 +240,9 @@ grammar_c = bison_gen.process(
     preserve_path_from: meson.current_source_dir(),
 )
 
+limited_api_version = '3.9'
+use_limited_api = host_machine.system() != 'windows' and py.language_version().version_compare('>=3.9')
+
 parser = py.extension_module(
     '_parser',
     'beancount/parser/decimal.c',
@@ -243,6 +252,7 @@ parser = py.extension_module(
     grammar_c,
     install: true,
     subdir: 'beancount/parser',
+    limited_api: use_limited_api ? limited_api_version : '',
 )
 
 # Support prehistoric development practices: use ``meson setup build;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ requires = [
     "meson >= 1.2.1",
 ]
 
+[tool.meson-python]
+# these allow meson-python to set wheels with abi3 tags,
+# but we still disable it in meson.build
+# for non-support os and python version
+limited-api = true
+
 [project]
 name = "beancount"
 description = "Command-line Double-Entry Accounting"


### PR DESCRIPTION
meson can't build abi3 wheels for windows yet.

the abi3 wheels is disabled by default so users still got non-abi3 wheel when they try to install from source, but we still build them in CI, so users of wheels can use them.