### PR TITLE
Make round_to honour its documented round-down contract

### DIFF
--- a/beancount/core/number.py
+++ b/beancount/core/number.py
@@ -16,6 +16,7 @@ __copyright__ = "Copyright (C) 2015-2021, 2024-2026  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import re
+from decimal import ROUND_FLOOR
 from decimal import Decimal
 
 # Constants.
@@ -74,13 +75,16 @@ def D(strord: Decimal | str | None = None) -> Decimal:
 def round_to(number: Decimal, increment: Decimal) -> Decimal:
     """Round a number *down* to a particular increment.
 
+    Rounding is towards negative infinity, per the docstring contract: the
+    result is never greater than `number`, for either sign.
+
     Args:
       number: A Decimal, the number to be rounded.
       increment: A Decimal, the size of the increment.
     Returns:
       A Decimal, the rounded number.
     """
-    return int(number / increment) * increment
+    return (number / increment).to_integral_value(rounding=ROUND_FLOOR) * increment
 
 
 def same_sign(number1: Decimal, number2: Decimal) -> bool:

--- a/beancount/core/number_test.py
+++ b/beancount/core/number_test.py
@@ -43,13 +43,27 @@ class TestToDecimal(unittest.TestCase):
     def test_round_to(self):
         self.assertEqual(D("135.12"), round_to(D("135.12345"), D("0.01")))
         self.assertEqual(D("135.12"), round_to(D("135.12987"), D("0.01")))
-        self.assertEqual(D("-135.12"), round_to(D("-135.12345"), D("0.01")))
-        self.assertEqual(D("-135.12"), round_to(D("-135.12987"), D("0.01")))
+        self.assertEqual(D("-135.13"), round_to(D("-135.12345"), D("0.01")))
+        self.assertEqual(D("-135.13"), round_to(D("-135.12987"), D("0.01")))
 
         self.assertEqual(D("130"), round_to(D("135.12345"), D("10")))
         self.assertEqual(D("130"), round_to(D("135.12987"), D("10")))
-        self.assertEqual(D("-130"), round_to(D("-135.12345"), D("10")))
-        self.assertEqual(D("-130"), round_to(D("-135.12987"), D("10")))
+        self.assertEqual(D("-140"), round_to(D("-135.12345"), D("10")))
+        self.assertEqual(D("-140"), round_to(D("-135.12987"), D("10")))
+
+    def test_round_to_rounds_down_toward_negative_infinity(self):
+        """The docstring promises rounding *down*: the result is never greater
+        than the input, for either sign."""
+        self.assertEqual(D("-0.13"), round_to(D("-0.125"), D("0.01")))
+        self.assertEqual(D("-1.00"), round_to(D("-1.00"), D("0.01")))
+        self.assertEqual(D("0.12"), round_to(D("0.125"), D("0.01")))
+        self.assertTrue(
+            all(
+                round_to(D(value), D(increment)) <= D(value)
+                for value in ["-3.33", "-0.01", "0", "0.01", "3.33"]
+                for increment in ["0.5", "0.01", "1"]
+            )
+        )
 
     def test_same_sign(self):
         self.assertTrue(same_sign(D("135.12345"), D("234.20")))


### PR DESCRIPTION
Fixes #1043.

## The bug

`beancount.core.number.round_to` documents "Round a number *down* to a particular increment", but implements:

```python
return int(number / increment) * increment
```

Python's `int()` truncates towards zero, not down. Every negative amount rounded the wrong way:

```python
>>> round_to(D("-135.12987"), D("0.01"))
Decimal('-135.12')    # documented round-down gives -135.13
```

Positive amounts are bit-identical under both operations, which is why this survived: the existing test data only exercises the sign where truncation and floor agree. The two negative assertions in `test_round_to` had pinned the truncating behaviour (`-135.12987 → -135.12`), contradicting the docstring on the function they test.

## The fix

```python
return (number / increment).to_integral_value(rounding=ROUND_FLOOR) * increment
```

- Uses the decimal module's own rounding modes, so no float-style surprises.
- Docstring now states the rule explicitly (towards negative infinity; result never greater than the input).
- `test_round_to`: the two negative assertions updated from `-135.12 → -135.13` and `-130 → -140`. These assertions encoded the deviation being fixed.
- New `test_round_to_rounds_down_toward_negative_infinity`: pins the never-greater-than-input property across both signs and three increments, plus exact values for `-0.125 @ 0.01`.

## Testing

- `pytest beancount/core/number_test.py`: 12 passed.
- Full core suite: 306 passed + 12 subtests.
- Whole tree except parser/cparser: 650 passed, 3 skipped.
- Parser suite: 455 passed; 2 pre-existing failures in `test_number_expr_not_lexed_as_date` (both trees, with and without this change) - these are an artefact of running against a copied official 3.2.3 compiled `_parser` extension because this Windows box has no MSVC to build meson locally; the failures are lexer/date-parsing behaviour unrelated to `core.number`.
- `ruff check` and `ruff format --check` clean at the repo's pinned version (0.15.10).

## Behaviour-change note

This changes returned values for negative amounts, so it is semver-relevant if anyone depended on truncation. I would argue nobody sanely did, since the documented contract said otherwise and the old behaviour silently violates it, but maintainers may prefer a CHANGES note or a different release treatment. Happy to adjust.