### PR TITLE
Simple fix for dropped column

### DIFF
--- a/beancount/core/inventory.py
+++ b/beancount/core/inventory.py
@@ -440,12 +440,7 @@ class Inventory(dict[tuple[str, Optional[Cost]], Position]):
 
             # Compute the new number of units.
             number = pos.units.number + units.number  # type: ignore[operator]
-            if number == ZERO:
-                # If empty, delete the position.
-                del self[key]
-            else:
-                # Otherwise update it.
-                self[key] = Position(Amount(number, units.currency), cost)
+            self[key] = Position(Amount(number, units.currency), cost)
         else:
             # If not found, create a new one.
             if units.number == ZERO:


### PR DESCRIPTION
See also: https://github.com/beancount/beanquery/issues/271 

I'm not sure this is the RIGHT fix for the long term, but it fixes my test case (and my real case) where a column that only has rows that are sums (aggregates in general) that are zero get dropped.

I'd welcome feedback on whether this change will cause problems elsewhere, what a better/more complete fix might be, and how I can improve the PR (e.g. adding a test case).

Using the test case below, using the code from Pypi I get:

```
$ python3 bug.py
+---------------+
| leaf(account) |
+---------------+
| Bob           |
+---------------+
```

With this change (hand applied to the installed code, sigh...), I get:

```
$ python3 bug.py
+---------------+---------------------+
| leaf(account) | sum(position) (USD) |
+---------------+---------------------+
| Bob           | 0.00                |
+---------------+---------------------+
```

Rather than deleting positions that are zero, it just passes them on up the chain.

To test, save this ledger as `bug.beancount`

```
option "title" "Bug demo"

2025-08-01 * "Bob bought a this expense"
  Income:Bob                                   -1.00 USD
  Expenses:This:Bob                             1.00 USD
```

Then run this query (ignore whining about unopened accounts) via `bean-query bug.beancount`:

```
select leaf(account), sum(position) where account ~ "^(Expenses|Income).*" group by leaf(account)
```

or run this little python program

```
"""Document this..."""

import sys

from beancount import loader
from beanquery import query, query_render

entries, errors, options_map = loader.load_file("bug.beancount")

fmtopts = dict(
    boxed=True, spaced=False, narrow=False, nullvalue="0.00", numberify=False
)

sql = 'select leaf(account), sum(position) where account ~ "^(Income|Expenses).*" group by leaf(account)'
rtypes, rrows = query.run_query(entries, options_map, sql, None, numberify=True)
query_render.render_text(rtypes, rrows, options_map["dcontext"], sys.stdout, **fmtopts)
```