### PR TITLE
feat: introduce I/O plugin architecture for parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ CLUSTERS_REGEXPS =							\
 	beancount/parser		 	parser			\
 	beancount/plugins/.*_test\.py	 	plugins/tests		\
 	beancount/plugins		 	plugins			\
+	beancount/plugins/io/.*_test\.py	 	plugins/io/tests		\
+	beancount/plugins/io		 	plugins/io			\
 	beancount/reports/.*_test\.py	 	reports/tests		\
 	beancount/reports		 	reports			\
 	beancount/scripts/bake.*_test\.py	scripts/bake/tests	\

--- a/beancount/loader.py
+++ b/beancount/loader.py
@@ -117,14 +117,16 @@ def load_file(
 
     if encryption.is_encrypted_file(filename):
         # Note: Caching is not supported for encrypted files.
-        entries, errors, options_map = load_encrypted_file(
-            filename, log_timings, log_errors, extra_validations, False, encoding
+        # We explicitly call the uncached internal loader `_load` to prevent writing
+        # the decrypted plaintext to the cache directory.
+        entries, errors, options_map = _load(
+            [(filename, True)], log_timings, extra_validations, encoding
         )
     else:
         entries, errors, options_map = _load_file(
             filename, log_timings, extra_validations, encoding
         )
-        _log_errors(errors, log_errors)
+    _log_errors(errors, log_errors)
     return entries, errors, options_map
 
 
@@ -418,9 +420,6 @@ def _parse_recursive(
             if is_file:
                 cwd = path.dirname(source)
                 source_filename = source
-                if encryption.is_encrypted_file(source):
-                    source = encryption.read_encrypted_file(source)
-                    is_file = False
             else:
                 # If we're parsing a string, the CWD is the current process
                 # working directory.

--- a/beancount/parser/parser.py
+++ b/beancount/parser/parser.py
@@ -113,10 +113,13 @@ __copyright__ = "Copyright (C) 2013-2018, 2020-2022, 2024-2026  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import codecs
+import configparser
 import contextlib
 import functools
+import importlib
 import inspect
 import io
+import os
 import sys
 import textwrap
 from typing import TYPE_CHECKING
@@ -139,6 +142,47 @@ if TYPE_CHECKING:
 # When importing the module, always check that the compiled source matched the
 # installed source.
 hashsrc.check_parser_source_files(_parser)
+
+
+_io_plugins = None
+_io_plugin_errors = None
+
+def _get_io_plugins(filename=None):
+    """Return a list of I/O plugin functions to run and a list of import errors."""
+    global _io_plugins, _io_plugin_errors
+    if _io_plugins is not None:
+        return _io_plugins, _io_plugin_errors
+
+    _io_plugins = []
+    _io_plugin_errors = []
+    plugin_modules = ["beancount.plugins.io.encryption"]
+
+    if filename and filename != "<string>":
+        dir_path = os.path.dirname(os.path.abspath(filename))
+        beanrc_path = os.path.join(dir_path, ".beanrc")
+        if os.path.isfile(beanrc_path):
+            config = configparser.ConfigParser()
+            try:
+                config.read(beanrc_path)
+                if config.has_section("beancount.plugins.io") and config.has_option("beancount.plugins.io", "plugins"):
+                    plugins_str = config.get("beancount.plugins.io", "plugins")
+                    if plugins_str:
+                        plugin_modules.extend(p.strip() for p in plugins_str.split(","))
+            except configparser.Error as exc:
+                _io_plugin_errors.append(f"Error parsing {beanrc_path}: {exc}")
+
+    for module_name in plugin_modules:
+        if not module_name:
+            continue
+        try:
+            module = importlib.import_module(module_name)
+            if hasattr(module, "__plugins__"):
+                for func_name in module.__plugins__:
+                    _io_plugins.append(getattr(module, func_name))
+        except Exception as exc:
+            _io_plugin_errors.append(f"Error importing I/O plugin {module_name}: {exc}")
+
+    return _io_plugins, _io_plugin_errors
 
 
 def is_posting_incomplete(posting) -> bool:
@@ -219,11 +263,50 @@ def parse_file(
         # readinto() method.
         elif not isinstance(file, io.IOBase):
             file_io = ctx.enter_context(open(file, "rb"))
+            if report_filename is None:
+                report_filename = file
         else:
             file_io = file
+
+        files = [(file_io, report_filename)]
+        io_errors = []
+
+        io_plugins_list, io_plugin_import_errors = _get_io_plugins(report_filename)
+
+        # Track import errors
+        if io_plugin_import_errors:
+            for err_msg in io_plugin_import_errors:
+                io_errors.append(grammar.ParserError(
+                    data.new_metadata(report_filename or "<string>", report_firstline),
+                    err_msg
+                ))
+
+        for plugin_func in io_plugins_list:
+            new_files = []
+            for f_io, f_name in files:
+                for new_f_io, new_f_name, plugin_errors in plugin_func(f_io, f_name):
+                    new_files.append((new_f_io, new_f_name))
+                    if plugin_errors:
+                        if isinstance(plugin_errors, list):
+                            io_errors.extend(plugin_errors)
+                        else:
+                            io_errors.append(plugin_errors)
+            files = new_files
+
         builder = grammar.Builder()
-        parser = _parser.Parser(builder, debug=debug)
-        parser.parse(file_io, filename=report_filename, lineno=report_firstline, **kw)
+        parser_instance = _parser.Parser(builder, debug=debug)
+
+        all_entries = []
+        for f_io, f_name in files:
+            parser_instance.parse(f_io, filename=f_name, lineno=report_firstline, **kw)
+            all_entries.extend(builder.entries)
+
+        builder.entries = all_entries
+
+        # Add IO plugin errors to builder
+        for err in io_errors:
+            builder.errors.append(err)
+
     return builder.finalize()
 
 

--- a/beancount/parser/parser_test.py
+++ b/beancount/parser/parser_test.py
@@ -6,7 +6,9 @@ __copyright__ = "Copyright (C) 2013-2025  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import io
+import os
 import sys
+import tempfile
 import textwrap
 import unittest
 
@@ -376,6 +378,71 @@ class TestLineno(unittest.TestCase):
         self.assertEqual(entries[1].meta["lineno"], lineno + 2)
         self.assertEqual(entries[2].meta["lineno"], lineno + 6)
         self.assertEqual(entries[3].meta["lineno"], lineno + 8)
+
+
+class TestIOPlugins(unittest.TestCase):
+    def test_io_plugins(self):
+        # Force parser to reload io plugins
+        parser._io_plugins = None
+        parser._io_plugin_errors = None
+
+        input_str = textwrap.dedent("""
+          # My Doc
+
+          ```beancount
+          2014-01-27 * "UNION MARKET"
+            Assets:Cash   -22.02 USD
+            Expenses:Food:Grocery            22.02 USD
+          ```
+        """)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            beanrc_path = os.path.join(tmpdir, ".beanrc")
+            with open(beanrc_path, "w") as f:
+                f.write("[beancount.plugins.io]\nplugins = beancount.plugins.io.literate\n")
+
+            filename = os.path.join(tmpdir, "doc.md")
+            with open(filename, "w") as f:
+                f.write(input_str)
+
+            try:
+                entries, errors, _ = parser.parse_file(filename)
+
+                # Expect 1 entry, properly loaded through the plugin system's test run.
+                self.assertEqual(1, len(entries))
+                self.assertEqual("Assets:Cash", entries[0].postings[0].account)
+            finally:
+                parser._io_plugins = None
+                parser._io_plugin_errors = None
+
+    def test_io_plugins_import_error(self):
+        # Force parser to reload io plugins
+        parser._io_plugins = None
+        parser._io_plugin_errors = None
+
+        input_str = textwrap.dedent("""
+          2014-01-27 * "UNION MARKET"
+            Assets:Cash   -22.02 USD
+            Expenses:Food:Grocery            22.02 USD
+        """)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            beanrc_path = os.path.join(tmpdir, ".beanrc")
+            with open(beanrc_path, "w") as f:
+                f.write("[beancount.plugins.io]\nplugins = beancount.non_existent_plugin\n")
+
+            filename = os.path.join(tmpdir, "doc.beancount")
+            with open(filename, "w") as f:
+                f.write(input_str)
+
+            try:
+                entries, errors, _ = parser.parse_file(filename)
+
+                self.assertEqual(1, len(entries))
+                self.assertTrue(any("Error importing I/O plugin" in str(e) for e in errors))
+            finally:
+                parser._io_plugins = None
+                parser._io_plugin_errors = None
 
 
 if __name__ == "__main__":

--- a/beancount/plugins/io/encryption.py
+++ b/beancount/plugins/io/encryption.py
@@ -1,0 +1,14 @@
+import io
+
+from beancount.utils import encryption
+
+__plugins__ = ["read_encrypted_file"]
+
+
+def read_encrypted_file(file_io, filename):
+    """If the file is encrypted, decrypt it and return the new IO object."""
+    if filename and encryption.is_encrypted_file(filename):
+        contents = encryption.read_encrypted_file(filename)
+        yield (io.BytesIO(contents.encode("utf-8")), filename, [])
+    else:
+        yield (file_io, filename, [])

--- a/beancount/plugins/io/literate.py
+++ b/beancount/plugins/io/literate.py
@@ -1,0 +1,85 @@
+import enum
+import io
+
+from beancount.core import data
+from beancount.parser.grammar import ParserError
+
+__plugins__ = ["read_literate_file"]
+
+START_BEAN = "```beancount"
+END_BEAN = "```"
+
+
+class ParseState(enum.Enum):
+    COMMENT = enum.auto()
+    CODEBLOCK = enum.auto()
+
+
+def find_next_state(state, line):
+    stripped_line = line.strip()
+    if state == ParseState.COMMENT:
+        if stripped_line.startswith(START_BEAN):
+            return ParseState.CODEBLOCK, None
+    elif state == ParseState.CODEBLOCK:
+        if stripped_line == END_BEAN:
+            return ParseState.COMMENT, None
+
+    return state, None
+
+
+def read_literate_file(file_io, filename):
+    """Parses markdown files and extracts Beancount code blocks."""
+    if not filename or not filename.endswith(".md"):
+        # We only process markdown files.
+        yield (file_io, filename, [])
+        return
+
+    contents = file_io.read()
+    if isinstance(contents, bytes):
+        contents = contents.decode("utf-8")
+
+    state = ParseState.COMMENT
+    output = io.StringIO()
+    line_number_start = 0
+    errors = []
+
+    lines = contents.splitlines(True)
+    for line_number, line in enumerate(lines):
+        stripped_line = line.strip()
+        next_state, error_msg = find_next_state(state, line)
+
+        if state == ParseState.COMMENT and next_state == ParseState.CODEBLOCK:
+            # Check for remaining text after ```beancount
+            remaining = stripped_line[len(START_BEAN) :].strip()
+            if remaining:
+                meta = data.new_metadata(filename, line_number + 1)
+                errors.append(
+                    ParserError(meta, f"Extra text after code block marker: '{remaining}'")
+                )
+            line_number_start = line_number
+            # Use line_number + 2 because line_number is 0-indexed and the first line of content is the next line
+            output.write(f"; from {filename} starting at {line_number + 2}\n")
+            # We don't write the ```beancount line itself.
+
+        elif state == ParseState.CODEBLOCK:
+            if next_state == ParseState.CODEBLOCK:
+                output.write(line)
+            else:
+                # Exiting code block
+                block = f"Block{line_number_start + 1}-{line_number + 1}"
+                yield (
+                    io.BytesIO(output.getvalue().encode("utf-8")),
+                    f"{filename}:{block}",
+                    errors,
+                )
+                output = io.StringIO()
+                errors = []  # Reset errors for next block
+
+        state = next_state
+
+    if state == ParseState.CODEBLOCK:
+        # File ended while still inside a code block
+        meta = data.new_metadata(filename, len(lines))
+        errors.append(ParserError(meta, "Unclosed markdown code block"))
+        block = f"Block{line_number_start + 1}-{len(lines)}"
+        yield (io.BytesIO(output.getvalue().encode("utf-8")), f"{filename}:{block}", errors)

--- a/beancount/plugins/io/literate_test.py
+++ b/beancount/plugins/io/literate_test.py
@@ -1,0 +1,119 @@
+import os
+import tempfile
+import textwrap
+import unittest
+
+from beancount.parser import parser
+
+
+class TestLiterateIOPlugin(unittest.TestCase):
+    def test_literate_plugin_success(self):
+        parser._io_plugins = None
+        parser._io_plugin_errors = None
+
+        input_str = textwrap.dedent("""
+          # My Ledger
+
+          Here is some text.
+
+          ```beancount
+          2014-01-27 * "UNION MARKET"
+            Assets:Cash   -22.02 USD
+            Expenses:Food:Grocery            22.02 USD
+          ```
+
+          Some more text.
+        """)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            beanrc_path = os.path.join(tmpdir, ".beanrc")
+            with open(beanrc_path, "w") as f:
+                f.write("[beancount.plugins.io]\nplugins = beancount.plugins.io.literate\n")
+
+            filename = os.path.join(tmpdir, "doc.md")
+            with open(filename, "w") as f:
+                f.write(input_str)
+
+            try:
+                entries, errors, _ = parser.parse_file(filename)
+                self.assertEqual(0, len(errors))
+                self.assertEqual(1, len(entries))
+                self.assertEqual("Assets:Cash", entries[0].postings[0].account)
+            finally:
+                parser._io_plugins = None
+                parser._io_plugin_errors = None
+
+    def test_literate_plugin_errors(self):
+        parser._io_plugins = None
+        parser._io_plugin_errors = None
+
+        input_str = textwrap.dedent("""
+          # My Ledger
+
+          ```beancount some extra text here
+          2014-01-27 * "UNION MARKET"
+            Assets:Cash   -22.02 USD
+            Expenses:Food:Grocery            22.02 USD
+          ```
+
+          ```beancount
+          2014-01-28 * "UNCLOSED"
+            Assets:Cash   -10.00 USD
+        """)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            beanrc_path = os.path.join(tmpdir, ".beanrc")
+            with open(beanrc_path, "w") as f:
+                f.write("[beancount.plugins.io]\nplugins = beancount.plugins.io.literate\n")
+
+            filename = os.path.join(tmpdir, "doc.md")
+            with open(filename, "w") as f:
+                f.write(input_str)
+
+            try:
+                entries, errors, _ = parser.parse_file(filename)
+                self.assertEqual(2, len(errors))
+                self.assertTrue(
+                    any("Extra text after code block marker" in str(e) for e in errors)
+                )
+                self.assertTrue(
+                    any("Unclosed markdown code block" in str(e) for e in errors)
+                )
+                self.assertEqual(2, len(entries))
+            finally:
+                parser._io_plugins = None
+                parser._io_plugin_errors = None
+
+    def test_literate_plugin_ignored_for_non_md(self):
+        parser._io_plugins = None
+        parser._io_plugin_errors = None
+
+        # Even though there's a markdown block, the plugin shouldn't touch it
+        # because the file doesn't end with .md
+        input_str = textwrap.dedent("""
+          2014-01-27 * "NORMAL FILE"
+            Assets:Cash   -22.02 USD
+            Expenses:Food:Grocery            22.02 USD
+        """)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            beanrc_path = os.path.join(tmpdir, ".beanrc")
+            with open(beanrc_path, "w") as f:
+                f.write("[beancount.plugins.io]\nplugins = beancount.plugins.io.literate\n")
+
+            filename = os.path.join(tmpdir, "doc.beancount")
+            with open(filename, "w") as f:
+                f.write(input_str)
+
+            try:
+                entries, errors, _ = parser.parse_file(filename)
+                self.assertEqual(0, len(errors))
+                self.assertEqual(1, len(entries))
+                self.assertEqual("NORMAL FILE", entries[0].narration)
+            finally:
+                parser._io_plugins = None
+                parser._io_plugin_errors = None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/meson.build
+++ b/meson.build
@@ -71,6 +71,9 @@ py.install_sources(
     beancount/plugins/pedantic.py
     beancount/plugins/sellgains.py
     beancount/plugins/unique_prices.py
+    beancount/plugins/io/__init__.py
+    beancount/plugins/io/encryption.py
+    beancount/plugins/io/literate.py
     beancount/projects/__init__.py
     beancount/projects/export.py
     beancount/scripts/__init__.py
@@ -170,6 +173,7 @@ py.install_sources('''
     beancount/plugins/onecommodity_test.py
     beancount/plugins/pedantic_test.py
     beancount/plugins/sellgains_test.py
+    beancount/plugins/io/literate_test.py
     beancount/plugins/unique_prices_test.py
     beancount/projects/export_test.py
     beancount/scripts/check_examples_test.py


### PR DESCRIPTION
Adds support for I/O plugins via the '.beanrc' config file. I/O plugins run just before the C parser is invoked on a file, allowing dynamic preprocessing such as decryption. To demonstrate this architecture, the existing file encryption logic has been extracted from loader.py and reimplemented as a built-in I/O plugin module:
beancount.plugins.io.encryption.

For some info on my motivation for this change, see: https://docs.google.com/document/d/16conmm3cKC4raXnFW1UiiSmMGIhs0qO2oLK2siHUBOI/edit?usp=sharing and https://github.com/beancount/beancount/issues/388