### PR TITLE
pyproject: add dependency groups for easy uv setup

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -36,6 +36,4 @@ jobs:
 
       # pip doesn't support this
       - uses: astral-sh/setup-uv@v5
-      - run: uv pip install -r ./pyproject.toml --extra types --system
-
-      - run: uv run --with mypy --with types-python-dateutil --with types-regex mypy .
+      - run: uv run --no-dev --group types mypy .

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ ruff lint:
 	NO_COLOR=1 uv tool run 'ruff==0.14.10' format .
 
 mypy typecheck:
-	NO_COLOR=1 uv run --with mypy --with types-python-dateutil --with types-regex mypy .
+	NO_COLOR=1 uv run mypy .
 
 # Check everything.
 status check: filter-terms missing-tests dep-constraints multi-imports test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,19 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[project.optional-dependencies]
+[dependency-groups]
+test = [
+    "pytest",
+]
 types = [
-    "mypy==1.4.0",
+    "mypy",
+    "types-python-dateutil",
     "types-regex",
+]
+# The dev group will automatically be installed by uv when using e.g. `uv sync`
+dev = [
+    { include-group = "test" },
+    { include-group = "types" },
 ]
 
 [project.scripts]
@@ -65,6 +74,9 @@ ignore_errors = true
 line-length = 92
 # Please note: We use 'ruff format' to autoformat buffers.
 # See 'rust-format.el' and .dir-locals.el at the root of the project.
+
+[tool.pytest.ini_options]
+testpaths = ["beancount"]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.


### PR DESCRIPTION
Like this, one can just run `uv sync` to get a .venv with test and types dependencies setup as well.
Then also a plain `pytest` or `mypy` in an editor integration works without extra steps.
