### PR TITLE
Add support for printing @@ postings on request

### DIFF
--- a/beancount/parser/printer.py
+++ b/beancount/parser/printer.py
@@ -296,7 +296,16 @@ class EntryPrinter:
             position_str = ""
 
         if posting.price is not None:
-            position_str += " @ {}".format(posting.price.to_string(self.dformat_max))
+            meta = posting.meta or {}
+            price_total_format = meta.get("__print_price_total_format")
+            if price_total_format is not None:
+                # Calculate the total amount by multiplying the per-unit price
+                # and print using the @@ syntax.
+                total_number = posting.price.number * abs(posting.units.number)
+                total_amount = amount.Amount(total_number, posting.price.currency)
+                position_str += " @@ {}".format(total_amount.to_string(price_total_format))
+            else:
+                position_str += " @ {}".format(posting.price.to_string(self.dformat_max))
 
         return flag_account, position_str, weight_str
 

--- a/beancount/parser/printer_test.py
+++ b/beancount/parser/printer_test.py
@@ -13,9 +13,11 @@ from decimal import Decimal
 from beancount import loader
 from beancount.core import data
 from beancount.core.amount import Amount
+from beancount.core.number import MISSING
 from beancount.ops.balance import BalanceError
 from beancount.parser import cmptest
 from beancount.parser import printer
+from beancount.core.position import CostSpec
 from beancount.utils import test_utils
 
 META = data.new_metadata("beancount/core/testing.beancount", 12345)
@@ -759,6 +761,55 @@ class TestPrinterMisc(test_utils.TestCase):
         self.assertFalse(errors)
         self.assertIs(entries[-1].postings[-1].meta["foo"], None)
 
+    def test_price_total_format_uses_total_price_syntax(self):
+        # 10 HOOL @ 1.45 USD -> total 14.50 USD, printed with @@ total syntax.
+        lot_date = date(2015, 1, 1)
+        units = Amount(Decimal('10'), 'HOOL')
+        total = Amount(Decimal('14.50'), 'USD')
+        price = Amount(total.number / units.number, 'USD')
+        cost = CostSpec(
+            number_per=MISSING, # inferred from transaction
+            number_total=None,
+            currency='HOOL',
+            date=lot_date,
+            label=None,
+            merge=False,
+        )
+        posting_buy_lot = data.Posting(
+            account='Assets:US:Investments:HOOL',
+            units=units,
+            cost=cost,
+            price=price,
+            flag=None,
+            meta={'__print_price_total_format': "{:.2f}"}
+        )
+        posting_cash = data.Posting(
+            account='Assets:US:Investments:Cash',
+            units=Amount(Decimal('-14.50'), 'USD'),
+            cost=None,
+            price=None,
+            flag=None,
+            meta=None
+        )
+        txn = data.Transaction(
+            meta=None,
+            date=lot_date,
+            flag='*',
+            payee=None,
+            narration='Buy 10 sh. HOOL',
+            tags=frozenset(),
+            links=frozenset(),
+            postings=[posting_buy_lot, posting_cash],
+        )
 
+        out = printer.format_entry(txn)
+
+        expected_str = textwrap.dedent("""\
+            2015-01-01 * "Buy 10 sh. HOOL"
+              Assets:US:Investments:HOOL      10 HOOL {2015-01-01} @@ 14.50 USD
+              Assets:US:Investments:Cash  -14.50 USD
+        """)
+        self.assertEqual(expected_str, out)
+        
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I have a use case where I parse some external data and use the beancount APIs to create Postings and Transaction objects then print them. For stocks, it is easier for me to deal with the total amount of a posting then to handle multi-digit per-unit costs. While the parser supports the @@ format for specifying the total, the printer currently only supports printing per-unit prices.

This PR provides a metadata-based method to request the printer to print using the @@ format, along with a pytest unittest showing example usage.

(Related to #1023 but adds unit test, I don't appear to have permission to re-open closed PRs)