### PR TITLE
Add support for printing @@ postings on request

### DIFF
--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -296,7 +296,16 @@ class EntryPrinter:
             position_str = ""
 
         if posting.price is not None:
-            position_str += " @ {}".format(posting.price.to_string(self.dformat_max))
+            meta = posting.meta or {}
+            price_total_format = meta.get("__print_price_total_format")
+            if price_total_format is not None:
+                # Calculate the total amount by multiplying the per-unit price
+                # and print using the @@ syntax.
+                total_number = posting.price.number * abs(posting.units.number)
+                total_amount = amount.Amount(total_number, posting.price.currency)
+                position_str += " @@ {}".format(total_amount.to_string(price_total_format))
+            else:
+                position_str += " @ {}".format(posting.price.to_string(self.dformat_max))
 
         return flag_account, position_str, weight_str
 


### PR DESCRIPTION
I have a use case where I parse some external data and use the beancount APIs to create Postings and Transaction objects then print them.  For stocks, it is easier for me to deal with the total amount of a posting then to handle multi-digit per-unit costs.  While the parser supports the @@ format for specifying the total, the printer currently only supports printing per-unit prices.

This PR provides a metadata-based method to request the printer to print using the @@ format.

An example for using this is:

```
from beancount.core import data
account = ...
units = ...
cost = ...
price = ...
flag = ...
meta = {}
meta['__print_price_total_format'] = '{:.2f}'
posting = data.Posting(account=account, units=units, cost=cost, price=price, flag=flag, meta=meta)
```