### PR TITLE
build: use pypi distributed flex/bison

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -56,21 +56,6 @@ jobs:
         env:
           CIBW_SKIP: '*-musllinux*'
           CIBW_ARCHS: ${{ matrix.architecture }}
-          CIBW_BEFORE_ALL_LINUX: |
-            curl -sSfO https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.xz
-            tar xJf bison-3.8.2.tar.xz
-            cd bison-3.8.2 && ./configure && make && make install
-            curl -sSfLO https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
-            tar xzf flex-2.6.4.tar.gz
-            cd flex-2.6.4 && ./configure CFLAGS="-D_GNU_SOURCE" && make && make install
-          CIBW_ENVIRONMENT_MACOS: |
-            PATH="/usr/local/opt/bison/bin:/opt/homebrew/opt/bison/bin:$PATH"
-          CIBW_BEFORE_ALL_MACOS: |
-            brew install bison
-          CIBW_ENVIRONMENT_WINDOWS: |
-            PATH="$PATH;C:/msys64/usr/bin"
-          CIBW_BEFORE_ALL_WINDOWS: |
-            pacman --noconfirm -S bison flex
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 build-backend = "mesonpy"
 requires = [
+    'flex-bin ; sys_platform == "linux" or sys_platform == "darwin"',
+    'bison-bin ; sys_platform == "linux" or sys_platform == "darwin"',
+    'winflexbison-bin>=2.5.25.1 ; sys_platform == "win32"',
     "meson-python >= 0.14.0",
     "meson >= 1.2.1",
 ]


### PR DESCRIPTION
I just create pre-compiled binary on pypi for flex/bison/winflexbison , so it will be possible to use then to build beancount without extra system tool dependency.

They don't target to any python abi, so they doesn't need to release a new version for new python.


https://pypi.org/project/flex-bin/#files
https://pypi.org/project/bison-bin/#files
https://pypi.org/project/winflexbison-bin/#files
