### PR TITLE
bean-format: fix currency column detection in the presence of multiline narrations

### DIFF
--- a/beancount/scripts/format_test.py
+++ b/beancount/scripts/format_test.py
@@ -313,6 +313,42 @@ class TestScriptFormat(test_utils.ClickTestCase):
             result.stdout,
         )
 
+    @test_utils.docfile
+    def test_multiline_narration_like_account(self, filename):
+        """
+        2023-02-02 * "payee" "multiline
+        1                                                                                   :    1234 TEXT"
+          Assets:BIBEssen:Checking                                                             -39.99 EUR
+          Assets:ZeroSum:Transfers                                                              39.99 EUR
+        """
+        result = self.run_with_args(format.main, filename)
+        self.assertEqual(
+            textwrap.dedent("""
+        2023-02-02 * "payee" "multiline
+        1                                                                                   :    1234 TEXT"
+          Assets:BIBEssen:Checking  -39.99 EUR
+          Assets:ZeroSum:Transfers   39.99 EUR
+        """),
+            result.stdout,
+        )
+
+    @test_utils.docfile
+    def test_escaped_quote_in_narration(self, filename):
+        """
+        2023-02-02 * "narration with \\" quote"
+          Assets:Checking                                                             -39.99 EUR
+          Expenses:Test                                                                39.99 EUR
+        """
+        result = self.run_with_args(format.main, filename)
+        self.assertEqual(
+            textwrap.dedent("""
+        2023-02-02 * "narration with \\" quote"
+          Assets:Checking  -39.99 EUR
+          Expenses:Test     39.99 EUR
+        """),
+            result.stdout,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When a transaction contains a multiline narration where the second line happens to be _roughly_ interpretable as a posting, the formatter gets confused and will align all the amounts far to the right.

```beancount
2023-02-02 * "payee" "multiline
1                                                           :    1234 TEXT"
  Assets:BIBEssen:Checking                                     -39.99 EUR
```

This might seem contrived, but it can easily happen when automatically importing from e.g. paypal:

```beancount
2021-09-16 * "PayPal S.a.r.l. et Cie., S.C.A." "Basislastschrift
PP.1234.PP . SOME SHOP Ihr Einkauf bei FOO BAR EREF: 123867451723645 PP.1234PP PAYPAL MREF: AJSH6SA CRED: 128736419832746
  Assets:BIBEssen:Checking                       -14.99 EUR
  Expenses:Entertainment:Games                    14.99 EUR
```


I think the implementation I is probably good enough, but obviously the entire thing is not the most robust piece of code.