### PR TITLE
feat: discover unpriced opening balances for automated fetching

### DIFF
--- a/beancount/ops/find_prices.py
+++ b/beancount/ops/find_prices.py
@@ -120,3 +120,33 @@ def find_balance_currencies(entries, date=None):
                 currencies.add(base_quote)
 
     return currencies
+
+
+def find_unpriced_currencies(entries, date=None):
+    """Return currencies that have a balance but no price or cost history.
+
+    This identifies commodities on the books that have no cost basis,
+    no price conversions, and no price directives, meaning bean-price
+    currently ignores them.
+
+    Args:
+      entries: A list of directives.
+      date: A datetime.date instance.
+    Returns:
+      A set of base currency strings.
+    """
+    currencies_on_books = set()
+    balances, _ = summarize.balance_by_account(entries, date)
+    for _, balance in balances.items():
+        for pos in balance:
+            if pos.cost is None:
+                # Add regular currencies.
+                currencies_on_books.add(pos.units.currency)
+
+    # Currencies that have a known conversion or price directive
+    converted = find_currencies_converted(entries, date) | find_currencies_priced(
+        entries, date
+    )
+    priced_bases = {base for base, quote in converted}
+
+    return currencies_on_books - priced_bases

--- a/beancount/ops/find_prices_test.py
+++ b/beancount/ops/find_prices_test.py
@@ -19,11 +19,13 @@ class TestFromFile(unittest.TestCase):
         2000-01-10 open Assets:Cash
         2000-01-10 open Assets:External
         2000-01-10 open Expenses:Foreign
+        2015-11-12 open Assets:US:Investments:USDT
 
         2010-01-01 commodity USD
         2010-01-01 commodity QQQ
         2010-01-01 commodity XSP
         2010-01-01 commodity AMTKPTS
+        2015-11-12 commodity USDT
 
         2015-02-06 *
           Assets:Cash                     1505.00 USD
@@ -62,6 +64,11 @@ class TestFromFile(unittest.TestCase):
         2015-10-13 *
           Assets:Cash                        -1000.00 EUR @ 140.004 JPY
           Expenses:Foreign                     140004 JPY
+
+        ;; Zero-balanced commodity
+        2015-11-12 *
+          Assets:US:Investments:USDT          1000.00 USDT
+          Assets:External
         """
         self.entries = entries
 
@@ -123,6 +130,10 @@ class TestFromFile(unittest.TestCase):
             self.entries, datetime.date(2015, 2, 1)
         )
         self.assertEqual(set(), currencies)
+
+    def test_find_unpriced_currencies(self):
+        currencies = find_prices.find_unpriced_currencies(self.entries, None)
+        self.assertEqual({"USDT", "CAD"}, currencies)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Problem:**  
Beancount's native `find_balance_currencies` drops assets initialized via opening balances without a cost basis (`{}`) or price conversion (`@`). As a result, tools like `bean-price` silently ignore these assets, leaving opening balances and gifts permanently unpriced.

**Example of dropped asset:**
```beancount
2026-04-01 * "Opening Balance"
  Assets:Crypto:Wallet:Tron   1000.00 USDT   ;; Ignored by find_prices
  Equity:Opening-Balances
```

**Solution:**  
Introduces `find_unpriced_currencies` to `beancount.ops.find_prices`. This explicitly returns base currencies with positive on-book balances that lack any pricing metadata or quote history.
This creates the API hook needed for external tools (e.g., `bean-price`) to identify these ignored assets and automatically fetch prices against a default fiat currency starting from their transaction date.

**Changes:**  
- Added `find_unpriced_currencies` to `find_prices.py`.
- Added `test_find_unpriced_currencies` tests.