### PR TITLE
Fix insecure pickle cache placement (CWE-502)

### DIFF
--- a/beancount/loader.py
+++ b/beancount/loader.py
@@ -72,6 +72,35 @@ RENAMED_MODULES: dict[str, str] = {}
 
 
 # Filename pattern for the pickle-cache.
+# Stored in the user's cache directory (not alongside the data file) to prevent
+# an attacker who has write access to the data directory from injecting a
+# malicious pickle payload. See CWE-502.
+def _get_default_cache_dir() -> str:
+    """Return a user-specific cache directory that the data-file owner controls."""
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA") or os.path.expanduser("~")
+    elif sys.platform == "darwin":
+        base = os.path.expanduser("~/Library/Caches")
+    else:
+        base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return os.path.join(base, "beancount")
+
+
+def _make_cache_filename(filename: str) -> str:
+    """Return a collision-free cache path for *filename* under the user cache dir.
+
+    Incorporates a hash of the file's absolute directory so that two files with
+    the same basename in different directories map to distinct cache files.
+    """
+    abs_filename = path.abspath(filename)
+    dir_hash = hashlib.sha256(path.dirname(abs_filename).encode()).hexdigest()[:16]
+    cache_name = f".{path.basename(abs_filename)}-{dir_hash}.picklecache"
+    cache_dir = _get_default_cache_dir()
+    os.makedirs(cache_dir, exist_ok=True)
+    return os.path.join(cache_dir, cache_name)
+
+
+# Legacy pattern kept for backwards-compat when explicitly overridden via env var.
 PICKLE_CACHE_FILENAME = ".{filename}.picklecache"
 
 # The runtime threshold below which we don't bother creating a cache file, in
@@ -823,12 +852,14 @@ def initialize(use_cache: bool, cache_filename: str | None = None) -> None:
     global _load_file
 
     # Make a function to compute the cache filename.
-    cache_pattern = (
-        cache_filename
-        or os.getenv("BEANCOUNT_LOAD_CACHE_FILENAME")
-        or PICKLE_CACHE_FILENAME
-    )
-    cache_getter = functools.partial(get_cache_filename, cache_pattern)
+    # Explicit overrides (argument or env var) use the legacy pattern-based path.
+    # The default uses _make_cache_filename which stores caches in the user's
+    # dedicated cache directory rather than alongside the data file (CWE-502).
+    explicit_pattern = cache_filename or os.getenv("BEANCOUNT_LOAD_CACHE_FILENAME")
+    if explicit_pattern:
+        cache_getter = functools.partial(get_cache_filename, explicit_pattern)
+    else:
+        cache_getter = _make_cache_filename
 
     if use_cache:
         _load_file = pickle_cache_function(


### PR DESCRIPTION
## Security Fix — Insecure Deserialization via Pickle Cache (CWE-502)

### Summary

The default pickle cache is stored alongside the `.beancount` file as
`.{filename}.picklecache`. Since `pickle.load()` is called without any integrity
verification, an attacker who can write to the same directory as a user's beancount
file can plant a malicious cache file that executes arbitrary Python code the next
time any beancount command (`bean-check`, `bean-report`, `bean-query`, etc.) processes
that file. The cache is enabled by default.

**Attack vector**: supply a `.beancount` file alongside a crafted `.picklecache` — e.g.,
in a shared directory, a downloaded demo archive, or a collaborative repository.

### Root Cause

```python
# loader.py:231 — no signature or HMAC check before deserialization
result = pickle.load(file)   # executes __reduce__ in attacker-controlled payload
```

The `needs_refresh()` freshness check happens *after* `pickle.load()` returns, so the
deserialization (and any embedded payload) already ran regardless of whether the cache is
considered fresh.

**Vulnerable code:**
```python
PICKLE_CACHE_FILENAME = ".{filename}.picklecache"   # same dir as data file

if exists:
    with open(cache_filename, "rb") as file:
        result = pickle.load(file)   # ← RCE if file is attacker-controlled
```

### Fix

Move the default cache location to the user's OS-specific cache directory
(`XDG_CACHE_HOME/beancount` on Linux, `~/Library/Caches/beancount` on macOS,
`LOCALAPPDATA/beancount` on Windows). A 16-char SHA-256 prefix of the source
directory is incorporated in the filename to prevent collisions between files with
the same basename in different directories.

```python
# After fix — cache stored where only the user can write
# /home/alice/.cache/beancount/.finances.beancount-a1b2c3d4e5f6a7b8.picklecache
```

The `BEANCOUNT_LOAD_CACHE_FILENAME` env-var override and the explicit
`cache_filename` argument to `initialize()` still accept the legacy relative
pattern for backwards compatibility.

### Impact
- **Type**: CWE-502 — Deserialization of Untrusted Data → RCE
- **Auth required**: No (file system access to data directory)
- **Affected versions**: All versions with pickle cache (default)
- **CVSS:3.1**: AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H = **7.8 High**

### Verification

Dynamically confirmed on beancount v3.2.3 (python:3.12-slim Docker) — `touch /tmp/BEANCOUNT_PWNED_3_2_3` executed silently via `bean-check test.beancount` before fix; no longer executes after fix because the malicious `.test.beancount.picklecache` in the data directory is not loaded.

### References
- CWE-502: https://cwe.mitre.org/data/definitions/502.html
- Similar: CVE-2022-21699 (Jupyter — arbitrary code via pickle)