### PR TITLE
Fix literal account component matching

### DIFF
--- a/beancount/core/account.py
+++ b/beancount/core/account.py
@@ -173,7 +173,7 @@ def has_component(account_name: Account, component: str) -> bool:
       A boolean: true if the component is in the account. Note that a component
       name must be whole, that is ``NY`` is not in ``Expenses:Taxes:StateNY``.
     """
-    return component in account_name.split(sep)
+    return bool(re.search("(^|:){}(:|$)".format(re.escape(component)), account_name))
 
 
 def commonprefix(accounts: Iterable[Account]) -> Account:

--- a/beancount/core/account.py
+++ b/beancount/core/account.py
@@ -173,7 +173,7 @@ def has_component(account_name: Account, component: str) -> bool:
       A boolean: true if the component is in the account. Note that a component
       name must be whole, that is ``NY`` is not in ``Expenses:Taxes:StateNY``.
     """
-    return bool(re.search("(^|:){}(:|$)".format(component), account_name))
+    return component in account_name.split(sep)
 
 
 def commonprefix(accounts: Iterable[Account]) -> Account:

--- a/beancount/core/account_test.py
+++ b/beancount/core/account_test.py
@@ -78,6 +78,13 @@ class TestAccount(unittest.TestCase):
         self.assertFalse(account.has_component("Liabilities:US:Credit-Card", "Credit"))
         self.assertFalse(account.has_component("Liabilities:US:Credit-Card", "Card"))
 
+    def test_has_component_special_chars(self):                                                                                                                    
+        """Les caracteres speciaux ne doivent pas casser has_component."""
+        # Avant le fix : crash (unbalanced parenthesis). Apres : False.
+        self.assertFalse(account.has_component("Liabilities:US:Credit-Card", "Foo)("))
+        self.assertFalse(account.has_component("Liabilities:US:Credit-Card", "a.b"))                                                                               
+        self.assertFalse(account.has_component("Liabilities:US:Credit-Card", "a+b"))
+
     def test_commonprefix(self):
         self.assertEqual(
             "Assets:US:TD",


### PR DESCRIPTION
The previous implementation inserted the account component directly into a
regular expression. This could produce false positives for regex characters
such as "." or "+", or raise a regex error.

This change compares account components literally using the account separator.