### PR TITLE
Preserve total-cost syntax when printing CostSpec

### DIFF
--- a/beancount/core/position.py
+++ b/beancount/core/position.py
@@ -92,11 +92,14 @@ def cost_to_str(cost, dformat, detail=True):
     elif isinstance(cost, CostSpec):
         if isinstance(cost.number_per, Decimal) or isinstance(cost.number_total, Decimal):
             amountlist = []
-            if isinstance(cost.number_per, Decimal):
-                amountlist.append(dformat.format(cost.number_per))
-            if isinstance(cost.number_total, Decimal):
-                amountlist.append("#")
+            if is_total_cost_spec(cost):
                 amountlist.append(dformat.format(cost.number_total))
+            else:
+                if isinstance(cost.number_per, Decimal):
+                    amountlist.append(dformat.format(cost.number_per))
+                if isinstance(cost.number_total, Decimal):
+                    amountlist.append("#")
+                    amountlist.append(dformat.format(cost.number_total))
             if isinstance(cost.currency, str):
                 amountlist.append(cost.currency)
             strlist.append(" ".join(amountlist))
@@ -109,6 +112,15 @@ def cost_to_str(cost, dformat, detail=True):
                 strlist.append("*")
 
     return ", ".join(strlist)
+
+
+def is_total_cost_spec(cost):
+    """Return true if the cost spec came from total-cost-only syntax."""
+    return (
+        isinstance(cost, CostSpec)
+        and cost.number_per == ZERO
+        and isinstance(cost.number_total, Decimal)
+    )
 
 
 # Lookup for ordering a list of currencies: we want the majors first, then the
@@ -154,7 +166,12 @@ def to_string(pos, dformat=DEFAULT_FORMATTER, detail=True):
     """
     pos_str = pos.units.to_string(dformat)
     if pos.cost is not None:
-        pos_str = "{} {{{}}}".format(pos_str, cost_to_str(pos.cost, dformat, detail))
+        cost_str = cost_to_str(pos.cost, dformat, detail)
+        pos_str = (
+            "{} {{{{{}}}}}".format(pos_str, cost_str)
+            if is_total_cost_spec(pos.cost)
+            else "{} {{{}}}".format(pos_str, cost_str)
+        )
     return pos_str
 
 

--- a/beancount/core/position_test.py
+++ b/beancount/core/position_test.py
@@ -16,6 +16,7 @@ from beancount.core import display_context
 from beancount.core import position
 from beancount.core.amount import A
 from beancount.core.amount import Amount
+from beancount.core.number import MISSING
 from beancount.core.number import ZERO
 from beancount.core.number import D
 from beancount.core.position import Cost
@@ -109,6 +110,9 @@ class TestCostSpec(unittest.TestCase):
         cost = position.CostSpec(None, D("202.46"), "USD", None, None, False)
         self.assertEqual("# 202.46 USD", position.cost_to_str(cost, self.dformat))
 
+        cost = position.CostSpec(ZERO, D("202.46"), "USD", None, None, False)
+        self.assertEqual("202.46 USD", position.cost_to_str(cost, self.dformat))
+
         cost = position.CostSpec(D("101.23"), None, "USD", None, "f4412439c31b", True)
         self.assertEqual(
             '101.23 USD, "f4412439c31b", *', position.cost_to_str(cost, self.dformat)
@@ -152,6 +156,9 @@ class TestCostSpec(unittest.TestCase):
 
         cost = position.CostSpec(None, D("202.46"), "USD", None, None, False)
         self.assertEqual("# 202.46 USD", position.cost_to_str(cost, self.dformat, False))
+
+        cost = position.CostSpec(ZERO, D("202.46"), "USD", None, None, False)
+        self.assertEqual("202.46 USD", position.cost_to_str(cost, self.dformat, False))
 
         cost = position.CostSpec(D("101.23"), None, "USD", None, "f4412439c31b", True)
         self.assertEqual("101.23 USD", position.cost_to_str(cost, self.dformat, False))
@@ -220,6 +227,16 @@ class TestPosition(unittest.TestCase):
     def test_to_string_no_detail(self):
         pos = from_string("2.2 HOOL {532.43 USD, 2014-06-15}")
         self.assertEqual(("2.2 HOOL {532.43 USD}"), pos.to_string(detail=False))
+
+    def test_to_string__total_cost_spec(self):
+        cost = position.CostSpec(ZERO, D("202.46"), "USD", None, None, False)
+        pos = Position(A("2 HOOL"), cost)
+        self.assertEqual("2 HOOL {{202.46 USD}}", pos.to_string())
+
+    def test_to_string__missing_per_unit_cost_spec(self):
+        cost = position.CostSpec(MISSING, D("202.46"), "USD", None, None, False)
+        pos = Position(A("2 HOOL"), cost)
+        self.assertEqual("2 HOOL {# 202.46 USD}", pos.to_string())
 
     def test_from_amounts(self):
         pos = from_amounts(A("10.00 USD"))

--- a/beancount/parser/printer_test.py
+++ b/beancount/parser/printer_test.py
@@ -15,6 +15,7 @@ from beancount.core import data
 from beancount.core.amount import Amount
 from beancount.ops.balance import BalanceError
 from beancount.parser import cmptest
+from beancount.parser import parser
 from beancount.parser import printer
 from beancount.utils import test_utils
 
@@ -741,6 +742,20 @@ class TestPrinterMisc(test_utils.TestCase):
         txn = errors[0].entry
         oss = io.StringIO()
         printer.print_entry(txn, file=oss)
+
+    def test_render_total_cost_spec(self):
+        input_string = textwrap.dedent("""
+
+          2013-05-18 * ""
+            Assets:Investments:MSFT  10 MSFT {{2000 USD}}
+            Assets:Investments:Cash  -20000 USD
+
+        """)
+        entries, errors, options_map = parser.parse_string(input_string)
+        self.assertFalse(errors)
+        oss = io.StringIO()
+        printer.print_entries(entries, file=oss)
+        self.assertRegex(oss.getvalue(), r"10 MSFT \{\{2000 USD\}\}")
 
     def test_render_meta_with_None(self):
         # Issue 378.


### PR DESCRIPTION
Preserve total-cost syntax when printing incomplete `CostSpec`s.

`{{2000 USD}}` parses to `CostSpec(number_per=ZERO, number_total=2000, ...)`, but printing that incomplete entry previously produced `{0 # 2000 USD}`. This PR changes `position.to_string()` so that total-cost-only specs print back as `{{2000 USD}}`, while genuinely missing per-unit specs still print as `{# 2000 USD}`. The reason for this change is to produce syntax that better aligns with what I assume people actually write in the ledger.

Booked `Cost` output is unchanged, so normal loaded entries still print in the existing normalized per-unit form.

**Compatibility**

This changes the printed output for pre-booking/incomplete `CostSpec`s with `number_per == ZERO` and `number_total` set:

```beancount
10 MSFT {0 # 2000 USD}
```

now prints as:

```beancount
10 MSFT {{2000 USD}}
```

As this is technically a breaking change, please let me know if you don't want to proceed with it, and I'll close the PR.

**Tests**

Added coverage for:

- total-cost-only `CostSpec` rendering as `{{...}}`
- missing per-unit total-cost component still rendering as `{# ...}`
- parser-to-printer behavior for `{{...}}` before booking