### PR TITLE
parser: preserve zero-valued plain auto-postings

### DIFF
--- a/TODO
+++ b/TODO
@@ -1073,9 +1073,6 @@ Improve this bit:
 
   - Unref the constants in finalizer for module, here: {48414425cf78}.
 
-  - Write a test to ensure that an auto-posting with no effect results in no
-    new posting getting inserted.
-
   - Implement an optional feature that disables the merging of inventory lots
     for all lots except lots without cost. In other words, if there's a cost
     object, don't even compare them or try to merge them together; only lots
@@ -4655,7 +4652,8 @@ Improve this bit:
     trips, should be mirroring tolerances input syntax. Bug with Beancount:
     journal ?Assets:Caroline:Octopus? does not render with correct precision.
 
-  - Remove unused auto-postings, they distract from the reporting.
+  - Document the policy for preserving zero auto-postings on plain unit
+    postings while still pruning zero-valued cost/price interpolations.
 
   - Deal with flattening now (default should be never to flatten, never render
     empty fields on a continuation line for an inventory) and THEN implement CSV

--- a/beancount/parser/booking_full.py
+++ b/beancount/parser/booking_full.py
@@ -938,7 +938,9 @@ def interpolate_group(postings, balances, currency, tolerances):
                 tolerances, units.currency, units_number
             )
 
-            if weight != ZERO:
+            # Preserve zero-valued postings for a fully blank balancing leg so
+            # a user-authored placeholder account is not silently dropped.
+            if weight != ZERO or (cost is None and incomplete_posting.price is None):
                 new_pos = Position(Amount(units_number, units.currency), cost)
                 new_posting = incomplete_posting._replace(
                     units=new_pos.units, cost=new_pos.cost

--- a/beancount/parser/booking_full_test.py
+++ b/beancount/parser/booking_full_test.py
@@ -1064,9 +1064,10 @@ class TestInterpolateCurrencyGroup(unittest.TestCase):
                     None,
                 ),
                 "RSPCAD": (
-                    False,
+                    True,
                     """
               1997-03-16 *
+                Assets:CA:Pop:Checking               0 RSPCAD
                 Assets:CA:CRA:PreTaxRSP:Allowed  -2000 RSPCAD
                 Assets:CA:CRA:PreTaxRSP:Unused    2000 RSPCAD
             """,
@@ -1076,7 +1077,7 @@ class TestInterpolateCurrencyGroup(unittest.TestCase):
         )
 
     @parser.parse_doc(allow_incomplete=True)
-    def test_auto_posting__superfluous_unused(self, entries, errors, _):
+    def test_auto_posting__preserve_zero_two_leg(self, entries, errors, _):
         """
         2000-01-01 open Assets:Account1
         2000-01-01 open Assets:Account2
@@ -1089,19 +1090,19 @@ class TestInterpolateCurrencyGroup(unittest.TestCase):
             entries[-1],
             {
                 "USD": (
-                    False,
+                    True,
                     """
               2016-04-23 * ""
                 Assets:Account1     0.00 USD
+                Assets:Account2     0.00 USD
             """,
                     None,
                 )
             },
         )
-        # FIXME: This ought to return a "Superfluous posting" error for Account2 only.
 
     @parser.parse_doc(allow_incomplete=True)
-    def test_auto_posting__superfluous_unneeded(self, entries, errors, _):
+    def test_auto_posting__preserve_zero_multi_leg(self, entries, errors, _):
         """
         2000-01-01 open Assets:Account1
         2000-01-01 open Assets:Account2
@@ -1116,20 +1117,22 @@ class TestInterpolateCurrencyGroup(unittest.TestCase):
             entries[-1],
             {
                 "USD": (
-                    False,
+                    True,
                     """
               2016-04-23 * ""
                 Assets:Account1   100.00 USD
                 Assets:Account2  -100.00 USD
+                Assets:Account3     0.00 USD
             """,
                     None,
                 )
             },
         )
-        # FIXME: This ought to return a "Superfluous posting" error for Account3 only.
 
     @parser.parse_doc(allow_incomplete=True)
-    def test_auto_posting__superfluous_needed_one_side(self, entries, errors, _):
+    def test_auto_posting__preserve_zero_in_one_currency_group(
+        self, entries, errors, _
+    ):
         """
         2000-01-01 open Assets:Account1
         2000-01-01 open Assets:Account2
@@ -1148,11 +1151,12 @@ class TestInterpolateCurrencyGroup(unittest.TestCase):
             entries[-1],
             {
                 "USD": (
-                    False,
+                    True,
                     """
               2016-04-23 * ""
                 Assets:Account1   100.00 USD
                 Assets:Account2  -100.00 USD
+                Assets:Account5     0.00 USD
             """,
                     None,
                 ),


### PR DESCRIPTION
Fixes #962.

## Summary

Preserve zero-valued interpolated postings for a fully blank balancing leg, instead of silently dropping the user-authored placeholder account.

Before this change, a transaction like:

```beancount
2025-05-29 * "Pay Sample Bill"
  Liabilities:Foo  0.00 USD
  Expenses:Bar
```

would prune the blank leg after interpolation because the inferred residual was `0.00 USD`.

After this change, Beancount keeps the posting as:

```beancount
2025-05-29 * "Pay Sample Bill"
  Liabilities:Foo  0.00 USD
  Expenses:Bar     0.00 USD
```

## Rationale

If the user explicitly writes a balancing leg, preserving it even when it resolves to zero is more consistent than silently deleting it.

This keeps transaction shape stable for downstream consumers and plugins, while still avoiding zero-valued costed/priced interpolations.

This also fixes the concern raised by sim642 in the issue discussion: before this patch, a zero-valued auto-posting could be pruned before account-reference validation saw it, so an unknown placeholder account could fail to produce a validation error. After this patch, the zero-valued plain balancing leg is preserved, so the expected unknown-account validation error is reported.

## Implementation

In `beancount/parser/booking_full.py`, `MissingType.UNITS` interpolation now keeps zero-valued results when the posting is a fully blank balancing leg, i.e. it has no cost and no price.

A short comment was added to explain the rule.

## Tests

Updated coverage in `beancount/parser/booking_full_test.py` to verify preservation of zero-valued plain blank balancing legs in:

- a 2-leg case
- a multi-leg single-currency case
- one currency group of a multi-currency case
- the mixed-currency underdefined case

Also renamed the affected tests to match the new semantics.