### PR TITLE
build: include generated source in sdist

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -11,8 +11,61 @@ on:
       - .github/workflows/wheels.yaml
 
 jobs:
+
+  verify-wheel-from-sdist:
+    name: Verify wheel build from sdist
+    needs:
+      - sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: source
+          path: dist
+
+      - name: Install GNU flex/bison
+        run: sudo apt-get update && sudo apt-get install -y flex bison
+
+      - name: Build wheel from sdist
+        run: |
+          mkdir -p wheelhouse
+          python -m pip wheel dist/*.tar.gz -w wheelhouse
+
+  verify-wheel-from-root:
+    name: Verify wheel build from repo root
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install GNU flex/bison
+        run: sudo apt-get update && sudo apt-get install -y flex bison
+
+      - name: Verify generated parser files are absent in repo
+        run: |
+          test ! -f beancount/parser/lexer.c
+          test ! -f beancount/parser/lexer.h
+          test ! -f beancount/parser/grammar.c
+          test ! -f beancount/parser/grammar.h
+
+      - name: Build wheel from repository root
+        run: |
+          mkdir -p wheelhouse
+          python -m pip wheel . -w wheelhouse
+
   wheels:
     name: Build wheels
+    needs:
+      - sdist
+      - verify-wheel-from-sdist
+      - verify-wheel-from-root
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -33,7 +86,10 @@ jobs:
           - os: windows-latest
             architecture: ARM64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: source
+          path: dist
 
       - uses: actions/setup-python@v5
         with:
@@ -49,10 +105,15 @@ jobs:
           architecture: x86
         if: runner.os == 'Windows' && matrix.architecture == 'x86'
 
+        # a dirty fix for bug of cibuildwheel
+      - run: rm -rf 'C:/Program Files/Git/usr/bin/link.EXE'
+        shell: bash
+        if: runner.os == 'Windows'
 
       - run: pip install cibuildwheel~=3.3.0
 
-      - run: cibuildwheel
+      - run: cibuildwheel dist/*.tar.gz
+        shell: bash
         env:
           CIBW_SKIP: '*-musllinux*'
           CIBW_ARCHS: ${{ matrix.architecture }}
@@ -67,8 +128,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y flex bison
       - run: python -m pip install build
       - run: python -m build --sdist
+      - name: Verify generated parser sources in sdist
+        run: |
+          tar -tf dist/*.tar.gz | grep -E '/beancount/parser/lexer\.(c|h)$'
+          tar -tf dist/*.tar.gz | grep -E '/beancount/parser/grammar\.(c|h)$'
       - uses: actions/upload-artifact@v4
         with:
           name: source

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -11,25 +11,6 @@ on:
       - .github/workflows/wheels.yaml
 
 jobs:
-
-  verify-wheel-from-sdist:
-    name: Verify wheel build from sdist
-    needs:
-      - sdist
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: source
-          path: dist
-
-      - name: Build wheel from sdist
-        run: pipx build dist/*.tar.gz
-
   verify-wheel-from-root:
     name: Verify wheel build from repo root
     runs-on: ubuntu-latest
@@ -51,13 +32,12 @@ jobs:
           test ! -f beancount/parser/grammar.h
 
       - name: Build wheel from repository root
-        run: pipx build .
+        run: pipx run build .
 
   wheels:
     name: Build wheels
     needs:
       - sdist
-      - verify-wheel-from-sdist
       - verify-wheel-from-root
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -56,9 +56,7 @@ jobs:
           test ! -f beancount/parser/grammar.h
 
       - name: Build wheel from repository root
-        run: |
-          mkdir -p wheelhouse
-          python -m pip wheel . -w wheelhouse
+        run: pipx build .
 
   wheels:
     name: Build wheels

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -27,13 +27,8 @@ jobs:
           name: source
           path: dist
 
-      - name: Install GNU flex/bison
-        run: sudo apt-get update && sudo apt-get install -y flex bison
-
       - name: Build wheel from sdist
-        run: |
-          mkdir -p wheelhouse
-          python -m pip wheel dist/*.tar.gz -w wheelhouse
+        run: pipx build dist/*.tar.gz
 
   verify-wheel-from-root:
     name: Verify wheel build from repo root

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,29 @@
 project('beancount', 'c', version: files('beancount/VERSION'), meson_version: '>=1.1')
 
-bison = find_program('bison', 'win_bison', version: '>=3.8.0')
-flex = find_program('flex', 'win_flex', version: '>=2.6.4')
+fs = import('fs')
+
+parser_codegen_sources = [
+    'beancount/parser/lexer.c',
+    'beancount/parser/lexer.h',
+    'beancount/parser/grammar.c',
+    'beancount/parser/grammar.h',
+]
+
+has_pregenerated_parser = true
+foreach source : parser_codegen_sources
+    if not fs.exists(meson.current_source_dir() / source)
+        has_pregenerated_parser = false
+    endif
+endforeach
+
+bison = disabler()
+flex = disabler()
+has_codegen_tools = false
+if not has_pregenerated_parser
+    bison = find_program('bison', 'win_bison', version: '>=3.8.0')
+    flex = find_program('flex', 'win_flex', version: '>=2.6.4')
+    has_codegen_tools = true
+endif
 
 py = import('python').find_installation(pure: false)
 
@@ -212,27 +234,41 @@ if host_machine.system() == 'windows'
     add_project_arguments('-DYY_NO_UNISTD_H', language: 'c')
 endif
 
-flex_gen = generator(
-    flex,
-    output: ['@BASENAME@.c', '@BASENAME@.h'],
-    arguments: ['--outfile=@OUTPUT0@', '--header-file=@OUTPUT1@', '@INPUT@']
-)
+if has_pregenerated_parser
+    lexer_c = 'beancount/parser/lexer.c'
+    grammar_c = 'beancount/parser/grammar.c'
+else
+    flex_gen = generator(
+        flex,
+        output: ['@BASENAME@.c', '@BASENAME@.h'],
+        arguments: ['--outfile=@OUTPUT0@', '--header-file=@OUTPUT1@', '@INPUT@']
+    )
 
-lexer_c = flex_gen.process(
-    'beancount/parser/lexer.l',
-    preserve_path_from: meson.current_source_dir(),
-)
+    lexer_c = flex_gen.process(
+        'beancount/parser/lexer.l',
+        preserve_path_from: meson.current_source_dir(),
+    )
 
-bison_gen = generator(
-    bison,
-    output: ['@BASENAME@.c', '@BASENAME@.h'],
-    arguments: ['--report=itemset', '--verbose', '-Wall', '-Werror', '-o', '@OUTPUT0@', '@INPUT@']
-)
+    bison_gen = generator(
+        bison,
+        output: ['@BASENAME@.c', '@BASENAME@.h'],
+        arguments: ['--report=itemset', '--verbose', '-Wall', '-Werror', '-o', '@OUTPUT0@', '@INPUT@']
+    )
 
-grammar_c = bison_gen.process(
-    'beancount/parser/grammar.y',
-    preserve_path_from: meson.current_source_dir(),
-)
+    grammar_c = bison_gen.process(
+        'beancount/parser/grammar.y',
+        preserve_path_from: meson.current_source_dir(),
+    )
+endif
+
+if (not has_pregenerated_parser) and has_codegen_tools
+    meson.add_dist_script(
+        py,
+        meson.project_source_root() / 'tools/generate_parser_for_sdist.py',
+        bison.full_path(),
+        flex.full_path(),
+    )
+endif
 
 parser = py.extension_module(
     '_parser',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [build-system]
 build-backend = "mesonpy"
 requires = [
-    'flex-bin ; sys_platform == "linux" or sys_platform == "darwin"',
-    'bison-bin ; sys_platform == "linux" or sys_platform == "darwin"',
-    'winflexbison-bin>=2.5.25.1 ; sys_platform == "win32"',
     "meson-python >= 0.14.0",
     "meson >= 1.2.1",
 ]

--- a/tools/generate_parser_for_sdist.py
+++ b/tools/generate_parser_for_sdist.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Generate parser C sources into the Meson dist directory."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+
+
+def run(command: list[str], cwd: pathlib.Path) -> None:
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: generate_parser_for_sdist.py <bison> <flex>",
+            file=sys.stderr,
+        )
+        return 2
+
+    dist_root_env = os.environ.get("MESON_DIST_ROOT")
+    if not dist_root_env:
+        print("MESON_DIST_ROOT is not set", file=sys.stderr)
+        return 2
+
+    dist_root = pathlib.Path(dist_root_env)
+    parser_dir = dist_root / "beancount" / "parser"
+
+    bison = pathlib.Path(sys.argv[1])
+    flex = pathlib.Path(sys.argv[2])
+
+    run(
+        [
+            str(flex),
+            "--outfile=lexer.c",
+            "--header-file=lexer.h",
+            "lexer.l",
+        ],
+        cwd=parser_dir,
+    )
+
+    run(
+        [
+            str(bison),
+            "--report=itemset",
+            "--verbose",
+            "-Wall",
+            "-Werror",
+            "-o",
+            "grammar.c",
+            "grammar.y",
+        ],
+        cwd=parser_dir,
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
now we include generate files in sdist and build wheels from sdist in ci. so even we haven't build wheels for new python, they only need a c compiler to build the wheels from published sdist
