### PR TITLE
booking: return an error for total cost on zero units

### DIFF
--- a/beancount/parser/booking_full.py
+++ b/beancount/parser/booking_full.py
@@ -734,6 +734,9 @@ def compute_cost_number(costspec, units):
         # component involved.
         cost_total = number_total
         units_number = abs(units.number)
+        if units_number == ZERO:
+            # Per-unit cost is undefined when there are no units.
+            return None
         if number_per is not None:
             cost_total += number_per * units_number
         unit_cost = cost_total / units_number
@@ -766,7 +769,12 @@ def convert_costspec_to_cost(posting):
                 cost_total = number_total
                 if number_per is not MISSING:
                     cost_total += number_per * units_number
-                unit_cost = cost_total / units_number
+                # Zero units cannot be converted to a per-unit cost; use
+                # zero so interpolation can report the invalid amount.
+                if units_number == ZERO:
+                    unit_cost = ZERO
+                else:
+                    unit_cost = cost_total / units_number
             else:
                 unit_cost = number_per
             new_cost = Cost(unit_cost, cost.currency, cost.date, cost.label)

--- a/beancount/parser/booking_full_test.py
+++ b/beancount/parser/booking_full_test.py
@@ -1340,6 +1340,52 @@ class TestComputeCostNumber(unittest.TestCase):
             ),
         )
 
+    def test_zero_units_total(self):
+        self.assertIsNone(
+            bf.compute_cost_number(
+                position.CostSpec(None, D("20"), "USD", None, None, False),
+                amount.from_string("0 HOOL"),
+            )
+        )
+
+
+class TestZeroUnitsTotalCost(cmptest.TestCase):
+    @loader.load_doc(expect_errors=True)
+    def test_double_brace_total_cost(self, entries, errors, options_map):
+        """
+        2024-01-01 open Assets:Stock HOOL
+        2024-01-01 open Assets:Cash USD
+
+        2024-02-01 * "zero units, total cost"
+          Assets:Stock      0 HOOL {{20.00 USD}}
+          Assets:Cash     -20.00 USD
+        """
+        self.assertTrue(
+            any(
+                isinstance(error, bf.InterpolationError)
+                and 'Amount is zero: "0 HOOL"' in error.message
+                for error in errors
+            )
+        )
+
+    @loader.load_doc(expect_errors=True)
+    def test_compound_total_cost(self, entries, errors, options_map):
+        """
+        2024-01-01 open Assets:Stock HOOL
+        2024-01-01 open Assets:Cash USD
+
+        2024-02-01 * "zero units, total cost"
+          Assets:Stock      0 HOOL {0 # 20.00 USD}
+          Assets:Cash     -20.00 USD
+        """
+        self.assertTrue(
+            any(
+                isinstance(error, bf.InterpolationError)
+                and 'Amount is zero: "0 HOOL"' in error.message
+                for error in errors
+            )
+        )
+
 
 class TestParseBookingOptions(cmptest.TestCase):
     @loader.load_doc()


### PR DESCRIPTION
Fixes #1048

`convert_costspec_to_cost` (and `compute_cost_number`) divided a total cost by the unit count with no zero check. `0 HOOL {{20.00 USD}}` — and the `{0 # 20.00 USD}` spelling — therefore escaped `load_file` / `bean-check` as `decimal.DivisionByZero` instead of a booking error.

The `@@` total-price path already survives this input and reports a balance error. The zero-units-at-cost check in `interpolate_group` already knows how to emit `Amount is zero`, but it never ran because conversion crashed first.

This guards both divisions. `compute_cost_number` returns `None` when the per-unit cost is undefined (its documented fallback). `convert_costspec_to_cost` uses a zero unit cost so interpolation can report `Amount is zero: "0 HOOL"`, then validation reports the same residual as the `@@` path.

Verification:

```
pytest beancount/parser/booking_full_test.py
```

121 passed (20 skipped). Includes the existing `TestComputeCostNumber` cases plus both spellings of the #1048 reproducer.

I reviewed, understand, and take responsibility for this change.