### PR TITLE
feat: add default `None` for Posting optional attributes

### DIFF
--- a/beancount/core/data.py
+++ b/beancount/core/data.py
@@ -229,11 +229,11 @@ class Posting(NamedTuple):
     """
 
     account: Account
-    units: Optional[Amount]
-    cost: Optional[Union[Cost, CostSpec]]
-    price: Optional[Amount]
-    flag: Optional[Flag]
-    meta: Optional[Meta]
+    units: Optional[Amount] = None
+    cost: Optional[Union[Cost, CostSpec]] = None
+    price: Optional[Amount] = None
+    flag: Optional[Flag] = None
+    meta: Optional[Meta] = None
 
 
 class Transaction(NamedTuple):


### PR DESCRIPTION
This is a quality of life change that should not affect any previous code.

Previously `Posting("Expenses:Food")` will throw a `TypeError` becasue it need users to pass all argumenst, but actully only `account: Account` is required.

After this, `Posting("Expenses:Food")` is valid.

But we can't do the same thing fot `Transaction`, because the `postings` is the last property, and `list` is mutable. same problem like the default of value of function arguments.

https://github.com/beancount/beancount/blob/661d3e81476c3eba7c05576454c67698f9d8baf2/beancount/core/data.py#L266-L269 , this default value will be shared by all `Transaction` instance what do not have a `postings` argument.