### PR TITLE
[fix] treeify: Allow accounts with components starting with a number

### DIFF
--- a/beancount/tools/treeify.py
+++ b/beancount/tools/treeify.py
@@ -22,7 +22,7 @@ import re
 import sys
 
 # Default regular expressions used for splitting.
-DEFAULT_PATTERN = r"(Assets|Liabilities|Equity|Income|Expenses)(:[A-Z][A-Za-z0-9-_']*)*"
+DEFAULT_PATTERN = r"(Assets|Liabilities|Equity|Income|Expenses)(:[A-Z0-9][A-Za-z0-9-_']*)*"
 DEFAULT_DELIMITER = "[ \t]+"
 DEFAULT_SPLITTER = ":"
 

--- a/beancount/tools/treeify_test.py
+++ b/beancount/tools/treeify_test.py
@@ -90,6 +90,7 @@ class TestTreeify(TestTreeifyBase):
     def test_simple(self):
         self.treeify_equal(
             """\
+          2014-10-19 Assets:Home:123ForestLane                    450,000.00 USD
           2014-12-25 Assets:US:BofA:Checking                        5,545.01 USD
           2014-11-11 Assets:US:Federal:PreTax401k
           2014-10-04 Assets:US:Hooli:Vacation                         332.64 VACHR
@@ -109,6 +110,8 @@ class TestTreeify(TestTreeifyBase):
         """,
             """\
                      |-- Assets
+                     |   |-- Home
+          2014-10-19 |   |   `-- 123ForestLane                    450,000.00 USD
                      |   `-- US
                      |       |-- BofA
           2014-12-25 |       |   `-- Checking                       5,545.01 USD


### PR DESCRIPTION
Account components may begin with [0-9], which was disallowed

Added a test case

Resolves #387

I noticed that the `DEFAULT_PATTERN` currently allows underscore and single quote in account names, which are disallowed by the spec/documentation. Not sure if that is intentional or should be changed to strictly conform.